### PR TITLE
Improve SEO: meta descriptions on all docs + sitemap lastmod & og:site_name

### DIFF
--- a/docs/api/1_data-model.md
+++ b/docs/api/1_data-model.md
@@ -1,6 +1,7 @@
 ---
 id: data-model
 title: Data model
+description: "Explore the Gladys Assistant 4 database model: tables, relationships and the full schema diagram for developers building on top of Gladys."
 sibebar_label: Data model
 ---
 

--- a/docs/api/2_rest_api.md
+++ b/docs/api/2_rest_api.md
@@ -1,6 +1,7 @@
 ---
 id: rest-api
 title: HTTP API
+description: "Use the Gladys Assistant HTTP REST API: authenticate, retrieve an access token, and automate your smart home from your own scripts and clients."
 sidebar_label: HTTP API
 ---
 

--- a/docs/api/3_mqtt_api.md
+++ b/docs/api/3_mqtt_api.md
@@ -1,6 +1,7 @@
 ---
 id: mqtt-api
 title: MQTT API
+description: "Reference for the Gladys Assistant MQTT API: every topic to push device states (temperature, text, binary) and control your smart home over MQTT."
 sidebar_label: MQTT API
 ---
 

--- a/docs/dashboard/alarm.md
+++ b/docs/dashboard/alarm.md
@@ -1,6 +1,7 @@
 ---
 id: alarm
 title: How to set up your own alarm system with Gladys?
+description: "Build a complete home alarm system with Gladys Assistant: arm, disarm, partial and panic modes, arming delay, alarm code and scene-based strategies."
 sidebar_label: Alarm
 ---
 

--- a/docs/dashboard/camera.md
+++ b/docs/dashboard/camera.md
@@ -1,6 +1,7 @@
 ---
 id: camera
 title: Display a camera on the dashboard
+description: "Display a camera on your Gladys Assistant dashboard and watch the live video stream, with automatic image refresh from your IP camera."
 sidebar_label: Camera
 ---
 

--- a/docs/dashboard/chart.md
+++ b/docs/dashboard/chart.md
@@ -1,6 +1,7 @@
 ---
 id: chart
 title: Display a chart on the dashboard
+description: "Add a chart widget to your Gladys Assistant dashboard to visualize sensor data: line, bar, area or binary charts with custom time grouping."
 sidebar_label: Chart
 ---
 

--- a/docs/dashboard/devices.md
+++ b/docs/dashboard/devices.md
@@ -1,6 +1,7 @@
 ---
 id: devices
 title: Display devices on the dashboard
+description: "Control your devices and view sensor values directly from the Gladys Assistant dashboard with the Devices widget."
 sidebar_label: Devices
 ---
 

--- a/docs/dashboard/edf-tempo.md
+++ b/docs/dashboard/edf-tempo.md
@@ -1,6 +1,7 @@
 ---
 id: edf-tempo
 title: Display EDF Tempo days on your dashboard
+description: "Show EDF Tempo days on your Gladys Assistant dashboard: current and next-day color, peak and off-peak hours, to optimize your electricity bill."
 sidebar_label: EDF Tempo
 ---
 

--- a/docs/dashboard/gauge.md
+++ b/docs/dashboard/gauge.md
@@ -1,6 +1,7 @@
 ---
 id: gauge
 title: Display a gauge on the dashboard
+description: "Add a gauge widget to your Gladys Assistant dashboard to display a sensor's current value between its minimum and maximum range."
 sidebar_label: Gauge
 ---
 

--- a/docs/dashboard/humidity-in-room.md
+++ b/docs/dashboard/humidity-in-room.md
@@ -1,6 +1,7 @@
 ---
 id: humidity-in-room
 title: Display the average humidity of a room on the dashboard
+description: "Display the average humidity of a room on your Gladys Assistant dashboard, aggregated from all humidity sensors, with custom color thresholds."
 sidebar_label: Room humidity
 ---
 

--- a/docs/dashboard/intro.md
+++ b/docs/dashboard/intro.md
@@ -1,6 +1,7 @@
 ---
 id: intro
 title: The Gladys Assistant Dashboard
+description: "Discover the Gladys Assistant dashboard: create multiple dashboards, share them with your family, control devices, view cameras and sensors, with tablet mode."
 sidebar_label: Introduction
 ---
 

--- a/docs/dashboard/temperature-in-room.md
+++ b/docs/dashboard/temperature-in-room.md
@@ -1,6 +1,7 @@
 ---
 id: temperature-in-room
 title: Display the average room temperature on the dashboard
+description: "Display the average temperature of a room on your Gladys Assistant dashboard, aggregated from all temperature sensors in the room."
 sidebar_label: Room Temperature
 ---
 

--- a/docs/dashboard/voice-assistant.md
+++ b/docs/dashboard/voice-assistant.md
@@ -1,6 +1,7 @@
 ---
 id: voice-assistant
 title: Talk to Gladys from the dashboard with the voice assistant
+description: "Talk to Gladys Assistant from your dashboard with the voice assistant widget: speak, read the live transcription and AI answer, and hear it read aloud."
 sidebar_label: Voice assistant
 ---
 

--- a/docs/dashboard/weather.md
+++ b/docs/dashboard/weather.md
@@ -1,6 +1,7 @@
 ---
 id: weather
 title: Display weather on the dashboard
+description: "Display the local weather on your Gladys Assistant dashboard using the OpenWeather integration and your home's location."
 sidebar_label: Weather
 ---
 

--- a/docs/dev/1_mac-linux.md
+++ b/docs/dev/1_mac-linux.md
@@ -1,6 +1,7 @@
 ---
 id: setup-development-environment-mac-linux
 title: Setup a Mac/Linux development environment
+description: "Set up a Gladys Assistant development environment on Mac or Linux: install Node.js, the server backend and frontend to start contributing."
 sidebar_label: Mac/Linux
 ---
 

--- a/docs/dev/2_windows.md
+++ b/docs/dev/2_windows.md
@@ -1,6 +1,7 @@
 ---
 id: setup-development-environment-windows
 title: Setup a Windows development environment
+description: "Set up a Gladys Assistant development environment on Windows with WSL2, Docker Desktop and VS Code to start contributing to the project."
 sidebar_label: Windows
 ---
 

--- a/docs/dev/3_developing_a_service.md
+++ b/docs/dev/3_developing_a_service.md
@@ -1,6 +1,7 @@
 ---
 id: developing-a-service
 title: Contributing on Gladys Assistant
+description: "Contribute to Gladys Assistant: discover the open-source stack (Preact, Node.js, SQLite, DuckDB) and learn how to develop a new service or integration."
 sidebar_label: Contributing on Gladys Assistant
 ---
 

--- a/docs/dev/4_cypress_tests.md
+++ b/docs/dev/4_cypress_tests.md
@@ -1,6 +1,7 @@
 ---
 id: cypress-tests
 title: Run Cypress tests in Gladys
+description: "Run Cypress end-to-end frontend tests in Gladys Assistant: start the backend, launch the frontend and execute the test suite."
 sidebar_label: Frontend tests
 ---
 

--- a/docs/installation/0_1_recommended-hardware.md
+++ b/docs/installation/0_1_recommended-hardware.md
@@ -1,6 +1,7 @@
 ---
 id: recommended-hardware
 title: Recommended Hardware
+description: "The best Zigbee hardware to build a reliable Gladys Assistant smart home: recommended coordinator dongle and top-rated devices in every category."
 sidebar_label: Recommended hardware
 ---
 

--- a/docs/installation/1_1_mini-pc.md
+++ b/docs/installation/1_1_mini-pc.md
@@ -1,6 +1,7 @@
 ---
 id: mini-pc
 title: Install Gladys Assistant on a Mini-PC
+description: "Install Gladys Assistant on a mini-PC, the recommended setup: choose your hardware, install Ubuntu Server and run Gladys with Docker."
 sidebar_label: Install on a Mini-PC
 ---
 

--- a/docs/installation/1_raspberry-pi.md
+++ b/docs/installation/1_raspberry-pi.md
@@ -1,6 +1,7 @@
 ---
 id: raspberry-pi
 title: Installing Gladys Assistant on a Raspberry Pi
+description: "Install Gladys Assistant on a Raspberry Pi 3, 4 or 5 in minutes with our official 64-bit image. The easiest way to discover Gladys."
 sidebar_label: Install on a Raspberry Pi
 ---
 

--- a/docs/installation/2_docker.md
+++ b/docs/installation/2_docker.md
@@ -1,6 +1,7 @@
 ---
 id: docker
 title: Install Gladys Assistant with Docker
+description: "Install Gladys Assistant with Docker on any system (mini-PC, NAS, Linux server, VM) in a single command. Free, open-source and self-hosted."
 sidebar_label: Install with Docker
 ---
 

--- a/docs/installation/3_docker-compose.md
+++ b/docs/installation/3_docker-compose.md
@@ -1,6 +1,7 @@
 ---
 id: docker-compose
 title: Install Gladys Assistant with Docker Compose
