### PR TITLE
SEO: WebSite/Organization schema, richer meta descriptions, sitemap priorities

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -237,6 +237,46 @@ module.exports = function createConfig() {
           changefreq: "weekly",
           priority: 0.5,
           filename: "sitemap.xml",
+          createSitemapItems: async (params) => {
+            const { defaultCreateSitemapItems, ...rest } = params;
+            const items = await defaultCreateSitemapItems(rest);
+            // Give search engines a clearer priority hierarchy instead of a
+            // flat 0.5 on every URL. Low-value listing pages (tags, archive,
+            // pagination) are demoted; key landing pages are promoted.
+            return items
+              .filter(
+                (item) =>
+                  !item.url.includes("/tags/") &&
+                  !item.url.includes("/page/")
+              )
+              .map((item) => {
+                const path = item.url
+                  .replace("https://gladysassistant.com", "")
+                  .replace("/fr/", "/");
+                if (path === "/") {
+                  return { ...item, priority: 1.0, changefreq: "daily" };
+                }
+                if (
+                  path === "/docs/" ||
+                  path === "/docs/integrations/" ||
+                  path === "/plus/" ||
+                  path === "/starter-kit/" ||
+                  path === "/blog/"
+                ) {
+                  return { ...item, priority: 0.8 };
+                }
+                if (
+                  path === "/blog/archive/" ||
+                  path === "/blog/authors/"
+                ) {
+                  return { ...item, priority: 0.3 };
+                }
+                if (path.startsWith("/blog/") || path.startsWith("/docs/")) {
+                  return { ...item, priority: 0.7 };
+                }
+                return item;
+              });
+          },
         },
       },
     ],

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -352,14 +352,14 @@
     "description": "Integration improve integration list here"
   },
   "home.metaDescription": {
-    "message": "Gladys Assistant est un logiciel de domotique moderne et respecteux de la vie privée.",
+    "message": "Gladys Assistant est une plateforme de domotique open-source et respectueuse de la vie privée. Auto-hébergée, sans cloud — une alternative simple à Home Assistant.",
     "description": "home page meta description"
   },
   "openPage.title": {
     "message": "Gladys Assistant en chiffre"
   },
   "openPage.metaDescription": {
-    "message": "Découvrez les statistiques d'usages de Gladys Assistant !",
+    "message": "Découvrez en temps réel les métriques ouvertes de Gladys Assistant : instances actives, utilisateurs Gladys Plus, revenu mensuel récurrent et statistiques de la communauté.",
     "description": "gladys open page meta description"
   },
   "openPage.description": {
@@ -415,7 +415,7 @@
     "description": "Contact page title"
   },
   "contact.metaDescription": {
-    "message": "Si vous avez une idée, une question, une demande de partnariat.",
+    "message": "Contactez l'équipe Gladys Assistant : questions, idées, demandes de partenariat ou support pour votre domotique open-source et respectueuse de la vie privée.",
     "description": "Contact page meta description"
   },
   "contactPage.title": {

--- a/src/data/structuredData.js
+++ b/src/data/structuredData.js
@@ -171,11 +171,32 @@ function getOrganizationNode() {
     name: "Gladys Assistant",
     url: SITE_URL,
     logo: `${SITE_URL}/img/logo.svg`,
+    description:
+      "Privacy-first, open-source, self-hosted home automation platform. A simpler alternative to Home Assistant, focused on local control and European privacy standards.",
+    foundingDate: "2013",
     sameAs: SAME_AS,
     founder: {
       "@type": "Person",
       name: "Pierre-Gilles Leymarie",
     },
+    contactPoint: {
+      "@type": "ContactPoint",
+      email: "hello@gladysassistant.com",
+      contactType: "customer support",
+      availableLanguage: ["English", "French"],
+    },
+  };
+}
+
+function getWebSiteNode(lang) {
+  const prefix = lang === "fr" ? "/fr" : "";
+  return {
+    "@type": "WebSite",
+    "@id": `${SITE_URL}/#website`,
+    name: "Gladys Assistant",
+    url: `${SITE_URL}${prefix}/`,
+    inLanguage: lang === "fr" ? "fr" : "en",
+    publisher: { "@id": `${SITE_URL}/#organization` },
   };
 }
 
@@ -187,6 +208,7 @@ export function getHomepageSchema(lang) {
     "@context": "https://schema.org",
     "@graph": [
       getOrganizationNode(),
+      getWebSiteNode(lang),
       {
         "@type": "SoftwareApplication",
         "@id": `${SITE_URL}/#software`,
@@ -221,6 +243,7 @@ export function getPlusPageSchema(lang) {
     "@context": "https://schema.org",
     "@graph": [
       getOrganizationNode(),
+      getWebSiteNode(lang),
       {
         "@type": "Product",
         "@id": `${pageUrl}#product`,

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -91,7 +91,8 @@ function Home() {
       description={translate({
         id: "contact.metaDescription",
         description: "Contact page meta description",
-        message: "If you want to contact us",
+        message:
+          "Get in touch with the Gladys Assistant team: questions, ideas, partnership requests, or support for your open-source, privacy-first smart home.",
       })}
     >
       <main>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,7 +23,7 @@ function HomePage() {
         id: "home.metaDescription",
         description: "home page meta description",
         message:
-          "Gladys Assistant is a modern, privacy-first & open-source home automation software that runs anywhere.",
+          "Gladys Assistant is a privacy-first, open-source home automation platform. Self-hosted, no cloud required — a simpler alternative to Home Assistant.",
       })}
     >
       <JsonLd data={getHomepageSchema(i18n.currentLocale)} />

--- a/src/pages/open.js
+++ b/src/pages/open.js
@@ -204,7 +204,8 @@ function Open() {
       description={translate({
         id: "openPage.metaDescription",
         description: "gladys open page meta description",
-        message: "See some interesting statistics about Gladys usage !",
+        message:
+          "Explore Gladys Assistant's open metrics in real time: active instances, Gladys Plus users, monthly recurring revenue, and community statistics.",
       })}
     >
       <main>


### PR DESCRIPTION
- Add WebSite JSON-LD node (publisher → Organization) to homepage & Plus page
- Enrich Organization schema: description, foundingDate (2013), contactPoint
- Rewrite thin meta descriptions (homepage, contact, open) in EN & FR with keyword-rich copy; fix FR typos ("respecteux", "partnariat")
- Differentiate sitemap priorities (homepage 1.0, key landings 0.8, content 0.7, blog listing pages 0.3) and drop low-value /tags/ & /page/ URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sitemap generation by excluding tag and paginated URLs, while giving important pages better search visibility settings.
  * Added richer structured data for key pages, including organization details and website metadata.
* **Documentation**
  * Refreshed homepage, open page, and contact page copy in French to better describe the product, open metrics, and support options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->