### PR TITLE
Set a proper SEO meta description for the blog (EN & FR)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -214,6 +214,8 @@ module.exports = function createConfig() {
         },
         blog: {
           showReadingTime: true,
+          blogDescription:
+            "Follow the latest from Gladys Assistant: new releases, integrations, AI features, tutorials and updates from the open-source, privacy-first home assistant.",
           // Please change this to your repo.
           editUrl: "https://github.com/GladysAssistant/v4-website/edit/master/",
           editLocalizedFiles: true,

--- a/i18n/fr/docusaurus-plugin-content-blog/options.json
+++ b/i18n/fr/docusaurus-plugin-content-blog/options.json
@@ -4,7 +4,7 @@
     "description": "The title for the blog used in SEO"
   },
   "description": {
-    "message": "Blog",
+    "message": "Suivez l'actualité de Gladys Assistant : nouvelles versions, intégrations, fonctionnalités IA, tutoriels et mises à jour de l'assistant domotique open-source et respectueux de la vie privée.",
     "description": "The description for the blog used in SEO"
   },
   "sidebar.title": {


### PR DESCRIPTION
The blog index page meta description was just the word **"Blog"**. This sets a proper, keyword-rich SEO description in both locales.

- **EN:** `blogDescription` added to the blog options in `docusaurus.config.js`
- **FR:** `description` message updated in `i18n/fr/docusaurus-plugin-content-blog/options.json`

### Verification
✅ `yarn build` passes. Confirmed in the generated HTML that `/blog/` and `/fr/blog/` now emit the new `name="description"` and `og:description` meta tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