+description: "Install Gladys Assistant manually with Docker Compose on a mini-PC, Synology NAS, Linux VM or any machine running Docker."
 sidebar_label: Install with Docker Compose
 ---
 

--- a/docs/installation/4_freebox-delta.md
+++ b/docs/installation/4_freebox-delta.md
@@ -1,6 +1,7 @@
 ---
 id: freebox-delta
 title: Install Gladys Assistant on a Freebox Delta
+description: "Install Gladys Assistant on a Freebox Delta by creating a Docker virtual machine. Step-by-step self-hosted setup guide."
 sidebar_label: Install on a Freebox Delta
 ---
 

--- a/docs/installation/5_synology.md
+++ b/docs/installation/5_synology.md
@@ -1,6 +1,7 @@
 ---
 id: synology
 title: Install Gladys Assistant on a Synology NAS
+description: "Install Gladys Assistant on a Synology NAS with Docker: set up storage, deploy the container via SSH and start your self-hosted smart home."
 sidebar_label: Install on a Synology NAS
 ---
 

--- a/docs/installation/6_unraid.md
+++ b/docs/installation/6_unraid.md
@@ -1,6 +1,7 @@
 ---
 id: unraid
 title: Install Gladys Assistant on a Unraid NAS
+description: "Install Gladys Assistant on an Unraid NAS from the Apps store: configure the Docker container with host networking and start automating your home."
 sidebar_label: Install on an Unraid NAS
 ---
 

--- a/docs/installation/7_mobile.md
+++ b/docs/installation/7_mobile.md
@@ -1,6 +1,7 @@
 ---
 id: phone
 title: Using Gladys Assistant on your phone
+description: "Use Gladys Assistant on your phone as a PWA: install it on Android and iOS, with remote access through Gladys Plus, end-to-end encrypted."
 sidebar_label: On your phone
 ---
 

--- a/docs/installation/8_faq.md
+++ b/docs/installation/8_faq.md
@@ -1,6 +1,7 @@
 ---
 id: faq
 title: FAQ
+description: "Frequently asked questions about Gladys Assistant: how to update with Watchtower, who uses Gladys, and how to contribute to the open-source project."
 sidebar_label: FAQ
 ---
 

--- a/docs/integrations/airplay.md
+++ b/docs/integrations/airplay.md
@@ -1,6 +1,7 @@
 ---
 id: airplay
 title: How to connect any Airplay speaker to your smart home system
+description: "Connect any AirPlay speaker or HomePod to Gladys Assistant: configure your speaker, discover it in Gladys and play audio across your smart home."
 sidebar_label: Airplay
 ---
 

--- a/docs/integrations/alexa.md
+++ b/docs/integrations/alexa.md
@@ -1,6 +1,7 @@
 ---
 id: alexa
 title: How to configure Alexa with Gladys Assistant
+description: "Control your Gladys Assistant devices with Amazon Alexa through Gladys Plus, the certified cloud gateway. Voice control for your smart home."
 sidebar_label: Alexa
 ---
 

--- a/docs/integrations/bluetooth.md
+++ b/docs/integrations/bluetooth.md
@@ -1,6 +1,7 @@
 ---
 id: bluetooth
 title: Manage presence with Bluetooth detection
+description: "Detect presence at home with Bluetooth in Gladys Assistant: use a Bluetooth key fob to automatically know when you are home or away."
 sidebar_label: Bluetooth
 ---
 

--- a/docs/integrations/broadlink.md
+++ b/docs/integrations/broadlink.md
@@ -1,6 +1,7 @@
 ---
 id: broadlink
 title: Broadlink
+description: "Control Broadlink devices with Gladys Assistant and replace your infrared remotes: discover devices and create virtual remote controls."
 sidebar_label: Broadlink
 ---
 

--- a/docs/integrations/caldav.md
+++ b/docs/integrations/caldav.md
@@ -1,6 +1,7 @@
 ---
 id: caldav
 title: CalDAV
+description: "Sync your Gladys Assistant calendar with iCloud, Google Calendar, Synology or Nextcloud via CalDAV to trigger scenes from your events."
 sidebar_label: CalDAV
 ---
 

--- a/docs/integrations/callmebot.md
+++ b/docs/integrations/callmebot.md
@@ -1,6 +1,7 @@
 ---
 id: callmebot
 title: Send Gladys messages to WhatsApp and Signal with CallMeBot
+description: "Send Gladys Assistant notifications to WhatsApp and Signal with CallMeBot: get your API key and set up one-way messaging from your smart home."
 sidebar_label: CallMeBot
 ---
 

--- a/docs/integrations/camera.md
+++ b/docs/integrations/camera.md
@@ -1,6 +1,7 @@
 ---
 id: camera
 title: Camera
+description: "Add IP cameras to Gladys Assistant using their RTSP or HTTP stream and view them live on your dashboard."
 sidebar_label: Camera
 ---
 

--- a/docs/integrations/enedis.md
+++ b/docs/integrations/enedis.md
@@ -1,6 +1,7 @@
 ---
 id: enedis
 title: View your electricity consumption in Gladys with Enedis
+description: "View your electricity consumption in Gladys Assistant with the Enedis integration: connect your Linky meter data via Gladys Plus (France only)."
 sidebar_label: Enedis
 ---
 

--- a/docs/integrations/energy-monitoring.md
+++ b/docs/integrations/energy-monitoring.md
@@ -1,6 +1,7 @@
 ---
 id: energy-monitoring
 title: Monitor your energy consumption in Gladys Assistant
+description: "Monitor your home energy consumption in Gladys Assistant in kWh, with a Lixee ZLinky for Linky meters or other compatible energy sensors."
 sidebar_label: Energy Monitoring
 ---
 

--- a/docs/integrations/free-mobile.md
+++ b/docs/integrations/free-mobile.md
@@ -1,6 +1,7 @@
 ---
 id: free-mobile
 title: How to configure Free Mobile with Gladys Assistant
+description: "Send SMS to your phone from Gladys Assistant with the French Free Mobile operator: enable SMS notifications, get your API key and send your first SMS."
 sidebar_label: Free Mobile
 ---
 

--- a/docs/integrations/google-cast.md
+++ b/docs/integrations/google-cast.md
@@ -1,6 +1,7 @@
 ---
 id: google-cast
 title: Make Gladys Assistant Speak on a Google Speaker
+description: "Make Gladys Assistant speak on a Google Cast speaker: add your device, assign it to a room and use the Speak on a Speaker action in your scenes."
 sidebar_label: Google Cast
 ---
 

--- a/docs/integrations/google-home.md
+++ b/docs/integrations/google-home.md
@@ -1,6 +1,7 @@
 ---
 id: google-home
 title: How to configure Google Home with Gladys Assistant
+description: "Control your Gladys Assistant devices with Google Home through Gladys Plus, the Google-certified cloud gateway. Voice control for your smart home."
 sidebar_label: Google Home
 ---
 

--- a/docs/integrations/homekit.md
+++ b/docs/integrations/homekit.md
@@ -1,6 +1,7 @@
 ---
 id: homekit
 title: Connect Gladys to HomeKit and use Siri
+description: "Connect Gladys Assistant to Apple HomeKit and control your devices with Siri: scan the QR code, add Gladys as a HomeKit bridge and import your devices."
 sidebar_label: HomeKit
 ---
 

--- a/docs/integrations/lan-manager.md
+++ b/docs/integrations/lan-manager.md
@@ -1,6 +1,7 @@
 ---
 id: lan-manager
 title: Manage presence by scanning your Wi-Fi network
+description: "Detect presence in Gladys Assistant by scanning your Wi-Fi network for your phone, tablet or computer to know when you are home or away."
 sidebar_label: Lan-Manager
 ---
 

--- a/docs/integrations/matter.md
+++ b/docs/integrations/matter.md
@@ -1,6 +1,7 @@
 ---
 id: matter
 title: Integrate Matter Devices in Gladys Assistant
+description: "Integrate Matter devices into Gladys Assistant: control lights, plugs, shutters, thermostats and sensors from different manufacturers."
 sidebar_label: Matter
 ---
 

--- a/docs/integrations/matterbridge.md
+++ b/docs/integrations/matterbridge.md
@@ -1,6 +1,7 @@
 ---
 id: matterbridge
 title: Matterbridge
+description: "Connect non-Matter devices (Shelly, Somfy) to Gladys Assistant with Matterbridge: enable the container, install plugins and pair them over Matter."
 sidebar_label: Matterbridge
 ---
 

--- a/docs/integrations/melcloud.md
+++ b/docs/integrations/melcloud.md
@@ -1,6 +1,7 @@
 ---
 id: melcloud
 title: MELCloud (Mitsubishi AC)
+description: "Control your Mitsubishi air conditioning from Gladys Assistant with the MELCloud integration: connect your account and manage your AC units."
 sidebar_label: MELCloud
 ---
 

--- a/docs/integrations/mqtt.md
+++ b/docs/integrations/mqtt.md
@@ -1,6 +1,7 @@
 ---
 id: mqtt
 title: MQTT
