### PR TITLE
Minor changes on 2_docker.md

### DIFF
--- a/fr/docs/installation/2_docker.md
+++ b/fr/docs/installation/2_docker.md
@@ -8,6 +8,10 @@ sidebar_label: Docker
 
 Ce tutoriel vous explique comment installer Gladys avec Docker sur Raspberry Pi.
 
+Pour trouver l'IP de votre Raspberry Pi, vous pouvez utiliser des apps comme ([Network Scanner](https://play.google.com/store/apps/details?id=com.easymobile.lan.scanner&hl=fr) sur Android ou [iNet](https://itunes.apple.com/fr/app/inet-network-scanner/id340793353?mt=8) sur iOS)
+
+Connectez-vous à votre Raspberry Pi avec SSH.
+
 ### Installer Docker sur Raspberry Pi
 
 ```bash
@@ -19,9 +23,9 @@ Ensuite, fermez votre session SSH puis reconnectez vous à votre Raspberry Pi.
 
 ### Lancer Gladys
 
-Si vous avez déjà lancé l'alpha auparavant, pensez à supprimer votre dossier `/var/lib/gladysassistant`, car nous avons fais des modifications à ce niveau entre l'alpha et la beta. Attention: vous perdrez les données de l'alpha!
+Si vous avez déjà lancé l'alpha auparavant, pensez à supprimer votre dossier `/var/lib/gladysassistant`, car nous avons fait des modifications à ce niveau entre l'alpha et la beta. Attention : vous perdrez les données de l'alpha !
 
-Pour lancer Gladys, exécutez la commande suivante sur votre Raspberry Pi:
+Pour lancer Gladys, exécutez la commande suivante sur votre Raspberry Pi :
 
 ```bash
 docker run -d \
@@ -43,11 +47,11 @@ gladysassistant/gladys:v4-arm
 Note:
 
 - Si vous êtes sur une architecture x64/x86, utilisez le tag `v4-amd64`, soit une image `gladysassistant/gladys:v4-amd64`
-- `-e TZ=Europe/Paris` => Pour changer le fuseau horaire du container, vous pouvez modifier cette variable. Vous trouverez toutes les valeurs possibles sur [cette list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+- `-e TZ=Europe/Paris` => Pour changer le fuseau horaire du container, vous pouvez modifier cette variable. Vous trouverez toutes les valeurs possibles sur [cette liste](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ## Mise à jour automatique avec Watchtower
 
-Vous pouvez utiliser Watchtower pour mettre automatiquement Gladys à jour quand une nouvelle version est disponible. Pour cela, lancez le container:
+Vous pouvez utiliser Watchtower pour mettre automatiquement Gladys à jour quand une nouvelle version est disponible. Pour cela, lancez le container :
 
 ```
 docker run -d \
@@ -58,15 +62,11 @@ docker run -d \
   --cleanup
 ```
 
-### Accéder à Gladys
+## Sur n'importe quel autre système
 
-Vous pouvez accéder à Gladys en tapant l'IP de votre Raspberry Pi sur votre navigateur. Pour trouver l'IP de votre Raspberry Pi, vous pouvez utiliser des apps comme ([Network Scanner](https://play.google.com/store/apps/details?id=com.easymobile.lan.scanner&hl=fr) sur Android ou [iNet](https://itunes.apple.com/fr/app/inet-network-scanner/id340793353?mt=8) sur iOS)
+Docker s'installe sur n'importe quel système, et vous permet de faire tourner Gladys n'importe où :
 
-## Sur n'importe quel système
-
-Docker s'installe sur n'importe quel système, et vous permet de faire tourner Gladys n'impote où :
-
-- Un NAS Synology
+- Un NAS Synology ([vérifier la compatibilité avec votre NAS sur cette page](https://www.synology.com/fr-fr/dsm/packages/Docker))
 - Une VM Linux
 - Un PC Windows
 - Sous MacOS
@@ -78,7 +78,7 @@ Je vous conseille de vous rendre sur la [documentation docker](https://docs.dock
 
 ### Lancer Gladys
 
-Pour lancer Gladys, exécutez la commande suivante sur votre Raspberry Pi:
+Pour lancer Gladys, exécutez la commande suivante sur votre système :
 
 ```bash
 docker run -d \
@@ -100,3 +100,8 @@ gladysassistant/gladys:v4-amd64
 Vous pouvez adapter dans la commande les ports exposés suivant votre système.
 
 Le `--network=host` n'est pas forcément adapté à tous les systèmes, il ne fonctionne pas sous MacOS ou Windows par exemple.
+
+
+## Accéder à Gladys
+
+Vous pouvez accéder à Gladys en tapant l'IP de votre système sur votre navigateur.


### PR DESCRIPTION
Correction de quelques fautes ou répétitions de Raspberry Pi et règles de typographies pour les signes de ponctuation  + déplacement de la section Accéder à Gladys à la fin car c'est commun à toutes les installations.

La distinction Raspberry Pi / autres systèmes n'a pas vraiment lieu d'être, les commandes sont identiques pour ma part je regrouperai les deux en indiquant que la différence se situe dans le tag de l'image à récupérer.
P.S. : Docker ne s'installe pas sur n'importe quel système (par ex : pas de docker sur FreeNAS/TrueNAS Core)