### PR TITLE
Load Integration from Airtable in FR and EN

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npm start
 
 ## How to add new integrations ?
 
+Don't add files into /{lang}/integrations/
+
 We use an AirTable spreadsheet to crowdsource the list of integrations.
 
 Please contact us on the forum if you want write access to this spreadsheet.


### PR DESCRIPTION
Script manages now FR and EN integration from Airtable.

You need to duplicate first Sheet and name them `FR` and `EN`. Column headers stay the same.

I can fill EN sheet from json integration files if you want.

<img width="287" alt="Capture d’écran 2020-11-24 à 22 03 57" src="https://user-images.githubusercontent.com/1773153/100151089-f54c5e80-2ea0-11eb-9d21-eaee083a3919.png">