+description: "Connect MQTT devices to Gladys Assistant: configure an MQTT broker and exchange data in both directions between Gladys and your sensors and actuators."
 sidebar_label: MQTT
 ---
 

--- a/docs/integrations/netatmo.md
+++ b/docs/integrations/netatmo.md
@@ -1,6 +1,7 @@
 ---
 id: netatmo
 title: Connect your Netatmo thermostats to your smart home system installation
+description: "Connect your Netatmo thermostats, valves and weather stations to Gladys Assistant via Netatmo Connect to monitor and control your smart home."
 sidebar_label: Netatmo
 toc_min_heading_level: 2
 toc_max_heading_level: 5

--- a/docs/integrations/nextcloud-talk.md
+++ b/docs/integrations/nextcloud-talk.md
@@ -1,6 +1,7 @@
 ---
 id: nextcloud-talk
 title: Nextcloud Talk
+description: "Use Nextcloud Talk to chat with Gladys Assistant: create a bot account, get your conversation token and send instructions to your smart home."
 sidebar_label: Nextcloud Talk
 ---
 

--- a/docs/integrations/node-red.md
+++ b/docs/integrations/node-red.md
@@ -1,6 +1,7 @@
 ---
 id: node-red
 title: Node-RED
+description: "Integrate Node-RED with Gladys Assistant to connect hardware, APIs and online services: enable the container and build powerful automations."
 sidebar_label: Node-RED
 ---
 

--- a/docs/integrations/nuki.md
+++ b/docs/integrations/nuki.md
@@ -1,6 +1,7 @@
 ---
 id: nuki
 title: Connect your Nuki lock to your smart home
+description: "Connect your Nuki smart lock to Gladys Assistant to lock, unlock and monitor battery and status, via the Nuki Web API or MQTT."
 sidebar_label: Nuki
 ---
 

--- a/docs/integrations/openweather.md
+++ b/docs/integrations/openweather.md
@@ -1,6 +1,7 @@
 ---
 id: openweather
 title: OpenWeather
+description: "Display weather forecasts in Gladys Assistant with OpenWeather: create an account, get your API key and add a weather widget to your dashboard."
 sidebar_label: OpenWeather
 ---
 

--- a/docs/integrations/owntracks.md
+++ b/docs/integrations/owntracks.md
@@ -1,6 +1,7 @@
 ---
 id: owntracks
 title: Owntracks
+description: "Track your phone's location in Gladys Assistant with OwnTracks and Gladys Plus to automate presence and trigger location-based scenes."
 sidebar_label: Owntracks
 ---
 

--- a/docs/integrations/philips-hue.md
+++ b/docs/integrations/philips-hue.md
@@ -1,6 +1,7 @@
 ---
 id: philips-hue
 title: Philips Hue
+description: "Connect your Philips Hue bridge and lights to Gladys Assistant to control them locally from your dashboard and scenes."
 sidebar_label: Philips Hue
 ---
 

--- a/docs/integrations/shelly.md
+++ b/docs/integrations/shelly.md
@@ -1,6 +1,7 @@
 ---
 id: shelly
 title: Integrating Shelly with Gladys via Matterbridge
+description: "Integrate Shelly modules into Gladys Assistant via Matterbridge: deploy the bridge, commission it in Gladys and control your Shelly devices over Matter."
 sidebar_label: Shelly
 ---
 

--- a/docs/integrations/somfy-tahoma.md
+++ b/docs/integrations/somfy-tahoma.md
@@ -1,6 +1,7 @@
 ---
 id: somfy-tahoma
 title: Integrating Somfy devices with Gladys via Matterbridge
+description: "Integrate Somfy TaHoma devices into Gladys Assistant via Matterbridge to control your roller shutters, blinds and openings over Matter."
 sidebar_label: Somfy
 ---
 

--- a/docs/integrations/sonoff.md
+++ b/docs/integrations/sonoff.md
@@ -1,6 +1,7 @@
 ---
 id: sonoff
 title: Sonoff
+description: "Connect Sonoff devices to Gladys Assistant using Tasmota firmware and an eWeLink account to control them locally in your smart home."
 sidebar_label: Sonoff
 ---
 

--- a/docs/integrations/sonos.md
+++ b/docs/integrations/sonos.md
@@ -1,6 +1,7 @@
 ---
 id: sonos
 title: How to connect a Sonos speaker to your smart home system
+description: "Connect your Sonos speakers to Gladys Assistant: discover them on your network and control them from your dashboard and scenes."
 sidebar_label: Sonos
 ---
 

--- a/docs/integrations/tasmota.md
+++ b/docs/integrations/tasmota.md
@@ -1,6 +1,7 @@
 ---
 id: tasmota
 title: Tasmota
+description: "Connect Tasmota devices to Gladys Assistant: flash the open-source firmware on your ESP8266 device, configure MQTT and control it in Gladys."
 sidebar_label: Tasmota
 ---
 

--- a/docs/integrations/telegram.md
+++ b/docs/integrations/telegram.md
@@ -1,6 +1,7 @@
 ---
 id: telegram
 title: Send Gladys notifications to Telegram
+description: "Send Gladys Assistant notifications to Telegram and control your smart home by chatting with Gladys: create a bot and link your account."
 sidebar_label: Telegram
 ---
 

--- a/docs/integrations/tp-link.md
+++ b/docs/integrations/tp-link.md
@@ -1,6 +1,7 @@
 ---
 id: tp-link
 title: TP-Link
+description: "Connect your TP-Link Kasa lights and plugs to Gladys Assistant: scan your Wi-Fi network, add devices and control them from your smart home."
 sidebar_label: TP-Link
 ---
 

--- a/docs/integrations/tuya.md
+++ b/docs/integrations/tuya.md
@@ -1,6 +1,7 @@
 ---
 id: tuya
 title: Tuya
+description: "Connect Tuya devices to Gladys Assistant: create a Tuya IoT cloud project, authorize the API and control your Tuya smart home devices."
 sidebar_label: Tuya
 ---
 

--- a/docs/integrations/xiaomi.md
+++ b/docs/integrations/xiaomi.md
@@ -1,6 +1,7 @@
 ---
 id: xiaomi
 title: Xiaomi
+description: "Connect Xiaomi devices to Gladys Assistant via the Mi Home gateway. Note: Zigbee or Matter is now recommended for these devices."
 sidebar_label: Xiaomi
 ---
 

--- a/docs/integrations/zigbee2mqtt.md
+++ b/docs/integrations/zigbee2mqtt.md
@@ -1,6 +1,7 @@
 ---
 id: zigbee2mqtt
 title: Connect Zigbee devices with an USB Zigbee dongle and Zigbee2mqtt
+description: "Connect Zigbee devices to Gladys Assistant with a USB Zigbee dongle and Zigbee2MQTT, with no third-party bridge and full local control."
 sidebar_label: Zigbee2Mqtt
 ---
 

--- a/docs/integrations/zwavejs-ui.md
+++ b/docs/integrations/zwavejs-ui.md
@@ -1,6 +1,7 @@
 ---
 id: zwavejs-ui
 title: Integrate your Z-Wave devices with Z-Wave JS UI
+description: "Integrate your Z-Wave devices into Gladys Assistant with Z-Wave JS UI over MQTT to control them and receive state changes in real time."
 sidebar_label: Z-Wave JS UI
 ---
 

--- a/docs/plus/intro.md
+++ b/docs/plus/intro.md
@@ -1,6 +1,7 @@
 ---
 id: intro
 title: Gladys Plus
+description: "Discover Gladys Plus: encrypted remote access, daily backups, Open API, open-weight AI, MCP server and Google Home for your Gladys Assistant smart home."
 sidebar_label: Intro
 ---
 

--- a/docs/plus/open-api.md
+++ b/docs/plus/open-api.md
@@ -1,6 +1,7 @@
 ---
 id: open-api
 title: Open API
+description: "Use the Gladys Plus Open API to send data to your smart home from outside your network: location, sensor values and events, with a secure API key."
 sidebar_label: Open API
 ---
 

--- a/docs/scenes/back-at-home.md
+++ b/docs/scenes/back-at-home.md
@@ -1,6 +1,7 @@
 ---
 id: back-at-home
 title: When a user comes back home
+description: "Trigger a Gladys Assistant scene when a user comes back home, based on presence detection, to automate your smart home on arrival."
 sidebar_label: Back at home
 ---
 

--- a/docs/scenes/calendar-event-is-coming.md
+++ b/docs/scenes/calendar-event-is-coming.md
@@ -1,6 +1,7 @@
 ---
 id: calendar-event-is-coming-trigger
 title: Trigger a scene when a calendar event is coming
+description: "Trigger a Gladys Assistant scene when a calendar event is coming or ending, with powerful name filters, using your CalDAV calendars."
 sidebar_label: Calendar event is coming
 ---
 

--- a/docs/scenes/calendar-event-is-running.md
+++ b/docs/scenes/calendar-event-is-running.md
@@ -1,6 +1,7 @@
 ---
 id: calendar-event-is-running-condition
 title: Condition in a scene on calendar event
+description: "Add a condition to a Gladys Assistant scene based on a running calendar event, to run automations only during holidays, sport or meetings."
 sidebar_label: Calendar event is running
 ---
 

--- a/docs/scenes/chain.md
+++ b/docs/scenes/chain.md
@@ -1,6 +1,7 @@
 ---
 id: chain-action
 title: Chain Scenes
+description: "Chain scenes in Gladys Assistant by triggering one scene from another, with built-in loop protection for safe, reusable automations."
 sidebar_label: Chain Scenes
 ---
 

--- a/docs/scenes/continue-only-if.md
+++ b/docs/scenes/continue-only-if.md
@@ -1,6 +1,7 @@
 ---
 id: continue-only-if-action
 title: Condition on variables
+description: "Use the Continue only if action in Gladys Assistant scenes to keep running only when a variable meets a condition, with math functions support."
 sidebar_label: Condition on variables
 ---
 

--- a/docs/scenes/device-state-changed-trigger.md
+++ b/docs/scenes/device-state-changed-trigger.md
@@ -1,6 +1,7 @@
 ---
 id: device-state-changed-trigger
 title: Trigger a scene when a device state changes
+description: "Trigger a Gladys Assistant scene when a device state changes, such as a temperature drop or a light turning on, with custom conditions."
 sidebar_label: Device state change
 ---
 

--- a/docs/scenes/edf-tempo.md
+++ b/docs/scenes/edf-tempo.md
@@ -1,6 +1,7 @@
 ---
 id: edf-tempo
 title: Save on your electricity bill with EDF Tempo and Gladys
+description: "Save on your electricity bill with EDF Tempo and Gladys Assistant: add a Tempo condition to your scenes to run automations only on the right days."
 sidebar_label: EDF Tempo
 ---
 

--- a/docs/scenes/get-last-device-state-action.md
+++ b/docs/scenes/get-last-device-state-action.md
@@ -1,6 +1,7 @@
 ---
 id: get-last-device-state-action
 title: Retrieve the last state
+description: "Retrieve the last state of a device in a Gladys Assistant scene and store it in a variable to use in conditions and following actions."
 sidebar_label: Retrieve the last state
 ---
 

--- a/docs/scenes/house-empty.md
+++ b/docs/scenes/house-empty.md
@@ -1,6 +1,7 @@
 ---
 id: house-empty
 title: When the house is empty
+description: "Trigger a Gladys Assistant scene when the house becomes empty, or add a condition to run automations only when no one is home."
 sidebar_label: House is empty
 ---
 

--- a/docs/scenes/house-no-longer-empty.md
+++ b/docs/scenes/house-no-longer-empty.md
@@ -1,6 +1,7 @@
 ---
 id: house-no-longer-empty
 title: When the house is no longer empty
+description: "Trigger a Gladys Assistant scene when the house is no longer empty, or add a condition to run automations only when someone is home."
 sidebar_label: House is no longer empty
 ---
 

--- a/docs/scenes/http-request.md
+++ b/docs/scenes/http-request.md
@@ -1,6 +1,7 @@
 ---
 id: http-request
 title: Make HTTP requests in a scene
+description: "Make HTTP requests in Gladys Assistant scenes to call external APIs and services, control unmanaged devices, or trigger an IFTTT action."
 sidebar_label: HTTP Request
 ---
 

--- a/docs/scenes/intro.md
+++ b/docs/scenes/intro.md
@@ -1,6 +1,7 @@
 ---
 id: intro
 title: Scenes in Gladys Assistant
+description: "Create powerful scenes in Gladys Assistant: chain actions, run them manually or with triggers, and automate your smart home your way."
 sidebar_label: Introduction
 ---
 

--- a/docs/scenes/left-home.md
+++ b/docs/scenes/left-home.md
@@ -1,6 +1,7 @@
 ---
 id: left-home
 title: When a user leaves home
+description: "Trigger a Gladys Assistant scene when a user leaves home, based on presence detection, to automate your smart home on departure."
 sidebar_label: Left home
 ---
 

--- a/docs/scenes/math-functions.md
+++ b/docs/scenes/math-functions.md
@@ -1,6 +1,7 @@
 ---
 id: math-functions
 title: Math functions available
+description: "Reference of the math functions available in Gladys Assistant scenes (addition, modulo, power) to build dynamic, calculated automations."
 sidebar_label: Math functions
 ---
 

--- a/docs/scenes/scheduled-trigger.md
+++ b/docs/scenes/scheduled-trigger.md
@@ -1,6 +1,7 @@
 ---
 id: scheduled-trigger
 title: Scheduled Trigger
+description: "Schedule Gladys Assistant scenes to run every month, week, day, at intervals or on a specific day for fully time-based home automation."
 sidebar_label: Scheduled Trigger
 ---
 

--- a/docs/scenes/send-a-message.md
+++ b/docs/scenes/send-a-message.md
@@ -1,6 +1,7 @@
 ---
 id: send-a-message-action
 title: Send a message
+description: "Send a message to a Gladys Assistant user in a scene via Telegram or the web chat, and inject sensor values and variables into the text."
 sidebar_label: Send a message
 ---
 

--- a/docs/scenes/send-a-sms.md
+++ b/docs/scenes/send-a-sms.md
@@ -1,6 +1,7 @@
 ---
 id: send-a-sms-action
 title: Send a SMS
+description: "Send an SMS to your phone in a Gladys Assistant scene with the French Free Mobile operator, and inject sensor values and variables into the message."
 sidebar_label: Send a SMS
 ---
 

--- a/docs/scenes/send-a-zigbee2mqtt-message.md
+++ b/docs/scenes/send-a-zigbee2mqtt-message.md
@@ -1,6 +1,7 @@
 ---
 id: send-a-zigbee2mqtt-message-action
 title: Send a Zigbee2Mqtt message
+description: "Send a Zigbee2MQTT message in a Gladys Assistant scene to control Zigbee devices directly, such as triggering a siren, with variable injection."
 sidebar_label: Send a Zigbee2Mqtt message
 ---
 

--- a/docs/scenes/sunset-sunrise.md
+++ b/docs/scenes/sunset-sunrise.md
@@ -1,6 +1,7 @@
 ---
 id: sunset-sunrise
 title: Sun trigger
+description: "Trigger a Gladys Assistant scene at sunrise or sunset, with an optional delay before or after, to automate your lights with the sun."
 sidebar_label: Sun trigger
 ---
 

--- a/docs/scenes/time-condition.md
+++ b/docs/scenes/time-condition.md
@@ -1,6 +1,7 @@
 ---
 id: time-condition
 title: Time condition
+description: "Add a time condition to a Gladys Assistant scene to continue only during a chosen time range and on selected days of the week."
 sidebar_label: Time condition
 ---
 

--- a/docs/scenes/turn-on-off-the-lights-action.md
+++ b/docs/scenes/turn-on-off-the-lights-action.md
@@ -1,6 +1,7 @@
 ---
 id: turn-on-off-the-lights-action
 title: Turn the lights on/off in a scene
+description: "Turn your lights on or off in a Gladys Assistant scene to automate wake-up, cinema mode, leaving home and more."
 sidebar_label: Turn the light on/off
 ---
 

--- a/docs/scenes/turn-on-off-the-switches-action.md
+++ b/docs/scenes/turn-on-off-the-switches-action.md
@@ -1,6 +1,7 @@
 ---
 id: turn-on-off-the-switches-action
 title: Switch remote control sockets on/off in a scene
+description: "Control remote sockets in a Gladys Assistant scene to automate lamps, LED strips or a coffee machine, with a step-by-step example."
 sidebar_label: Switch sockets on/off
 ---
 

--- a/docs/scenes/user-presence.md
+++ b/docs/scenes/user-presence.md
@@ -1,6 +1,7 @@
 ---
 id: user-presence
 title: Define the presence of a user in a scene
+description: "Define a user's presence or absence in a Gladys Assistant scene to drive return-home and away automations from any presence source."
 sidebar_label: User presence
 ---
 

--- a/docs/scenes/wait.md
+++ b/docs/scenes/wait.md
@@ -1,6 +1,7 @@
 ---
 id: wait-action
 title: Wait
+description: "Use the Wait action in a Gladys Assistant scene to pause for a fixed or calculated duration, based on variables and math functions."
 sidebar_label: Wait
 ---
 

--- a/docs/scenes/zone.md
+++ b/docs/scenes/zone.md
@@ -1,6 +1,7 @@
 ---
 id: zone
 title: When a user enters/leaves a zone
+description: "Trigger a Gladys Assistant scene when a user enters or leaves a geographic zone defined on the map for location-based automations."
 sidebar_label: User enters/leaves a zone
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,10 @@ module.exports = function createConfig() {
       locale === "fr"
         ? "img/presentation/gladys-assistant-og-image-2026-fr.jpg"
         : "img/presentation/gladys-assistant-og-image-2026-en.jpg",
-    metadata: [{ name: "twitter:site", content: "@gladysassistant" }],
+    metadata: [
+      { name: "twitter:site", content: "@gladysassistant" },
+      { property: "og:site_name", content: "Gladys Assistant" },
+    ],
     colorMode: {
       defaultMode: "dark",
       disableSwitch: true,
@@ -211,9 +214,11 @@ module.exports = function createConfig() {
           // Please change this to your repo.
           editUrl: "https://github.com/GladysAssistant/v4-website/edit/master/",
           editLocalizedFiles: true,
+          showLastUpdateTime: true,
         },
         blog: {
           showReadingTime: true,
+          showLastUpdateTime: true,
           blogDescription:
             "Follow the latest from Gladys Assistant: new releases, integrations, AI features, tutorials and updates from the open-source, privacy-first home assistant.",
           // Please change this to your repo.
@@ -226,6 +231,12 @@ module.exports = function createConfig() {
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
+        },
+        sitemap: {
+          lastmod: "date",
+          changefreq: "weekly",
+          priority: 0.5,
+          filename: "sitemap.xml",
         },
       },
     ],

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/1_data-model.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/1_data-model.md
@@ -1,6 +1,7 @@
 ---
 id: data-model
 title: Modélisation DB
+description: "Explorez le modèle de données de Gladys Assistant 4 : tables, relations et schéma complet de la base pour les développeurs qui veulent bâtir sur Gladys."
 sidebar_label: Modélisation
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/2_rest_api.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/2_rest_api.md
@@ -1,6 +1,7 @@
 ---
 id: rest-api
 title: HTTP API
+description: "Utilisez l'API REST HTTP de Gladys Assistant : authentifiez-vous, récupérez un token d'accès et automatisez votre maison connectée depuis vos propres scripts."
 sidebar_label: HTTP API
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/api/3_mqtt_api.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/api/3_mqtt_api.md
@@ -1,6 +1,7 @@
 ---
 id: mqtt-api
 title: MQTT API
+description: "Référence de l'API MQTT de Gladys Assistant : tous les topics pour envoyer des états d'appareils (température, texte, binaire) et piloter votre maison connectée."
 sidebar_label: MQTT API
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/alarm.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/alarm.md
@@ -1,6 +1,7 @@
 ---
 id: alarm
 title: Comment configurer le mode alarme ?
+description: "Créez un véritable système d'alarme avec Gladys Assistant : modes armé, désarmé, partiel et panique, délai d'armement, code et stratégies par scènes."
 sidebar_label: Alarme
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/camera.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/camera.md
@@ -1,6 +1,7 @@
 ---
 id: camera
 title: Afficher une caméra sur le tableau de bord
+description: "Affichez une caméra sur votre tableau de bord Gladys Assistant et regardez le flux vidéo en direct, avec rafraîchissement automatique de l'image."
 sidebar_label: Caméra
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/chart.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/chart.md
@@ -1,6 +1,7 @@
 ---
 id: chart
 title: Afficher un graphique sur le tableau de bord
+description: "Ajoutez un graphique à votre tableau de bord Gladys Assistant pour visualiser vos capteurs : courbe, barres, aire ou binaire, avec regroupement par intervalle."
 sidebar_label: Graphique
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/devices.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/devices.md
@@ -1,6 +1,7 @@
 ---
 id: devices
 title: Afficher ses appareils sur le tableau de bord
+description: "Pilotez vos appareils et affichez les valeurs de vos capteurs directement depuis le tableau de bord de Gladys Assistant avec le widget Appareils."
 sidebar_label: Appareils
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/edf-tempo.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/edf-tempo.md
@@ -1,6 +1,7 @@
 ---
 id: edf-tempo
 title: Afficher les jours EDF Tempo sur votre tableau de bord
+description: "Affichez les jours EDF Tempo sur votre tableau de bord Gladys Assistant : couleur du jour et du lendemain, heures pleines et creuses, pour optimiser votre facture."
 sidebar_label: EDF Tempo
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/gauge.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/gauge.md
@@ -1,6 +1,7 @@
 ---
 id: gauge
 title: Afficher une jauge sur le tableau de bord
+description: "Ajoutez une jauge à votre tableau de bord Gladys Assistant pour afficher la valeur actuelle d'un capteur entre son minimum et son maximum."
 sidebar_label: Jauge
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/humidity-in-room.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/humidity-in-room.md
@@ -1,6 +1,7 @@
 ---
 id: humidity-in-room
 title: Afficher la humidité moyenne d'une pièce sur le tableau de bord
+description: "Affichez l'humidité moyenne d'une pièce sur votre tableau de bord Gladys Assistant, calculée à partir de tous les capteurs, avec des seuils de couleur personnalisés."
 sidebar_label: Humidité de la pièce
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/intro.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/intro.md
@@ -1,6 +1,7 @@
 ---
 id: intro
 title: Le tableau de bord de Gladys Assistant
+description: "Découvrez le tableau de bord de Gladys Assistant : créez plusieurs tableaux, partagez-les en famille, pilotez appareils, caméras et capteurs, avec le mode tablette."
 sidebar_label: Introduction
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/temperature-in-room.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/temperature-in-room.md
@@ -1,6 +1,7 @@
 ---
 id: temperature-in-room
 title: Afficher la température moyenne d'une pièce sur le tableau de bord
+description: "Affichez la température moyenne d'une pièce sur votre tableau de bord Gladys Assistant, calculée à partir de tous les capteurs de température de la pièce."
 sidebar_label: Température de la pièce
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/voice-assistant.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/voice-assistant.md
@@ -1,6 +1,7 @@
 ---
 id: voice-assistant
 title: Parler à Gladys depuis le tableau de bord avec l'assistant vocal
+description: "Parlez à Gladys Assistant depuis votre tableau de bord avec le widget assistant vocal : posez une question, lisez la transcription et la réponse de l'IA, et écoutez-la."
 sidebar_label: Assistant vocal
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/weather.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dashboard/weather.md
@@ -1,6 +1,7 @@
 ---
 id: weather
 title: Afficher la météo sur le tableau de bord
+description: "Affichez la météo locale sur votre tableau de bord Gladys Assistant grâce à l'intégration OpenWeather et à la position de votre maison."
 sidebar_label: Météo
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dev/1_mac-linux.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dev/1_mac-linux.md
@@ -1,6 +1,7 @@
 ---
 id: setup-development-environment-mac-linux
 title: Mettre en place un environnement de développement sous Mac/Linux
+description: "Installez un environnement de développement Gladys Assistant sur Mac ou Linux : Node.js, le serveur backend et le frontend pour commencer à contribuer."
 sidebar_label: Mac/Linux
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dev/2_windows.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dev/2_windows.md
@@ -1,6 +1,7 @@
 ---
 id: setup-development-environment-windows
 title: Mettre en place un environnement de développement sous Windows
+description: "Installez un environnement de développement Gladys Assistant sur Windows avec WSL2, Docker Desktop et VS Code pour contribuer au projet."
 sidebar_label: Windows
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dev/3_developing_a_service.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dev/3_developing_a_service.md
@@ -1,6 +1,7 @@
 ---
 id: developing-a-service
 title: Contribuer sur Gladys Assistant
+description: "Contribuez à Gladys Assistant : découvrez la stack open-source (Preact, Node.js, SQLite, DuckDB) et apprenez à développer un nouveau service ou une intégration."
 sidebar_label: Contribuer sur Gladys Assistant
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dev/4_cypress_tests.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dev/4_cypress_tests.md
@@ -1,6 +1,7 @@
 ---
 id: cypress-tests
 title: Faire tourner les tests Cypress dans Gladys
+description: "Lancez les tests end-to-end Cypress du frontend de Gladys Assistant : démarrez le backend, lancez le frontend et exécutez la suite de tests."
 sidebar_label: Les tests frontends
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/0_1_recommended-hardware.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/0_1_recommended-hardware.md
@@ -1,6 +1,7 @@
 ---
 id: recommended-hardware
 title: Le matériel recommandé
+description: "Le meilleur matériel Zigbee pour une maison connectée Gladys Assistant fiable : dongle coordinateur recommandé et appareils les mieux notés dans chaque catégorie."
 sidebar_label: Matériel recommandé
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/1_1_mini-pc.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/1_1_mini-pc.md
@@ -1,6 +1,7 @@
 ---
 id: mini-pc
 title: Installer Gladys Assistant sur un Mini-PC
+description: "Installez Gladys Assistant sur un mini-PC, la méthode recommandée : choisissez votre matériel, installez Ubuntu Server et lancez Gladys avec Docker."
 sidebar_label: Installation sur Mini-PC
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/1_raspberry-pi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/1_raspberry-pi.md
@@ -1,6 +1,7 @@
 ---
 id: raspberry-pi
 title: Installation sur un Raspberry Pi
+description: "Installez Gladys Assistant sur un Raspberry Pi 3, 4 ou 5 en quelques minutes avec notre image officielle 64 bits. La façon la plus simple de découvrir Gladys."
 sidebar_label: Installation sur Raspberry Pi
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/2_docker.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/2_docker.md
@@ -1,6 +1,7 @@
 ---
 id: docker
 title: Installation avec Docker
+description: "Installez Gladys Assistant avec Docker sur n'importe quel système (mini-PC, NAS, serveur Linux, VM) en une seule commande. Gratuit, open-source et auto-hébergé."
 sidebar_label: Installation avec Docker
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/3_docker-compose.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/3_docker-compose.md
@@ -1,6 +1,7 @@
 ---
 id: docker-compose
 title: Installer Gladys Assistant avec Docker Compose
+description: "Installez Gladys Assistant manuellement avec Docker Compose sur un mini-PC, un NAS Synology, une VM Linux ou toute machine équipée de Docker."
 sidebar_label: Installation avec Docker-Compose
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/4_freebox-delta.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/4_freebox-delta.md
@@ -1,6 +1,7 @@
 ---
 id: freebox-delta
 title: Installer Gladys Assistant sur une Freebox Delta
+description: "Installez Gladys Assistant sur une Freebox Delta en créant une machine virtuelle Docker. Guide d'installation auto-hébergée pas à pas."
 sidebar_label: Installation sur Freebox Delta
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/5_synology.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/5_synology.md
@@ -1,6 +1,7 @@
 ---
 id: synology
 title: Installer Gladys Assistant sur un NAS Synology
+description: "Installez Gladys Assistant sur un NAS Synology avec Docker : créez le stockage, déployez le conteneur en SSH et lancez votre maison connectée auto-hébergée."
 sidebar_label: Installation sur NAS Synology
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/6_unraid.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/6_unraid.md
@@ -1,6 +1,7 @@
 ---
 id: unraid
 title: Installer Gladys Assistant sur un NAS Unraid
+description: "Installez Gladys Assistant sur un NAS Unraid depuis le store d'apps : configurez le conteneur Docker en réseau host et automatisez votre maison."
 sidebar_label: Installation sur NAS Unraid
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/7_mobile.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/7_mobile.md
@@ -1,6 +1,7 @@
 ---
 id: phone
 title: Utiliser Gladys Assistant sur son smartphone
+description: "Utilisez Gladys Assistant sur votre téléphone en PWA : installez-la sur Android et iOS, avec un accès distant chiffré de bout en bout via Gladys Plus."
 sidebar_label: Sur votre smartphone
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/8_faq.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/8_faq.md
@@ -1,6 +1,7 @@
 ---
 id: faq
 title: FAQ
+description: "Questions fréquentes sur Gladys Assistant : mise à jour avec Watchtower, qui utilise Gladys et comment contribuer au projet open-source."
 sidebar_label: FAQ
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/airplay.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/airplay.md
@@ -1,6 +1,7 @@
 ---
 id: airplay
 title: Connecter une enceinte Airplay à sa maison connectée
+description: "Connectez n'importe quelle enceinte AirPlay ou un HomePod à Gladys Assistant : configurez l'enceinte, détectez-la dans Gladys et diffusez l'audio chez vous."
 sidebar_label: Airplay
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/alexa.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/alexa.md
@@ -1,6 +1,7 @@
 ---
 id: alexa
 title: Utiliser Alexa avec Gladys Assistant
+description: "Pilotez vos appareils Gladys Assistant avec Amazon Alexa via Gladys Plus, la passerelle cloud certifiée. Le contrôle vocal de votre maison connectée."
 sidebar_label: Alexa
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/bluetooth.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/bluetooth.md
@@ -1,6 +1,7 @@
 ---
 id: bluetooth
 title: Gérer la présence avec la détection Bluetooth
+description: "Détectez la présence à la maison en Bluetooth avec Gladys Assistant : utilisez un porte-clés Bluetooth pour savoir automatiquement si vous êtes chez vous."
 sidebar_label: Bluetooth
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/broadlink.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/broadlink.md
@@ -1,6 +1,7 @@
 ---
 id: broadlink
 title: Broadlink
+description: "Contrôlez vos appareils Broadlink avec Gladys Assistant et remplacez vos télécommandes infrarouges : détectez les appareils et créez des télécommandes virtuelles."
 sidebar_label: Broadlink
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/caldav.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/caldav.md
@@ -1,6 +1,7 @@
 ---
 id: caldav
 title: CalDAV
+description: "Synchronisez le calendrier de Gladys Assistant avec iCloud, Google Agenda, Synology ou Nextcloud en CalDAV pour déclencher des scènes selon vos événements."
 sidebar_label: CalDAV
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/callmebot.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/callmebot.md
@@ -1,6 +1,7 @@
 ---
 id: callmebot
 title: Envoyez des messages Gladys vers WhatsApp et Signal avec CallMeBot
+description: "Envoyez des notifications Gladys Assistant vers WhatsApp et Signal avec CallMeBot : obtenez votre clé API et configurez la messagerie sortante."
 sidebar_label: CallMeBot
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/camera.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/camera.md
@@ -1,6 +1,7 @@
 ---
 id: camera
 title: Caméra
+description: "Ajoutez des caméras IP à Gladys Assistant via leur flux RTSP ou HTTP et regardez-les en direct sur votre tableau de bord."
 sidebar_label: Caméra
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/enedis.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/enedis.md
@@ -1,6 +1,7 @@
 ---
 id: enedis
 title: Visualiser sa consommation électrique dans Gladys avec Enedis
+description: "Visualisez votre consommation électrique dans Gladys Assistant avec l'intégration Enedis : récupérez les données de votre compteur Linky via Gladys Plus (France)."
 sidebar_label: Enedis
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/energy-monitoring.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/energy-monitoring.md
@@ -1,6 +1,7 @@
 ---
 id: energy-monitoring
 title: Surveillez votre consommation énergétique avec Gladys Assistant
+description: "Suivez la consommation d'énergie de votre maison dans Gladys Assistant en kWh, avec un Lixee ZLinky pour le compteur Linky ou d'autres capteurs compatibles."
 sidebar_label: Suivi de l'énergie
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/free-mobile.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/free-mobile.md
@@ -1,6 +1,7 @@
 ---
 id: free-mobile
 title: Comment configurer Free Mobile avec Gladys Assistant
+description: "Envoyez des SMS sur votre téléphone depuis Gladys Assistant avec l'opérateur Free Mobile : activez les notifications SMS, récupérez votre clé et envoyez votre premier SMS."
 sidebar_label: Free Mobile
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/google-cast.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/google-cast.md
@@ -1,6 +1,7 @@
 ---
 id: google-cast
 title: Faire parler Gladys Assistant sur une enceinte Google
+description: "Faites parler Gladys Assistant sur une enceinte Google Cast : ajoutez l'appareil, affectez-le à une pièce et utilisez l'action Parler sur une enceinte dans vos scènes."
 sidebar_label: Google Cast
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/google-home.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/google-home.md
@@ -1,6 +1,7 @@
 ---
 id: google-home
 title: Utiliser Google Home avec Gladys Assistant
+description: "Pilotez vos appareils Gladys Assistant avec Google Home via Gladys Plus, la passerelle cloud certifiée Google. Le contrôle vocal de votre maison connectée."
 sidebar_label: Google Home
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/homekit.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/homekit.md
@@ -1,6 +1,7 @@
 ---
 id: homekit
 title: Connecter Gladys à HomeKit et utiliser Siri
+description: "Connectez Gladys Assistant à Apple HomeKit et pilotez vos appareils avec Siri : scannez le QR code, ajoutez Gladys comme pont HomeKit et importez vos appareils."
 sidebar_label: HomeKit
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/lan-manager.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/lan-manager.md
@@ -1,6 +1,7 @@
 ---
 id: lan-manager
 title: Gérer la présence en scannant votre réseau
+description: "Détectez la présence dans Gladys Assistant en scannant votre réseau Wi-Fi à la recherche de votre téléphone ou ordinateur pour savoir si vous êtes chez vous."
 sidebar_label: Lan-Manager
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/matter.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/matter.md
@@ -1,6 +1,7 @@
 ---
 id: matter
 title: Intégrer des appareils Matter dans Gladys Assistant
+description: "Intégrez vos appareils Matter dans Gladys Assistant : pilotez lampes, prises, volets, thermostats et capteurs de différents fabricants."
 sidebar_label: Matter
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/matterbridge.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/matterbridge.md
@@ -1,6 +1,7 @@
 ---
 id: matterbridge
 title: Matterbridge
+description: "Connectez des appareils non-Matter (Shelly, Somfy) à Gladys Assistant avec Matterbridge : activez le conteneur, installez des plugins et appairez-les en Matter."
 sidebar_label: Matterbridge
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/melcloud.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/melcloud.md
@@ -1,6 +1,7 @@
 ---
 id: melcloud
 title: MELCloud (Climatisation Mitsubishi)
+description: "Pilotez votre climatisation Mitsubishi depuis Gladys Assistant avec l'intégration MELCloud : connectez votre compte et gérez vos unités de clim."
 sidebar_label: MELCloud
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/mqtt.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/mqtt.md
@@ -1,6 +1,7 @@
 ---
 id: mqtt
 title: MQTT
+description: "Connectez vos appareils MQTT à Gladys Assistant : configurez un broker MQTT et échangez des données dans les deux sens entre Gladys, capteurs et actionneurs."
 sidebar_label: MQTT
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/netatmo.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/netatmo.md
@@ -1,6 +1,7 @@
 ---
 id: netatmo
 title: Connecter ses thermostats Netatmo à sa maison connectée
+description: "Connectez vos thermostats, vannes et stations météo Netatmo à Gladys Assistant via Netatmo Connect pour superviser et piloter votre maison connectée."
 sidebar_label: Netatmo
 toc_min_heading_level: 2
 toc_max_heading_level: 5

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/nextcloud-talk.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/nextcloud-talk.md
@@ -1,6 +1,7 @@
 ---
 id: nextcloud-talk
 title: Nextcloud Talk
+description: "Utilisez Nextcloud Talk pour dialoguer avec Gladys Assistant : créez un compte bot, récupérez le token de conversation et envoyez des instructions à votre maison."
 sidebar_label: Nextcloud Talk
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/node-red.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/node-red.md
@@ -1,6 +1,7 @@
 ---
 id: node-red
 title: Node-RED
+description: "Intégrez Node-RED à Gladys Assistant pour connecter matériel, API et services en ligne : activez le conteneur et créez des automatisations puissantes."
 sidebar_label: Node-RED
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/nuki.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/nuki.md
@@ -1,6 +1,7 @@
 ---
 id: nuki
 title: Connecter sa serrure Nuki à sa maison connectée
+description: "Connectez votre serrure connectée Nuki à Gladys Assistant pour verrouiller, déverrouiller et suivre la batterie et l'état, via l'API Nuki Web ou MQTT."
 sidebar_label: Nuki
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/openweather.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/openweather.md
@@ -1,6 +1,7 @@
 ---
 id: openweather
 title: OpenWeather
+description: "Affichez les prévisions météo dans Gladys Assistant avec OpenWeather : créez un compte, récupérez votre clé API et ajoutez un widget météo au tableau de bord."
 sidebar_label: OpenWeather
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/owntracks.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/owntracks.md
@@ -1,6 +1,7 @@
 ---
 id: owntracks
 title: Owntracks
+description: "Suivez la position de votre téléphone dans Gladys Assistant avec OwnTracks et Gladys Plus pour automatiser la présence et déclencher des scènes géolocalisées."
 sidebar_label: Owntracks
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/philips-hue.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/philips-hue.md
@@ -1,6 +1,7 @@
 ---
 id: philips-hue
 title: Connecter ses Philips Hue dans Gladys Assistant
+description: "Connectez votre pont et vos ampoules Philips Hue à Gladys Assistant pour les piloter localement depuis votre tableau de bord et vos scènes."
 sidebar_label: Philips Hue
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/shelly.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/shelly.md
@@ -1,6 +1,7 @@
 ---
 id: shelly
 title: Intégrer Shelly à Gladys via Matterbridge
+description: "Intégrez vos modules Shelly dans Gladys Assistant via Matterbridge : déployez le pont, appairez-le dans Gladys et pilotez vos Shelly en Matter."
 sidebar_label: Shelly
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/somfy-tahoma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/somfy-tahoma.md
@@ -1,6 +1,7 @@
 ---
 id: somfy-tahoma
 title: Intégrer ses équipements Somfy à Gladys via Matterbridge
+description: "Intégrez vos appareils Somfy TaHoma dans Gladys Assistant via Matterbridge pour piloter vos volets roulants, stores et ouvertures en Matter."
 sidebar_label: Somfy
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/sonoff.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/sonoff.md
@@ -1,6 +1,7 @@
 ---
 id: sonoff
 title: Sonoff
+description: "Connectez vos appareils Sonoff à Gladys Assistant avec le firmware Tasmota et un compte eWeLink pour les piloter localement dans votre maison connectée."
 sidebar_label: Sonoff
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/sonos.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/sonos.md
@@ -1,6 +1,7 @@
 ---
 id: sonos
 title: Connecter une enceinte Sonos à sa maison connectée
+description: "Connectez vos enceintes Sonos à Gladys Assistant : détectez-les sur votre réseau et pilotez-les depuis votre tableau de bord et vos scènes."
 sidebar_label: Sonos
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tasmota.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tasmota.md
@@ -1,6 +1,7 @@
 ---
 id: tasmota
 title: Tasmota
+description: "Connectez vos appareils Tasmota à Gladys Assistant : flashez le firmware open-source sur votre ESP8266, configurez MQTT et pilotez-les dans Gladys."
 sidebar_label: Tasmota
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/telegram.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/telegram.md
@@ -1,6 +1,7 @@
 ---
 id: telegram
 title: Envoyer des notifications Gladys sur Telegram
+description: "Envoyez les notifications de Gladys Assistant sur Telegram et pilotez votre maison en discutant avec Gladys : créez un bot et liez votre compte."
 sidebar_label: Telegram
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tp-link.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tp-link.md
@@ -1,6 +1,7 @@
 ---
 id: tp-link
 title: TP-Link
+description: "Connectez vos ampoules et prises TP-Link Kasa à Gladys Assistant : scannez votre réseau Wi-Fi, ajoutez vos appareils et pilotez-les dans votre maison connectée."
 sidebar_label: TP-Link
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tuya.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tuya.md
@@ -1,6 +1,7 @@
 ---
 id: tuya
 title: Tuya
+description: "Connectez vos appareils Tuya à Gladys Assistant : créez un projet cloud Tuya IoT, autorisez l'API et pilotez vos appareils connectés Tuya."
 sidebar_label: Tuya
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/xiaomi.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/xiaomi.md
@@ -1,6 +1,7 @@
 ---
 id: xiaomi
 title: Xiaomi Home
+description: "Connectez vos appareils Xiaomi à Gladys Assistant via la passerelle Mi Home. Note : le Zigbee ou Matter est désormais recommandé pour ces appareils."
 sidebar_label: Xiaomi Home
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/zigbee2mqtt.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/zigbee2mqtt.md
@@ -1,6 +1,7 @@
 ---
 id: zigbee2mqtt
 title: Gérez ses appareils Zigbee dans sa domotique avec une clé USB Zigbee et Zigbee2mqtt
+description: "Connectez vos appareils Zigbee à Gladys Assistant avec un dongle USB Zigbee et Zigbee2MQTT, sans pont tiers et avec un contrôle 100 % local."
 sidebar_label: Zigbee2Mqtt
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/zwavejs-ui.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/zwavejs-ui.md
@@ -1,6 +1,7 @@
 ---
 id: zwavejs-ui
 title: Intégrez vos appareils Z-Wave grâce à Z-Wave JS UI
+description: "Intégrez vos appareils Z-Wave dans Gladys Assistant avec Z-Wave JS UI via MQTT pour les piloter et recevoir les changements d'état en temps réel."
 sidebar_label: Z-Wave JS UI
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/plus/intro.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/plus/intro.md
@@ -1,6 +1,7 @@
 ---
 id: intro
 title: Gladys Plus
+description: "Découvrez Gladys Plus : accès distant chiffré, sauvegardes quotidiennes, Open API, IA open-weight, serveur MCP et Google Home pour votre maison Gladys Assistant."
 sidebar_label: Intro
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/plus/open-api.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/plus/open-api.md
@@ -1,6 +1,7 @@
 ---
 id: open-api
 title: Open API
+description: "Utilisez l'Open API de Gladys Plus pour envoyer des données à votre maison depuis l'extérieur de votre réseau : localisation, valeurs de capteurs et événements, via une clé API."
 sidebar_label: Open API
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/back-at-home.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/back-at-home.md
@@ -1,6 +1,7 @@
 ---
 id: back-at-home
 title: Retour à la maison
+description: "Déclenchez une scène Gladys Assistant quand un utilisateur rentre à la maison, grâce à la détection de présence, pour automatiser votre maison à l'arrivée."
 sidebar_label: Retour à la maison
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/calendar-event-is-coming.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/calendar-event-is-coming.md
@@ -1,6 +1,7 @@
 ---
 id: calendar-event-is-coming-trigger
 title: Déclencher une scène quand un évènement arrive dans le calendrier
+description: "Déclenchez une scène Gladys Assistant à l'approche ou à la fin d'un événement de calendrier, avec de puissants filtres de nom, via vos calendriers CalDAV."
 sidebar_label: Un évènement du calendrier arrive
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/calendar-event-is-running.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/calendar-event-is-running.md
@@ -1,6 +1,7 @@
 ---
 id: calendar-event-is-running-condition
 title: Condition sur un évènement de calendrier
+description: "Ajoutez une condition à une scène Gladys Assistant selon un événement de calendrier en cours, pour n'exécuter vos automatisations qu'en vacances, au sport ou en réunion."
 sidebar_label: Un évènement du calendrier est en cours
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/chain.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/chain.md
@@ -1,6 +1,7 @@
 ---
 id: chain-action
 title: Lancer une scène depuis une scène
+description: "Enchaînez des scènes dans Gladys Assistant en déclenchant une scène depuis une autre, avec une protection anti-boucle intégrée pour des automatisations réutilisables."
 sidebar_label: Chaîner des scènes
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/continue-only-if.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/continue-only-if.md
@@ -1,6 +1,7 @@
 ---
 id: continue-only-if-action
 title: Condition sur variables
+description: "Utilisez l'action Continuer seulement si dans les scènes Gladys Assistant pour ne poursuivre que si une variable remplit une condition, avec fonctions mathématiques."
 sidebar_label: Condition sur variables
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/device-state-changed-trigger.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/device-state-changed-trigger.md
@@ -1,6 +1,7 @@
 ---
 id: device-state-changed-trigger
 title: Déclencher une scène lorsque l'état d'un appareil change
+description: "Déclenchez une scène Gladys Assistant quand l'état d'un appareil change, comme une baisse de température ou une lampe qui s'allume, avec des conditions personnalisées."
 sidebar_label: Déclencheur sur l'état d'un appareil
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/edf-tempo.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/edf-tempo.md
@@ -1,6 +1,7 @@
 ---
 id: edf-tempo
 title: Faire des économies sur sa facture d'électricité avec EDF Tempo et Gladys
+description: "Économisez sur votre facture d'électricité avec EDF Tempo et Gladys Assistant : ajoutez une condition Tempo à vos scènes pour automatiser selon la couleur du jour."
 sidebar_label: EDF Tempo
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/get-last-device-state-action.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/get-last-device-state-action.md
@@ -1,6 +1,7 @@
 ---
 id: get-last-device-state-action
 title: Récupérer le dernier état
+description: "Récupérez le dernier état d'un appareil dans une scène Gladys Assistant et stockez-le dans une variable pour vos conditions et actions suivantes."
 sidebar_label: Récupérer le dernier état
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/house-empty.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/house-empty.md
@@ -1,6 +1,7 @@
 ---
 id: house-empty
 title: Quand la maison est vide
+description: "Déclenchez une scène Gladys Assistant quand la maison devient vide, ou ajoutez une condition pour n'exécuter vos automatisations que si personne n'est là."
 sidebar_label: Maison vide
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/house-no-longer-empty.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/house-no-longer-empty.md
@@ -1,6 +1,7 @@
 ---
 id: house-no-longer-empty
 title: Quand la maison n'est plus vide
+description: "Déclenchez une scène Gladys Assistant quand la maison n'est plus vide, ou ajoutez une condition pour n'exécuter vos automatisations que si quelqu'un est présent."
 sidebar_label: Maison n'est plus vide
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/http-request.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/http-request.md
@@ -1,6 +1,7 @@
 ---
 id: http-request
 title: Faire des requêtes HTTP dans une scène
+description: "Effectuez des requêtes HTTP dans les scènes Gladys Assistant pour appeler des API externes, piloter des appareils non gérés ou déclencher une action IFTTT."
 sidebar_label: Requête HTTP
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/intro.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/intro.md
@@ -1,6 +1,7 @@
 ---
 id: intro
 title: Les scènes dans Gladys Assistant
+description: "Créez des scènes puissantes dans Gladys Assistant : enchaînez des actions, lancez-les manuellement ou via des déclencheurs, et automatisez votre maison à votre façon."
 sidebar_label: Introduction
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/left-home.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/left-home.md
@@ -1,6 +1,7 @@
 ---
 id: left-home
 title: Départ de la maison
+description: "Déclenchez une scène Gladys Assistant quand un utilisateur quitte la maison, grâce à la détection de présence, pour automatiser votre maison au départ."
 sidebar_label: Départ de la maison
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/math-functions.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/math-functions.md
@@ -1,6 +1,7 @@
 ---
 id: math-functions
 title: Fonctions mathématiques disponibles
+description: "Référence des fonctions mathématiques disponibles dans les scènes Gladys Assistant (addition, modulo, puissance) pour des automatisations dynamiques et calculées."
 sidebar_label: Fonctions mathématiques
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/scheduled-trigger.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/scheduled-trigger.md
@@ -1,6 +1,7 @@
 ---
 id: scheduled-trigger
 title: Programmer une scène
+description: "Planifiez vos scènes Gladys Assistant chaque mois, semaine, jour, à intervalles ou un jour précis pour une automatisation entièrement basée sur le temps."
 sidebar_label: Programmer une scène
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/send-a-message.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/send-a-message.md
@@ -1,6 +1,7 @@
 ---
 id: send-a-message-action
 title: Envoyer un message
+description: "Envoyez un message à un utilisateur Gladys Assistant dans une scène via Telegram ou le chat web, et injectez des valeurs de capteurs et des variables dans le texte."
 sidebar_label: Envoyer un message
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/send-a-sms.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/send-a-sms.md
@@ -1,6 +1,7 @@
 ---
 id: send-a-sms-action
 title: Envoyer un SMS
+description: "Envoyez un SMS sur votre téléphone dans une scène Gladys Assistant avec l'opérateur Free Mobile, et injectez des valeurs de capteurs et des variables dans le message."
 sidebar_label: Envoyer un SMS
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/send-a-zigbee2mqtt-message.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/send-a-zigbee2mqtt-message.md
@@ -1,6 +1,7 @@
 ---
 id: send-a-zigbee2mqtt-message-action
 title: Envoyer un message Zigbee2Mqtt
+description: "Envoyez un message Zigbee2MQTT dans une scène Gladys Assistant pour piloter directement des appareils Zigbee, comme déclencher une sirène, avec injection de variables."
 sidebar_label: Envoyer un message Zigbee2Mqtt
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/sunset-sunrise.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/sunset-sunrise.md
@@ -1,6 +1,7 @@
 ---
 id: sunset-sunrise
 title: Déclenchement lié au soleil
+description: "Déclenchez une scène Gladys Assistant au lever ou au coucher du soleil, avec un délai optionnel avant ou après, pour automatiser vos lumières avec le soleil."
 sidebar_label: Déclenchement solaire
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/time-condition.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/time-condition.md
@@ -1,6 +1,7 @@
 ---
 id: time-condition
 title: Condition temporelle
+description: "Ajoutez une condition horaire à une scène Gladys Assistant pour ne continuer que pendant une plage horaire choisie et certains jours de la semaine."
 sidebar_label: Condition temporelle
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/turn-on-off-the-lights-action.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/turn-on-off-the-lights-action.md
@@ -1,6 +1,7 @@
 ---
 id: turn-on-off-the-lights-action
 title: Allumer/éteindre la lumière dans une scène
+description: "Allumez ou éteignez vos lumières dans une scène Gladys Assistant pour automatiser le réveil, le mode cinéma, le départ de la maison et bien plus."
 sidebar_label: Allumer/éteindre la lumière
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/turn-on-off-the-switches-action.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/turn-on-off-the-switches-action.md
@@ -1,6 +1,7 @@
 ---
 id: turn-on-off-the-switches-action
 title: Allumer/éteindre des prises télécommandées dans une scène
+description: "Pilotez des prises télécommandées dans une scène Gladys Assistant pour automatiser lampes, rubans LED ou une cafetière, avec un exemple pas à pas."
 sidebar_label: Allumer/éteindre des prises
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/user-presence.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/user-presence.md
@@ -1,6 +1,7 @@
 ---
 id: user-presence
 title: Définir la présence d'un utilisateur dans une scène
+description: "Définissez la présence ou l'absence d'un utilisateur dans une scène Gladys Assistant pour piloter les automatisations de retour et de départ depuis n'importe quelle source."
 sidebar_label: Présence utilisateur
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/wait.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/wait.md
@@ -1,6 +1,7 @@
 ---
 id: wait-action
 title: Attendre
+description: "Utilisez l'action Attendre dans une scène Gladys Assistant pour patienter une durée fixe ou calculée, basée sur des variables et des fonctions mathématiques."
 sidebar_label: Attendre
 ---
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/scenes/zone.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/scenes/zone.md
@@ -1,6 +1,7 @@
 ---
 id: zone
 title: Quand un utilisateur entre/sort d'une zone
+description: "Déclenchez une scène Gladys Assistant quand un utilisateur entre ou sort d'une zone géographique définie sur la carte pour des automatisations géolocalisées."
 sidebar_label: Utilisateur entre/sort d'une zone
 ---
 


### PR DESCRIPTION
Add unique, keyword-rich meta descriptions to every documentation page (EN & FR). Previously 91 of 95 docs had no `description` frontmatter, so search engines fell back to auto-generated snippets (often a code block or truncated intro). Each page now ships a hand-written description in both languages.

Config-level SEO improvements:
- Enable `showLastUpdateTime` on docs & blog so the sitemap can emit `<lastmod>` entries (derived from git), giving crawlers a freshness signal. Also surfaces a "Last updated" date to readers.
- Configure the sitemap plugin explicitly (lastmod / changefreq / priority).
- Add a global `og:site_name` Open Graph tag.