### PR TITLE
SEO: add "Home Assistant vs Gladys" comparison and "Home Assistant alternative" pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -124,14 +124,6 @@ module.exports = function createConfig() {
               to: "docs",
             },
             {
-              label: "Gladys vs Home Assistant",
-              to: "home-assistant-vs-gladys-assistant/",
-            },
-            {
-              label: "Home Assistant alternative",
-              to: "home-assistant-alternative/",
-            },
-            {
               label: "Kit de démarrage officiel",
               href: "/starter-kit/",
               className: "footer__link-item footer__link--fr-only",
@@ -156,19 +148,15 @@ module.exports = function createConfig() {
           ],
         },
         {
-          title: "Socials",
+          title: "Compare",
           items: [
             {
-              label: "Twitter",
-              href: "https://twitter.com/gladysassistant",
+              label: "Gladys vs Home Assistant",
+              to: "home-assistant-vs-gladys-assistant/",
             },
             {
-              label: "Facebook",
-              href: "https://facebook.com/gladysassistant",
-            },
-            {
-              label: "Instagram",
-              href: "https://instagram.com/gladysassistant",
+              label: "Home Assistant alternative",
+              to: "home-assistant-alternative/",
             },
           ],
         },
@@ -199,6 +187,18 @@ module.exports = function createConfig() {
             {
               label: "Contact Us",
               href: "/contact",
+            },
+            {
+              label: "Twitter",
+              href: "https://twitter.com/gladysassistant",
+            },
+            {
+              label: "Facebook",
+              href: "https://facebook.com/gladysassistant",
+            },
+            {
+              label: "Instagram",
+              href: "https://instagram.com/gladysassistant",
             },
           ],
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -124,6 +124,14 @@ module.exports = function createConfig() {
               to: "docs",
             },
             {
+              label: "Gladys vs Home Assistant",
+              to: "home-assistant-vs-gladys-assistant/",
+            },
+            {
+              label: "Home Assistant alternative",
+              to: "home-assistant-alternative/",
+            },
+            {
               label: "Kit de démarrage officiel",
               href: "/starter-kit/",
               className: "footer__link-item footer__link--fr-only",
@@ -261,6 +269,8 @@ module.exports = function createConfig() {
                   path === "/docs/integrations/" ||
                   path === "/plus/" ||
                   path === "/starter-kit/" ||
+                  path === "/home-assistant-vs-gladys-assistant/" ||
+                  path === "/home-assistant-alternative/" ||
                   path === "/blog/"
                 ) {
                   return { ...item, priority: 0.8 };

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -11,6 +11,18 @@
     "message": "En savoir plus",
     "description": "The title of the footer links column with title=More in the footer"
   },
+  "link.title.Compare": {
+    "message": "Comparatif",
+    "description": "The title of the footer links column with title=Compare in the footer"
+  },
+  "link.item.label.Gladys vs Home Assistant": {
+    "message": "Gladys vs Home Assistant",
+    "description": "The label of footer link with label=Gladys vs Home Assistant linking to home-assistant-vs-gladys-assistant/"
+  },
+  "link.item.label.Home Assistant alternative": {
+    "message": "Alternative à Home Assistant",
+    "description": "The label of footer link with label=Home Assistant alternative linking to home-assistant-alternative/"
+  },
   "link.item.label.Raspberry Pi": {
     "message": "Raspberry Pi",
     "description": "The label of footer link with label=Raspberry Pi linking to docs/installation/raspberry-pi/"

--- a/src/data/alternativeData.js
+++ b/src/data/alternativeData.js
@@ -10,15 +10,15 @@ const alternativeContent = {
     meta: {
       title: "The best Home Assistant alternative: Gladys Assistant",
       description:
-        "Looking for a Home Assistant alternative? Gladys Assistant is a simpler, privacy-first, open-source home automation platform — no YAML, no cloud, stable automatic updates. Free and self-hosted.",
+        "Looking for a Home Assistant alternative? Gladys Assistant is a simpler, privacy-first, open-source home automation platform: no YAML, no cloud, stable automatic updates. Free and self-hosted.",
     },
     hero: {
       title: "Looking for a Home Assistant alternative?",
       subtitle:
-        "Meet Gladys Assistant — the simpler, privacy-first, open-source home automation platform.",
+        "Meet Gladys Assistant, the simpler, privacy-first, open-source home automation platform.",
       intro: [
-        "Home Assistant is a fantastic project. But it's not for everyone: between YAML files, a steep learning curve and frequent updates, many people look for something simpler — without giving up open-source and local control.",
-        "That's exactly why Gladys Assistant exists. It's a free, open-source, self-hosted home automation platform built around one idea: think about the user first. No configuration files, no cloud required — everything happens with a few clicks.",
+        "Home Assistant is a fantastic project, but it isn't for everyone. Between YAML files, a steep learning curve and frequent updates, many people look for something simpler, without giving up open-source and local control.",
+        "That's exactly why Gladys Assistant exists. It's a free, open-source, self-hosted home automation platform built around one idea: think about the user first. No configuration files, no cloud required, everything happens with a few clicks.",
       ],
       primaryCta: { label: "Get started free", href: "/docs/" },
       secondaryCta: {
@@ -29,7 +29,7 @@ const alternativeContent = {
     whyLooking: {
       title: "Why look for an alternative to Home Assistant?",
       intro:
-        "Home Assistant is incredibly powerful — but that power comes at a cost. The most common reasons people start searching for an alternative:",
+        "Home Assistant is incredibly powerful, but that power comes at a cost. The most common reasons people start searching for an alternative:",
       points: [
         "You have to edit YAML configuration files for some setups.",
         "The learning curve is steep, and the interface can feel overwhelming for a beginner.",
@@ -38,7 +38,7 @@ const alternativeContent = {
         "You want a clean, stable experience that just works, without tinkering.",
       ],
       outro:
-        "None of this makes Home Assistant a bad project — it's excellent if you love to tinker. It's simply a question of fit.",
+        "None of this makes Home Assistant a bad project. It's excellent if you love to tinker. It's simply a question of fit, and for most people who just want a smart home that works, there's a simpler way.",
     },
     reasons: {
       title: "Why Gladys is a great Home Assistant alternative",
@@ -46,7 +46,7 @@ const alternativeContent = {
         {
           icon: "🖱️",
           title: "No YAML, ever",
-          text: "Everything is configured by clicking in the interface. There are no configuration files to edit — because there are none.",
+          text: "Everything is configured by clicking in the interface. There are no configuration files to edit, because there are none.",
         },
         {
           icon: "🛡️",
@@ -56,17 +56,17 @@ const alternativeContent = {
         {
           icon: "🔒",
           title: "Privacy-first & self-hosted",
-          text: "Gladys runs at home, on your machine. Your data stays on your local network — no mandatory cloud, no tracking, no data selling.",
+          text: "Gladys runs at home, on your machine. Your data stays on your local network, with no mandatory cloud, no tracking and no data selling.",
         },
         {
           icon: "🔌",
           title: "Built on open standards",
-          text: "Zigbee, Matter and MQTT are first-class citizens. Thousands of devices are supported through these open protocols.",
+          text: "Zigbee, Matter and MQTT are first-class citizens, so thousands of devices are supported through these open protocols.",
         },
         {
           icon: "💬",
-          title: "Direct support from the maker",
-          text: "Ask a question by email, on the forum or on social media — the founder answers personally, in French or English.",
+          title: "A project that listens",
+          text: "Ask a question by email, on the forum or on social media, and the founder answers personally. Your feedback genuinely shapes the roadmap.",
         },
         {
           icon: "💚",
@@ -76,10 +76,10 @@ const alternativeContent = {
       ],
     },
     honesty: {
-      title: "Being honest: where Home Assistant still wins",
+      title: "Being fair: where Home Assistant has the edge",
       paragraphs: [
-        "I'm the creator of Gladys, so let me be transparent. Home Assistant has 2000+ integrations versus around 35 native ones in Gladys. If you own very niche or cloud-only devices, Home Assistant is more likely to support them out of the box. It also lets you share automations as YAML blueprints and offers far more knobs for power users.",
-        "But 35 native integrations still means thousands of compatible devices through Zigbee and Matter. For the rest, Matterbridge can bridge non-Matter devices onto a Matter network — and you can even run Gladys and Home Assistant side by side, using one as a backend and the other as your interface.",
+        "I'm the creator of Gladys, so let me be transparent. Home Assistant has a larger catalog of integrations, so if you own very niche or cloud-only devices, it may support them out of the box when Gladys doesn't yet. It also lets you share automations as YAML blueprints and gives power users more knobs to turn.",
+        "But Gladys already supports thousands of devices through Zigbee and Matter, the open standards the whole industry is moving toward. For anything else, Matterbridge can bridge non-Matter devices, and you can even run Gladys and Home Assistant side by side, using one as a backend and the other as your interface. In other words, choosing Gladys rarely means giving anything up.",
       ],
       compareLink: {
         label: "See the full Gladys vs Home Assistant comparison →",
@@ -127,15 +127,15 @@ const alternativeContent = {
     meta: {
       title: "La meilleure alternative à Home Assistant : Gladys Assistant",
       description:
-        "Vous cherchez une alternative à Home Assistant ? Gladys Assistant est une solution domotique open source, plus simple et respectueuse de la vie privée — sans YAML, sans cloud, avec des mises à jour automatiques et stables. Gratuite et auto-hébergée.",
+        "Vous cherchez une alternative à Home Assistant ? Gladys Assistant est une solution domotique open source, plus simple et respectueuse de la vie privée : sans YAML, sans cloud, avec des mises à jour automatiques et stables. Gratuite et auto-hébergée.",
     },
     hero: {
       title: "Vous cherchez une alternative à Home Assistant ?",
       subtitle:
-        "Découvrez Gladys Assistant — la solution domotique open source plus simple et respectueuse de votre vie privée.",
+        "Découvrez Gladys Assistant, la solution domotique open source plus simple et respectueuse de votre vie privée.",
       intro: [
-        "Home Assistant est un projet formidable. Mais il ne convient pas à tout le monde : entre les fichiers YAML, une courbe d'apprentissage raide et des mises à jour fréquentes, beaucoup cherchent quelque chose de plus simple — sans renoncer à l'open source et au contrôle local.",
-        "C'est exactement pour ça que Gladys Assistant existe. C'est une solution domotique gratuite, open source et auto-hébergée, construite autour d'une idée : penser d'abord à l'utilisateur. Pas de fichiers de configuration, pas de cloud obligatoire — tout se fait en quelques clics.",
+        "Home Assistant est un projet formidable, mais il ne convient pas à tout le monde. Entre les fichiers YAML, une courbe d'apprentissage raide et des mises à jour fréquentes, beaucoup cherchent quelque chose de plus simple, sans renoncer à l'open source et au contrôle local.",
+        "C'est exactement pour ça que Gladys Assistant existe. C'est une solution domotique gratuite, open source et auto-hébergée, construite autour d'une idée : penser d'abord à l'utilisateur. Pas de fichiers de configuration, pas de cloud obligatoire, tout se fait en quelques clics.",
       ],
       primaryCta: { label: "Commencer gratuitement", href: "/docs/" },
       secondaryCta: {
@@ -146,7 +146,7 @@ const alternativeContent = {
     whyLooking: {
       title: "Pourquoi chercher une alternative à Home Assistant ?",
       intro:
-        "Home Assistant est incroyablement puissant — mais cette puissance a un prix. Les raisons les plus fréquentes qui poussent à chercher une alternative :",
+        "Home Assistant est incroyablement puissant, mais cette puissance a un prix. Les raisons les plus fréquentes qui poussent à chercher une alternative :",
       points: [
         "Il faut éditer des fichiers de configuration YAML pour certains réglages.",
         "La courbe d'apprentissage est raide, et l'interface peut sembler intimidante pour un débutant.",
@@ -155,7 +155,7 @@ const alternativeContent = {
         "Vous voulez une expérience propre et stable qui fonctionne, sans bidouiller.",
       ],
       outro:
-        "Rien de tout cela ne fait de Home Assistant un mauvais projet — il est excellent si vous aimez bidouiller. C'est simplement une question d'adéquation à votre profil.",
+        "Rien de tout cela ne fait de Home Assistant un mauvais projet. Il est excellent si vous aimez bidouiller. C'est simplement une question d'adéquation, et pour la plupart des gens qui veulent juste une maison connectée qui fonctionne, il existe une voie plus simple.",
     },
     reasons: {
       title: "Pourquoi Gladys est une excellente alternative à Home Assistant",
@@ -163,7 +163,7 @@ const alternativeContent = {
         {
           icon: "🖱️",
           title: "Jamais de YAML",
-          text: "Tout se configure au clic dans l'interface. Aucun fichier de configuration à éditer — parce qu'il n'y en a pas.",
+          text: "Tout se configure au clic dans l'interface. Aucun fichier de configuration à éditer, parce qu'il n'y en a pas.",
         },
         {
           icon: "🛡️",
@@ -173,17 +173,17 @@ const alternativeContent = {
         {
           icon: "🔒",
           title: "Vie privée & auto-hébergement",
-          text: "Gladys tourne chez vous, sur votre machine. Vos données restent sur votre réseau local — pas de cloud obligatoire, pas de tracking, pas de revente.",
+          text: "Gladys tourne chez vous, sur votre machine. Vos données restent sur votre réseau local, sans cloud obligatoire, sans tracking et sans revente.",
         },
         {
           icon: "🔌",
           title: "Basée sur les standards ouverts",
-          text: "Zigbee, Matter et MQTT sont au cœur du projet. Des milliers d'appareils sont supportés via ces protocoles ouverts.",
+          text: "Zigbee, Matter et MQTT sont au cœur du projet, donc des milliers d'appareils sont supportés via ces protocoles ouverts.",
         },
         {
           icon: "💬",
-          title: "Support direct du créateur",
-          text: "Posez une question par mail, sur le forum ou les réseaux sociaux — le fondateur répond personnellement, en français ou en anglais.",
+          title: "Un projet à l'écoute",
+          text: "Posez une question par mail, sur le forum ou les réseaux sociaux, et le fondateur répond personnellement, en français. Vos retours façonnent vraiment la feuille de route.",
         },
         {
           icon: "💚",
@@ -195,8 +195,8 @@ const alternativeContent = {
     honesty: {
       title: "En toute honnêteté : là où Home Assistant garde l'avantage",
       paragraphs: [
-        "Je suis le créateur de Gladys, alors soyons transparents. Home Assistant a plus de 2000 intégrations, contre une trentaine de natives dans Gladys. Si vous avez des appareils très spécifiques ou cloud-only, Home Assistant a plus de chances de les supporter directement. Il permet aussi de partager des automatisations via des blueprints YAML et offre bien plus d'options pour les power users.",
-        "Mais une trentaine d'intégrations natives, cela représente déjà des milliers d'appareils compatibles via Zigbee et Matter. Pour le reste, Matterbridge permet de relier des appareils non-Matter à un réseau Matter — et vous pouvez même faire tourner Gladys et Home Assistant côte à côte, l'un servant de backend et l'autre d'interface.",
+        "Je suis le créateur de Gladys, alors soyons transparents. Home Assistant dispose d'un catalogue d'intégrations plus large : si vous avez des appareils très spécifiques ou cloud-only, il a plus de chances de les supporter directement, là où Gladys ne le fait pas encore. Il permet aussi de partager des automatisations via des blueprints YAML et offre plus de réglages aux power users.",
+        "Mais Gladys supporte déjà des milliers d'appareils via Zigbee et Matter, les standards ouverts vers lesquels toute l'industrie se dirige. Pour le reste, Matterbridge permet de relier des appareils non-Matter, et vous pouvez même faire tourner Gladys et Home Assistant côte à côte, l'un servant de backend et l'autre d'interface. Autrement dit, choisir Gladys ne veut presque jamais dire renoncer à quoi que ce soit.",
       ],
       compareLink: {
         label: "Voir le comparatif complet Gladys vs Home Assistant →",
@@ -250,12 +250,12 @@ export const alternativeFaqEn = [
   {
     question: "Is there a Home Assistant alternative without YAML?",
     answer:
-      "Yes. Gladys Assistant requires no YAML and no configuration files at all — everything is configured by clicking in the interface, which makes it much friendlier for beginners.",
+      "Yes. Gladys Assistant requires no YAML and no configuration files at all. Everything is configured by clicking in the interface, which makes it much friendlier for beginners.",
   },
   {
     question: "Is there a simpler Home Assistant alternative for beginners?",
     answer:
-      "Gladys Assistant is designed for simplicity: a clean interface, no configuration files, automatic atomic updates and a starter kit with everything pre-installed. It's one of the easiest open-source options to get started with.",
+      "Gladys Assistant is designed for simplicity: a clean interface, no configuration files, automatic atomic updates, rich documentation with videos, and a starter kit with everything pre-installed. It's one of the easiest open-source options to get started with.",
   },
   {
     question: "Can I migrate from Home Assistant to Gladys?",
@@ -283,12 +283,12 @@ export const alternativeFaqFr = [
   {
     question: "Existe-t-il une alternative à Home Assistant sans YAML ?",
     answer:
-      "Oui. Gladys Assistant ne nécessite aucun YAML ni fichier de configuration — tout se configure au clic dans l'interface, ce qui la rend bien plus accessible aux débutants.",
+      "Oui. Gladys Assistant ne nécessite aucun YAML ni fichier de configuration. Tout se configure au clic dans l'interface, ce qui la rend bien plus accessible aux débutants.",
   },
   {
     question: "Existe-t-il une alternative à Home Assistant plus simple pour les débutants ?",
     answer:
-      "Gladys Assistant est pensée pour la simplicité : interface épurée, aucun fichier de configuration, mises à jour automatiques et atomiques, et un kit de démarrage avec tout pré-installé. C'est l'une des options open source les plus faciles pour démarrer.",
+      "Gladys Assistant est pensée pour la simplicité : interface épurée, aucun fichier de configuration, mises à jour automatiques et atomiques, documentation riche avec vidéos, et un kit de démarrage avec tout pré-installé. C'est l'une des options open source les plus faciles pour démarrer.",
   },
   {
     question: "Puis-je migrer de Home Assistant vers Gladys ?",

--- a/src/data/alternativeData.js
+++ b/src/data/alternativeData.js
@@ -1,0 +1,310 @@
+// Content for the "Home Assistant alternative" landing page.
+// Different search intent from the head-to-head comparison page: people here
+// are actively looking to replace or avoid Home Assistant. So this page is
+// more Gladys-forward and persuasive, briefly covers other open-source
+// alternatives (for trust + intent coverage), stays honest about Gladys'
+// trade-offs, and links to the full comparison page rather than duplicating it.
+
+const alternativeContent = {
+  en: {
+    meta: {
+      title: "The best Home Assistant alternative: Gladys Assistant",
+      description:
+        "Looking for a Home Assistant alternative? Gladys Assistant is a simpler, privacy-first, open-source home automation platform — no YAML, no cloud, stable automatic updates. Free and self-hosted.",
+    },
+    hero: {
+      title: "Looking for a Home Assistant alternative?",
+      subtitle:
+        "Meet Gladys Assistant — the simpler, privacy-first, open-source home automation platform.",
+      intro: [
+        "Home Assistant is a fantastic project. But it's not for everyone: between YAML files, a steep learning curve and frequent updates, many people look for something simpler — without giving up open-source and local control.",
+        "That's exactly why Gladys Assistant exists. It's a free, open-source, self-hosted home automation platform built around one idea: think about the user first. No configuration files, no cloud required — everything happens with a few clicks.",
+      ],
+      primaryCta: { label: "Get started free", href: "/docs/" },
+      secondaryCta: {
+        label: "Gladys vs Home Assistant →",
+        href: "/home-assistant-vs-gladys-assistant/",
+      },
+    },
+    whyLooking: {
+      title: "Why look for an alternative to Home Assistant?",
+      intro:
+        "Home Assistant is incredibly powerful — but that power comes at a cost. The most common reasons people start searching for an alternative:",
+      points: [
+        "You have to edit YAML configuration files for some setups.",
+        "The learning curve is steep, and the interface can feel overwhelming for a beginner.",
+        "Frequent updates sometimes break a setup that was working fine.",
+        "It often feels \"made by developers, for developers\".",
+        "You want a clean, stable experience that just works, without tinkering.",
+      ],
+      outro:
+        "None of this makes Home Assistant a bad project — it's excellent if you love to tinker. It's simply a question of fit.",
+    },
+    reasons: {
+      title: "Why Gladys is a great Home Assistant alternative",
+      cards: [
+        {
+          icon: "🖱️",
+          title: "No YAML, ever",
+          text: "Everything is configured by clicking in the interface. There are no configuration files to edit — because there are none.",
+        },
+        {
+          icon: "🛡️",
+          title: "Rock-solid stability",
+          text: "Updates are fully automatic and atomic: Gladys can never end up in a half-broken state between two versions.",
+        },
+        {
+          icon: "🔒",
+          title: "Privacy-first & self-hosted",
+          text: "Gladys runs at home, on your machine. Your data stays on your local network — no mandatory cloud, no tracking, no data selling.",
+        },
+        {
+          icon: "🔌",
+          title: "Built on open standards",
+          text: "Zigbee, Matter and MQTT are first-class citizens. Thousands of devices are supported through these open protocols.",
+        },
+        {
+          icon: "💬",
+          title: "Direct support from the maker",
+          text: "Ask a question by email, on the forum or on social media — the founder answers personally, in French or English.",
+        },
+        {
+          icon: "💚",
+          title: "Free & open-source forever",
+          text: "The Gladys core is 100% free and open-source. An optional Gladys Plus subscription adds remote access, AI and backups.",
+        },
+      ],
+    },
+    honesty: {
+      title: "Being honest: where Home Assistant still wins",
+      paragraphs: [
+        "I'm the creator of Gladys, so let me be transparent. Home Assistant has 2000+ integrations versus around 35 native ones in Gladys. If you own very niche or cloud-only devices, Home Assistant is more likely to support them out of the box. It also lets you share automations as YAML blueprints and offers far more knobs for power users.",
+        "But 35 native integrations still means thousands of compatible devices through Zigbee and Matter. For the rest, Matterbridge can bridge non-Matter devices onto a Matter network — and you can even run Gladys and Home Assistant side by side, using one as a backend and the other as your interface.",
+      ],
+      compareLink: {
+        label: "See the full Gladys vs Home Assistant comparison →",
+        href: "/home-assistant-vs-gladys-assistant/",
+      },
+    },
+    others: {
+      title: "Other open-source Home Assistant alternatives",
+      intro:
+        "Gladys isn't the only option. To be fair, here are the main open-source alternatives to Home Assistant:",
+      cards: [
+        {
+          title: "openHAB",
+          text: "Java-based, very powerful and rules-driven. Highly flexible, but with a learning curve comparable to Home Assistant.",
+        },
+        {
+          title: "Domoticz",
+          text: "Lightweight and runs on modest hardware. Mature and stable, but the interface feels dated.",
+        },
+        {
+          title: "Jeedom",
+          text: "A French project with a plugin-based, freemium model. Flexible, but many plugins are paid.",
+        },
+        {
+          title: "Homey Pro",
+          text: "A polished experience, but it relies on proprietary paid hardware rather than being fully open and self-hosted.",
+        },
+      ],
+      outro:
+        "Among these, Gladys stands out for its simplicity and true product experience: a clean interface, no configuration files, and a focus on open standards.",
+    },
+    faqTitle: "Frequently asked questions",
+    cta: {
+      title: "Try the simple Home Assistant alternative",
+      text: "Gladys is free, open-source, and installs in a single Docker command. Privacy-first, self-hosted, no cloud required.",
+      primary: { label: "Get started", href: "/docs/" },
+      secondary: {
+        label: "Compare with Home Assistant",
+        href: "/home-assistant-vs-gladys-assistant/",
+      },
+    },
+  },
+
+  fr: {
+    meta: {
+      title: "La meilleure alternative à Home Assistant : Gladys Assistant",
+      description:
+        "Vous cherchez une alternative à Home Assistant ? Gladys Assistant est une solution domotique open source, plus simple et respectueuse de la vie privée — sans YAML, sans cloud, avec des mises à jour automatiques et stables. Gratuite et auto-hébergée.",
+    },
+    hero: {
+      title: "Vous cherchez une alternative à Home Assistant ?",
+      subtitle:
+        "Découvrez Gladys Assistant — la solution domotique open source plus simple et respectueuse de votre vie privée.",
+      intro: [
+        "Home Assistant est un projet formidable. Mais il ne convient pas à tout le monde : entre les fichiers YAML, une courbe d'apprentissage raide et des mises à jour fréquentes, beaucoup cherchent quelque chose de plus simple — sans renoncer à l'open source et au contrôle local.",
+        "C'est exactement pour ça que Gladys Assistant existe. C'est une solution domotique gratuite, open source et auto-hébergée, construite autour d'une idée : penser d'abord à l'utilisateur. Pas de fichiers de configuration, pas de cloud obligatoire — tout se fait en quelques clics.",
+      ],
+      primaryCta: { label: "Commencer gratuitement", href: "/docs/" },
+      secondaryCta: {
+        label: "Gladys vs Home Assistant →",
+        href: "/home-assistant-vs-gladys-assistant/",
+      },
+    },
+    whyLooking: {
+      title: "Pourquoi chercher une alternative à Home Assistant ?",
+      intro:
+        "Home Assistant est incroyablement puissant — mais cette puissance a un prix. Les raisons les plus fréquentes qui poussent à chercher une alternative :",
+      points: [
+        "Il faut éditer des fichiers de configuration YAML pour certains réglages.",
+        "La courbe d'apprentissage est raide, et l'interface peut sembler intimidante pour un débutant.",
+        "Les mises à jour fréquentes cassent parfois une installation qui fonctionnait bien.",
+        "On a souvent l'impression que c'est « fait par des développeurs, pour des développeurs ».",
+        "Vous voulez une expérience propre et stable qui fonctionne, sans bidouiller.",
+      ],
+      outro:
+        "Rien de tout cela ne fait de Home Assistant un mauvais projet — il est excellent si vous aimez bidouiller. C'est simplement une question d'adéquation à votre profil.",
+    },
+    reasons: {
+      title: "Pourquoi Gladys est une excellente alternative à Home Assistant",
+      cards: [
+        {
+          icon: "🖱️",
+          title: "Jamais de YAML",
+          text: "Tout se configure au clic dans l'interface. Aucun fichier de configuration à éditer — parce qu'il n'y en a pas.",
+        },
+        {
+          icon: "🛡️",
+          title: "Une stabilité à toute épreuve",
+          text: "Les mises à jour sont totalement automatiques et atomiques : Gladys ne peut jamais se retrouver dans un état bâtard entre deux versions.",
+        },
+        {
+          icon: "🔒",
+          title: "Vie privée & auto-hébergement",
+          text: "Gladys tourne chez vous, sur votre machine. Vos données restent sur votre réseau local — pas de cloud obligatoire, pas de tracking, pas de revente.",
+        },
+        {
+          icon: "🔌",
+          title: "Basée sur les standards ouverts",
+          text: "Zigbee, Matter et MQTT sont au cœur du projet. Des milliers d'appareils sont supportés via ces protocoles ouverts.",
+        },
+        {
+          icon: "💬",
+          title: "Support direct du créateur",
+          text: "Posez une question par mail, sur le forum ou les réseaux sociaux — le fondateur répond personnellement, en français ou en anglais.",
+        },
+        {
+          icon: "💚",
+          title: "Gratuite & open source pour toujours",
+          text: "Le cœur de Gladys est 100 % gratuit et open source. L'abonnement optionnel Gladys Plus ajoute l'accès distant, l'IA et les sauvegardes.",
+        },
+      ],
+    },
+    honesty: {
+      title: "En toute honnêteté : là où Home Assistant garde l'avantage",
+      paragraphs: [
+        "Je suis le créateur de Gladys, alors soyons transparents. Home Assistant a plus de 2000 intégrations, contre une trentaine de natives dans Gladys. Si vous avez des appareils très spécifiques ou cloud-only, Home Assistant a plus de chances de les supporter directement. Il permet aussi de partager des automatisations via des blueprints YAML et offre bien plus d'options pour les power users.",
+        "Mais une trentaine d'intégrations natives, cela représente déjà des milliers d'appareils compatibles via Zigbee et Matter. Pour le reste, Matterbridge permet de relier des appareils non-Matter à un réseau Matter — et vous pouvez même faire tourner Gladys et Home Assistant côte à côte, l'un servant de backend et l'autre d'interface.",
+      ],
+      compareLink: {
+        label: "Voir le comparatif complet Gladys vs Home Assistant →",
+        href: "/home-assistant-vs-gladys-assistant/",
+      },
+    },
+    others: {
+      title: "Les autres alternatives open source à Home Assistant",
+      intro:
+        "Gladys n'est pas la seule option. Pour être juste, voici les principales alternatives open source à Home Assistant :",
+      cards: [
+        {
+          title: "openHAB",
+          text: "Basé sur Java, très puissant et orienté règles. Très flexible, mais avec une courbe d'apprentissage comparable à Home Assistant.",
+        },
+        {
+          title: "Domoticz",
+          text: "Léger et tourne sur du matériel modeste. Mature et stable, mais l'interface est datée.",
+        },
+        {
+          title: "Jeedom",
+          text: "Un projet français au modèle freemium basé sur des plugins. Flexible, mais beaucoup de plugins sont payants.",
+        },
+        {
+          title: "Homey Pro",
+          text: "Une expérience soignée, mais qui repose sur du matériel propriétaire payant plutôt que sur un vrai auto-hébergement ouvert.",
+        },
+      ],
+      outro:
+        "Parmi elles, Gladys se distingue par sa simplicité et sa vraie expérience produit : une interface épurée, aucun fichier de configuration, et un focus sur les standards ouverts.",
+    },
+    faqTitle: "Questions fréquentes",
+    cta: {
+      title: "Essayez l'alternative simple à Home Assistant",
+      text: "Gladys est gratuite, open source, et s'installe en une seule commande Docker. Auto-hébergée, respectueuse de votre vie privée, sans cloud obligatoire.",
+      primary: { label: "Commencer", href: "/docs/" },
+      secondary: {
+        label: "Comparer avec Home Assistant",
+        href: "/home-assistant-vs-gladys-assistant/",
+      },
+    },
+  },
+};
+
+export const alternativeFaqEn = [
+  {
+    question: "What is the best alternative to Home Assistant?",
+    answer:
+      "It depends on your profile. If you want simplicity and a clean experience without YAML, Gladys Assistant is a great choice. Other open-source alternatives include openHAB, Domoticz and Jeedom, each with its own trade-offs.",
+  },
+  {
+    question: "Is there a Home Assistant alternative without YAML?",
+    answer:
+      "Yes. Gladys Assistant requires no YAML and no configuration files at all — everything is configured by clicking in the interface, which makes it much friendlier for beginners.",
+  },
+  {
+    question: "Is there a simpler Home Assistant alternative for beginners?",
+    answer:
+      "Gladys Assistant is designed for simplicity: a clean interface, no configuration files, automatic atomic updates and a starter kit with everything pre-installed. It's one of the easiest open-source options to get started with.",
+  },
+  {
+    question: "Can I migrate from Home Assistant to Gladys?",
+    answer:
+      "You don't have to migrate everything at once. Using Zigbee2MQTT or Matter, the same devices can appear in both at the same time, so you can run them side by side. Matterbridge can even expose your Home Assistant devices to Gladys.",
+  },
+  {
+    question: "Are there free alternatives to Home Assistant?",
+    answer:
+      "Yes. Gladys Assistant, openHAB and Domoticz are free and open-source. Jeedom is free but uses a freemium plugin model. Gladys is 100% free and open-source at its core, with an optional paid subscription.",
+  },
+  {
+    question: "Is Gladys a good Home Assistant alternative for privacy?",
+    answer:
+      "Yes. Gladys is self-hosted and runs on your own machine, so your smart home data stays on your local network. There is no mandatory cloud, no tracking and no data selling.",
+  },
+];
+
+export const alternativeFaqFr = [
+  {
+    question: "Quelle est la meilleure alternative à Home Assistant ?",
+    answer:
+      "Cela dépend de votre profil. Si vous voulez de la simplicité et une expérience propre sans YAML, Gladys Assistant est un excellent choix. Parmi les autres alternatives open source : openHAB, Domoticz et Jeedom, chacune avec ses compromis.",
+  },
+  {
+    question: "Existe-t-il une alternative à Home Assistant sans YAML ?",
+    answer:
+      "Oui. Gladys Assistant ne nécessite aucun YAML ni fichier de configuration — tout se configure au clic dans l'interface, ce qui la rend bien plus accessible aux débutants.",
+  },
+  {
+    question: "Existe-t-il une alternative à Home Assistant plus simple pour les débutants ?",
+    answer:
+      "Gladys Assistant est pensée pour la simplicité : interface épurée, aucun fichier de configuration, mises à jour automatiques et atomiques, et un kit de démarrage avec tout pré-installé. C'est l'une des options open source les plus faciles pour démarrer.",
+  },
+  {
+    question: "Puis-je migrer de Home Assistant vers Gladys ?",
+    answer:
+      "Vous n'êtes pas obligé de tout migrer d'un coup. Avec Zigbee2MQTT ou Matter, les mêmes appareils peuvent apparaître dans les deux en même temps : vous pouvez donc les faire tourner côte à côte. Matterbridge peut même exposer vos appareils Home Assistant dans Gladys.",
+  },
+  {
+    question: "Existe-t-il des alternatives gratuites à Home Assistant ?",
+    answer:
+      "Oui. Gladys Assistant, openHAB et Domoticz sont gratuits et open source. Jeedom est gratuit mais utilise un modèle freemium à base de plugins. Le cœur de Gladys est 100 % gratuit et open source, avec un abonnement payant optionnel.",
+  },
+  {
+    question: "Gladys est-elle une bonne alternative à Home Assistant pour la vie privée ?",
+    answer:
+      "Oui. Gladys est auto-hébergée et tourne sur votre propre machine : vos données domotiques restent sur votre réseau local. Pas de cloud obligatoire, pas de tracking, pas de revente de données.",
+  },
+];
+
+export default alternativeContent;

--- a/src/data/alternativeData.js
+++ b/src/data/alternativeData.js
@@ -127,10 +127,10 @@ const alternativeContent = {
     meta: {
       title: "La meilleure alternative à Home Assistant : Gladys Assistant",
       description:
-        "Vous cherchez une alternative à Home Assistant ? Gladys Assistant est une solution domotique open source, plus simple et respectueuse de la vie privée : sans YAML, sans cloud, avec des mises à jour automatiques et stables. Gratuite et auto-hébergée.",
+        "Vous cherchez une alternative à Home Assistant ? Gladys Assistant est une solution domotique open source, plus simple et respectueuse de la vie privée : sans YAML, sans cloud, avec des mises à jour automatiques et stables. Gratuite et auto-hébergée.",
     },
     hero: {
-      title: "Vous cherchez une alternative à Home Assistant ?",
+      title: "Vous cherchez une alternative à Home Assistant ?",
       subtitle:
         "Découvrez Gladys Assistant, la solution domotique open source plus simple et respectueuse de votre vie privée.",
       intro: [

--- a/src/data/comparisonData.js
+++ b/src/data/comparisonData.js
@@ -1,0 +1,514 @@
+// Content for the "Home Assistant vs Gladys Assistant" comparison landing page.
+// Kept as a locale-keyed data object (like structuredData.js) rather than dozens
+// of <Translate> ids, because the page is long-form prose that is easier to
+// maintain and keep in sync when both languages live side by side.
+//
+// The comparison is written in the founder's voice and intentionally honest
+// about Gladys' weaknesses — it mirrors the "honest comparison" YouTube video.
+
+// "Home Assistant vs Gladys Assistant" YouTube video. Rendered as an embedded
+// video in a dedicated section on the comparison page.
+const YOUTUBE_VIDEO_ID = "iVFXXDO798A";
+
+const comparisonContent = {
+  en: {
+    meta: {
+      title: "Home Assistant vs Gladys Assistant: an honest comparison (2026)",
+      description:
+        "Home Assistant or Gladys Assistant? An honest comparison by Gladys' founder: installation, ease of use, integrations, automations, community and pricing — to pick the right open-source home automation platform.",
+    },
+    hero: {
+      title: "Home Assistant vs Gladys Assistant",
+      subtitle: "An honest comparison between two open-source home assistants",
+      intro: [
+        "Still hesitating between Home Assistant and Gladys Assistant? This comparison will save you hours.",
+        "Full transparency: I'm Pierre-Gilles, the creator of Gladys Assistant. My goal here isn't to convince you to use Gladys — it's to promote open-source home automation and help you pick the solution that fits your profile. I'll be 100% honest about the strengths and weaknesses of each.",
+        "Both projects started in 2013, right after the first Raspberry Pi came out. They look similar, but they're actually quite different — and that difference is exactly what should guide your choice.",
+      ],
+    },
+    verdict: {
+      title: "The short version",
+      gladys: {
+        title: "Choose Gladys Assistant if…",
+        points: [
+          "You want something simple, fast to set up, and that just works.",
+          "You prefer a clean interface where everything happens with clicks — no configuration files, no YAML.",
+          "You value stability: updates are fully automatic and atomic.",
+          "You speak French, or want direct support from the founder.",
+        ],
+      },
+      ha: {
+        title: "Choose Home Assistant if…",
+        points: [
+          "You own very specific or niche devices that need a dedicated integration.",
+          "You're a power user who loves to tinker and customize to the extreme.",
+          "You're comfortable editing YAML and going under the hood.",
+          "You want the largest possible catalog of integrations.",
+        ],
+      },
+    },
+    tableTitle: "Quick comparison",
+    tableCols: { feature: "", gladys: "Gladys Assistant", ha: "Home Assistant" },
+    table: [
+      { feature: "Created", gladys: "2013", ha: "2013" },
+      { feature: "Backend", gladys: "Node.js (JavaScript)", ha: "Python" },
+      { feature: "Frontend", gladys: "Preact", ha: "Lit + Web Components" },
+      {
+        feature: "Installation",
+        gladys: "One Docker command, or a French starter kit (mini-PC) pre-installed",
+        ha: "Home Assistant OS, the HA Green box, or Docker",
+      },
+      {
+        feature: "Ready-to-flash OS image",
+        gladys: "No — bring your own Linux + Docker",
+        ha: "Yes (Home Assistant OS)",
+      },
+      {
+        feature: "Configuration files",
+        gladys: "None — everything is in the interface",
+        ha: "YAML needed for some parts",
+      },
+      {
+        feature: "Native integrations",
+        gladys: "~35, focused on open standards (Zigbee, Matter, MQTT)",
+        ha: "2000+",
+      },
+      {
+        feature: "Supported devices",
+        gladys: "Thousands via Zigbee, Matter and MQTT",
+        ha: "The widest catalog available",
+      },
+      {
+        feature: "Automations",
+        gladys: "A single \"Scenes\" tab, visual editor, Node-RED",
+        ha: "Automations / Scenes / Scripts / Blueprints, visual editor, YAML, Node-RED",
+      },
+      {
+        feature: "Share automations",
+        gladys: "No",
+        ha: "Yes (YAML blueprints)",
+      },
+      {
+        feature: "Native alarm mode",
+        gladys: "Yes",
+        ha: "Not native",
+      },
+      {
+        feature: "Native presence",
+        gladys: "Yes",
+        ha: "Via integrations",
+      },
+      {
+        feature: "Updates",
+        gladys: "Fully automatic and atomic",
+        ha: "Frequent, can occasionally break things",
+      },
+      {
+        feature: "Community",
+        gladys: "Mostly French (FR + EN forum), direct founder support",
+        ha: "Huge global community + HACF (French community)",
+      },
+      {
+        feature: "Pricing",
+        gladys: "Free & open-source + optional Gladys Plus subscription",
+        ha: "Free & open-source + optional Nabu Casa Cloud subscription",
+      },
+      {
+        feature: "Philosophy",
+        gladys: "User-first, product-grade simplicity",
+        ha: "Developer-first, ultimate flexibility",
+      },
+    ],
+    sections: [
+      {
+        id: "installation",
+        title: "Installation",
+        gladys: [
+          "Gladys installs with a single Docker command — there's a `docker run` and a `docker-compose` file you can copy, paste and launch. The only requirement is having Docker installed.",
+          "There's also an official starter kit: a Beelink mini-PC with Gladys pre-installed. You plug it in, follow the quick-start guide, and you're done. I don't make real margin on it — it just makes Gladys accessible to people who don't want to install it themselves.",
+          "The trade-off: there's no ready-to-flash OS image. You bring your own Linux (Ubuntu, Debian, whatever) and run the container. The upside is you stay free to use your mini-PC, NAS or Raspberry Pi for other things too.",
+        ],
+        ha: [
+          "Home Assistant offers Home Assistant OS, which is very polished — you install it like you'd install Ubuntu and you get Home Assistant running. They also sell the Home Assistant Green box with everything pre-installed.",
+          "It's relatively easy if you buy their box. But without it, I found it wasn't always obvious which installation method was the simplest — they tend to push Home Assistant OS over the plain Docker route.",
+        ],
+        takeaway:
+          "Both are easy if you buy their hardware. Gladys is simplest if you already know Docker; Home Assistant OS is great if you want a turnkey appliance.",
+      },
+      {
+        id: "interface",
+        title: "Interface & ease of use",
+        gladys: [
+          "Gladys has a clean, intuitive interface. The whole philosophy is to think about the user before the technical implementation: you never have to dig into logs or edit a file on disk. Everything happens with the mouse.",
+          "You can build as many dashboards as you want — one per room, or by theme (energy, security…). No configuration files, because there are none.",
+          "The honest downside: there are fewer options for power users. Gladys is like a consumer product — you can arrange the widgets you're given, but if a widget is missing, it has to be developed (it's open-source, so you can contribute one).",
+        ],
+        ha: [
+          "Home Assistant has a modern Material Design interface that's very clean and highly customizable. The dashboard is fully editable with tons of cards and options.",
+          "But you'll often see, on the forums, that some parts still require editing YAML files — which can be intimidating for a beginner.",
+        ],
+        takeaway:
+          "Gladys wins on simplicity: a beautiful interface with zero configuration. Home Assistant wins on customization if you like to tinker.",
+      },
+      {
+        id: "integrations",
+        title: "Integrations & compatibility",
+        gladys: [
+          "Gladys has a limited, curated set: roughly 35 native integrations, focused on open standards like Zigbee, Matter and MQTT. They're carefully built and tested end-to-end, designed like a consumer product rather than by developers for developers.",
+          "35 native integrations doesn't mean 35 compatible devices: through Zigbee alone there are thousands of compatible devices. The bet is that open standards — Matter especially — will dominate, so I invest heavily in those and very little in closed, cloud-only ecosystems.",
+          "For devices that aren't Matter yet, projects like Matterbridge can bridge them onto a Matter network — including a Home Assistant plugin.",
+        ],
+        ha: [
+          "Home Assistant has 2000+ integrations — an incredible number, with a very active community constantly adding more. This is where it's genuinely unbeatable.",
+          "The flip side is variable quality: some integrations are excellent, others less so, and it's up to you to find and test the ones you need.",
+        ],
+        takeaway:
+          "Home Assistant is unbeatable on sheer numbers. Gladys focuses on the essentials and bets on Matter & Zigbee for the future — the compatibility gap should shrink as everyone adopts Matter.",
+      },
+      {
+        id: "automations",
+        title: "Automations & scenes",
+        gladys: [
+          "Everything lives in a single \"Scenes\" tab. A scene can be a manual sequence of actions you trigger from your dashboard, or a full automation with triggers, conditions and actions.",
+          "There's a visual editor similar to Home Assistant's. You start with a trigger (optional), then chain as many conditions and actions as you want, and you can mix them — a condition leading to actions, then more conditions. It's quite powerful.",
+          "If Gladys isn't enough, you can offload complex logic to Node-RED and connect it via MQTT or HTTP. The honest downside: there's no built-in way to share a scene with others.",
+        ],
+        ha: [
+          "Home Assistant has a visual editor too, plus shareable YAML blueprints and a Node-RED integration to go further.",
+          "It splits things into four tabs — Automations, Scenes, Scripts and Blueprints — which can feel like four versions of the same thing when you're starting out. There's surely a good reason, but it adds a learning curve.",
+        ],
+        takeaway:
+          "Same core concept, two philosophies. Gladys keeps it in one simple place; Home Assistant is more complete with shareable blueprints.",
+      },
+      {
+        id: "community",
+        title: "Community & support",
+        gladys: [
+          "Gladys' community is mostly French, with an English-translated forum and some international users. As a French-born project, that's where it shines for proximity.",
+          "You also get direct support from the founder. If you have a question — even a deep one about the code — you can email me, post on the forum, or reach out on social media. I always answer.",
+        ],
+        ha: [
+          "Home Assistant has a massive global community with a huge forum, plus HACF, a French-speaking community where you can get help in French.",
+          "It's on another scale entirely — but most of the developer communication happens in English, since it's an American-rooted project.",
+        ],
+        takeaway:
+          "Home Assistant wins on sheer scale. Gladys wins on proximity and French-language support, with direct access to the maker.",
+      },
+      {
+        id: "pricing",
+        title: "Pricing & business model",
+        gladys: [
+          "Gladys is 100% free and open-source at its core, forever. There's an optional Gladys Plus subscription for remote access, encrypted automated backups, voice assistants (Google Home, Alexa), AI and Enedis energy data.",
+          "I also sell starter kits, but not to make margin — just to make Gladys more accessible. My business model is really the subscription.",
+        ],
+        ha: [
+          "Home Assistant is also 100% free and open-source at its core, with an optional Nabu Casa Cloud subscription (remote access, voice…) and a growing line of hardware like the HA Green box.",
+        ],
+        takeaway:
+          "Both have a transparent, very similar model: free open-source core + optional subscription. There aren't many viable business models in home automation, and both keep it honest.",
+      },
+    ],
+    whyNotBoth: {
+      title: "Why not both?",
+      paragraphs: [
+        "Here's the part most comparisons miss: you don't have to choose. You can run Gladys Assistant and Home Assistant on the same setup at the same time.",
+        "With Zigbee2MQTT, a single Zigbee instance can talk to both Gladys and Home Assistant — the same device shows up in both interfaces. The same goes for Matter: a Matter device paired to a hub (like an Apple TV) can be controlled from both. You can have several controllers at once.",
+        "You can even use Matterbridge to expose all your Home Assistant devices onto a Matter network, then pull them into Gladys — effectively using Home Assistant as a backend and Gladys as your frontend. And of course both expose rich APIs, so they can talk over MQTT or HTTP.",
+        "So if you love the Gladys interface but need a niche Home Assistant integration, run them side by side. There's really no excuse — everything is possible.",
+      ],
+    },
+    faqTitle: "Frequently asked questions",
+    cta: {
+      title: "Ready to try Gladys Assistant?",
+      text: "Gladys is free, open-source, and installs in a single Docker command. Privacy-first, self-hosted, no cloud required.",
+      primary: { label: "Get started", href: "/docs/" },
+      secondary: { label: "See the integrations", href: "/docs/integrations/" },
+    },
+    videoTitle: "Watch the full comparison",
+  },
+
+  fr: {
+    meta: {
+      title: "Home Assistant vs Gladys Assistant : le comparatif honnête (2026)",
+      description:
+        "Home Assistant ou Gladys Assistant ? Comparatif honnête par le créateur de Gladys : installation, simplicité, intégrations, automatisations, communauté et prix — pour choisir la bonne solution domotique open source.",
+    },
+    hero: {
+      title: "Home Assistant vs Gladys Assistant",
+      subtitle: "Un comparatif honnête entre deux assistants domotiques open source",
+      intro: [
+        "Vous hésitez encore entre Home Assistant et Gladys Assistant ? Ce comparatif va vous faire gagner des heures.",
+        "En toute transparence : je suis Pierre-Gilles, le créateur de Gladys Assistant. Mon but ici n'est pas de vous convaincre d'utiliser Gladys, mais de mettre en avant l'open source et de vous aider à choisir la solution la plus adaptée à votre profil. Je serai 100 % honnête sur les forces et les faiblesses de chacune.",
+        "Les deux projets sont nés en 2013, juste après la sortie du premier Raspberry Pi. Ils se ressemblent, mais ils sont en réalité très différents — et c'est justement cette différence qui doit guider votre choix.",
+      ],
+    },
+    verdict: {
+      title: "En résumé",
+      gladys: {
+        title: "Choisissez Gladys Assistant si…",
+        points: [
+          "Vous voulez quelque chose de simple, rapide à prendre en main, et qui fonctionne.",
+          "Vous préférez une interface épurée où tout se fait au clic — pas de fichiers de configuration, pas de YAML.",
+          "Vous tenez à la stabilité : les mises à jour sont totalement automatiques et atomiques.",
+          "Vous parlez français, ou vous voulez le support direct du fondateur.",
+        ],
+      },
+      ha: {
+        title: "Choisissez Home Assistant si…",
+        points: [
+          "Vous avez des équipements très spécifiques qui demandent une intégration dédiée.",
+          "Vous êtes un power user qui adore bidouiller et personnaliser à l'extrême.",
+          "Vous êtes à l'aise avec le YAML et aller sous le capot.",
+          "Vous voulez le plus grand catalogue d'intégrations possible.",
+        ],
+      },
+    },
+    tableTitle: "Comparatif express",
+    tableCols: { feature: "", gladys: "Gladys Assistant", ha: "Home Assistant" },
+    table: [
+      { feature: "Création", gladys: "2013", ha: "2013" },
+      { feature: "Backend", gladys: "Node.js (JavaScript)", ha: "Python" },
+      { feature: "Frontend", gladys: "Preact", ha: "Lit + Web Components" },
+      {
+        feature: "Installation",
+        gladys: "Une commande Docker, ou un kit de démarrage français (mini-PC) pré-installé",
+        ha: "Home Assistant OS, la box HA Green, ou Docker",
+      },
+      {
+        feature: "Image OS prête à flasher",
+        gladys: "Non — votre Linux + Docker",
+        ha: "Oui (Home Assistant OS)",
+      },
+      {
+        feature: "Fichiers de configuration",
+        gladys: "Aucun — tout est dans l'interface",
+        ha: "YAML nécessaire pour certaines parties",
+      },
+      {
+        feature: "Intégrations natives",
+        gladys: "~35, centrées sur les standards ouverts (Zigbee, Matter, MQTT)",
+        ha: "2000+",
+      },
+      {
+        feature: "Appareils supportés",
+        gladys: "Des milliers via Zigbee, Matter et MQTT",
+        ha: "Le catalogue le plus large",
+      },
+      {
+        feature: "Automatisations",
+        gladys: "Un seul onglet « Scènes », éditeur visuel, Node-RED",
+        ha: "Automatisations / Scènes / Scripts / Blueprints, éditeur visuel, YAML, Node-RED",
+      },
+      {
+        feature: "Partage d'automatisations",
+        gladys: "Non",
+        ha: "Oui (blueprints YAML)",
+      },
+      {
+        feature: "Mode alarme natif",
+        gladys: "Oui",
+        ha: "Non natif",
+      },
+      {
+        feature: "Présence native",
+        gladys: "Oui",
+        ha: "Via des intégrations",
+      },
+      {
+        feature: "Mises à jour",
+        gladys: "Totalement automatiques et atomiques",
+        ha: "Fréquentes, peuvent parfois casser des choses",
+      },
+      {
+        feature: "Communauté",
+        gladys: "Majoritairement française (forum FR + EN), support direct du fondateur",
+        ha: "Énorme communauté mondiale + HACF (communauté française)",
+      },
+      {
+        feature: "Modèle économique",
+        gladys: "Gratuit & open source + abonnement Gladys Plus optionnel",
+        ha: "Gratuit & open source + abonnement Nabu Casa Cloud optionnel",
+      },
+      {
+        feature: "Philosophie",
+        gladys: "L'utilisateur d'abord, simplicité « grand public »",
+        ha: "Le développeur d'abord, flexibilité maximale",
+      },
+    ],
+    sections: [
+      {
+        id: "installation",
+        title: "Installation",
+        gladys: [
+          "Gladys s'installe en une seule commande Docker — un `docker run` ou un fichier `docker-compose` que vous copiez, collez et lancez. La seule chose nécessaire, c'est d'avoir Docker installé.",
+          "Il existe aussi un kit de démarrage officiel : un mini-PC Beelink avec Gladys déjà installée. Vous le branchez, suivez le guide de démarrage rapide, et c'est prêt. Je ne fais pas vraiment de marge dessus — c'est juste pour rendre Gladys accessible à ceux qui ne veulent pas l'installer eux-mêmes.",
+          "Le compromis : pas d'image OS prête à flasher. C'est à vous d'installer un Linux (Ubuntu, Debian, ce que vous voulez) puis de lancer le conteneur. L'avantage, c'est que vous restez libre d'utiliser votre mini-PC, NAS ou Raspberry Pi pour autre chose.",
+        ],
+        ha: [
+          "Home Assistant propose Home Assistant OS, très abouti — vous l'installez comme vous installeriez Ubuntu et vous avez Home Assistant qui tourne. Ils vendent aussi la box Home Assistant Green avec tout pré-installé.",
+          "C'est relativement facile si vous achetez leur box. Mais sans elle, j'ai trouvé que ce n'était pas toujours clair quelle était la méthode la plus simple — ils mettent un peu de côté la voie Docker pour pousser Home Assistant OS.",
+        ],
+        takeaway:
+          "Les deux sont faciles si vous achetez leur matériel. Gladys est le plus simple si vous connaissez déjà Docker ; Home Assistant OS est idéal si vous voulez une solution clé en main.",
+      },
+      {
+        id: "interface",
+        title: "Interface & prise en main",
+        gladys: [
+          "Gladys a une interface épurée et intuitive. Toute la philosophie, c'est de penser à l'utilisateur avant la technique : vous n'avez jamais à aller chercher dans les logs ou à éditer un fichier sur le disque. Tout se passe à la souris.",
+          "Vous pouvez créer autant de tableaux de bord que vous voulez — un par pièce, ou par thématique (énergie, sécurité…). Pas de fichiers de configuration, parce qu'il n'y en a pas.",
+          "Le revers honnête : il y a moins d'options pour les power users. Gladys est comme un produit grand public — vous disposez les widgets fournis comme vous voulez, mais s'il manque un widget, il faut le développer (c'est open source, vous pouvez en proposer un).",
+        ],
+        ha: [
+          "Home Assistant a une interface moderne en Material Design, très propre et hautement personnalisable. Le tableau de bord est entièrement éditable, avec une multitude de cartes et d'options.",
+          "Mais on remarque souvent, sur les forums, que certaines parties demandent encore d'éditer des fichiers YAML — ce qui peut être intimidant pour un débutant.",
+        ],
+        takeaway:
+          "Gladys gagne sur la simplicité : une belle interface sans aucune configuration. Home Assistant gagne sur la personnalisation si vous aimez bidouiller.",
+      },
+      {
+        id: "integrations",
+        title: "Intégrations & compatibilité",
+        gladys: [
+          "Gladys a un set limité et soigné : environ 35 intégrations natives, centrées sur les standards ouverts comme Zigbee, Matter et MQTT. Elles sont testées de bout en bout et pensées comme un produit grand public, pas par des développeurs pour des développeurs.",
+          "35 intégrations natives ne veut pas dire 35 appareils compatibles : rien qu'en Zigbee, il y a des milliers d'appareils compatibles. Le pari, c'est que les standards ouverts — Matter en particulier — vont dominer ; j'y investis donc beaucoup, et très peu dans les écosystèmes fermés et cloud-only.",
+          "Pour les appareils qui ne sont pas encore Matter, des projets comme Matterbridge permettent de les relier à un réseau Matter — y compris via un plugin Home Assistant.",
+        ],
+        ha: [
+          "Home Assistant compte plus de 2000 intégrations — un nombre fou, avec une communauté très active qui en ajoute en permanence. C'est là qu'il est vraiment imbattable.",
+          "La contrepartie, c'est une qualité variable : certaines intégrations sont excellentes, d'autres moins, et c'est à vous de découvrir et tester celles dont vous avez besoin.",
+        ],
+        takeaway:
+          "Home Assistant est imbattable en nombre. Gladys se concentre sur l'essentiel et mise sur Matter & Zigbee pour l'avenir — l'écart de compatibilité devrait se réduire à mesure que tout le monde adopte Matter.",
+      },
+      {
+        id: "automatisations",
+        title: "Automatisations & scènes",
+        gladys: [
+          "Tout est dans un seul onglet « Scènes ». Une scène peut être une suite d'actions que vous lancez manuellement depuis votre tableau de bord, ou un scénario complet avec déclencheur, conditions et actions.",
+          "Il y a un éditeur visuel proche de celui de Home Assistant. Vous partez d'un déclencheur (optionnel), puis vous enchaînez autant de conditions et d'actions que vous voulez, et vous pouvez les mélanger — une condition menant à des actions, puis d'autres conditions. C'est assez puissant.",
+          "Si Gladys ne suffit pas, vous pouvez déporter la logique complexe vers Node-RED et le connecter en MQTT ou HTTP. Le revers honnête : il n'y a pas de moyen natif de partager une scène avec d'autres.",
+        ],
+        ha: [
+          "Home Assistant a aussi un éditeur visuel, des blueprints YAML partageables, et une intégration Node-RED pour aller plus loin.",
+          "Il découpe les choses en quatre onglets — Automatisations, Scènes, Scripts et Blueprints — ce qui peut donner l'impression de quatre fois la même chose quand on débute. Il y a sûrement une bonne raison, mais ça ajoute une courbe d'apprentissage.",
+        ],
+        takeaway:
+          "Même concept de base, deux philosophies. Gladys regroupe tout en un seul endroit simple ; Home Assistant est plus complet avec ses blueprints partageables.",
+      },
+      {
+        id: "communaute",
+        title: "Communauté & support",
+        gladys: [
+          "La communauté de Gladys est majoritairement française, avec un forum traduit en anglais et quelques utilisateurs internationaux. En tant que projet né en France, c'est là qu'elle brille pour la proximité.",
+          "Vous avez aussi le support direct du fondateur. Si vous avez une question — même très pointue sur le code — vous pouvez m'envoyer un mail, poster sur le forum ou me contacter sur les réseaux. Je réponds toujours.",
+        ],
+        ha: [
+          "Home Assistant a une communauté mondiale énorme avec un forum gigantesque, plus HACF, une communauté francophone où vous pouvez obtenir de l'aide en français.",
+          "C'est une tout autre ampleur — mais l'essentiel de la communication développeur se fait en anglais, car c'est un projet d'origine américaine.",
+        ],
+        takeaway:
+          "Home Assistant gagne sur l'ampleur. Gladys gagne sur la proximité et le support en français, avec un accès direct au créateur.",
+      },
+      {
+        id: "prix",
+        title: "Prix & modèle économique",
+        gladys: [
+          "Gladys est 100 % gratuite et open source dans son cœur, pour toujours. Il existe un abonnement optionnel Gladys Plus pour l'accès distant, les sauvegardes automatisées chiffrées, les assistants vocaux (Google Home, Alexa), l'IA et les données d'énergie Enedis.",
+          "Je vends aussi des kits de démarrage, mais pas pour faire de la marge — juste pour rendre Gladys plus accessible. Mon modèle économique repose vraiment sur l'abonnement.",
+        ],
+        ha: [
+          "Home Assistant est aussi 100 % gratuit et open source dans son cœur, avec un abonnement optionnel Nabu Casa Cloud (accès distant, vocal…) et une gamme de matériel grandissante comme la box HA Green.",
+        ],
+        takeaway:
+          "Les deux ont un modèle transparent et très similaire : cœur open source gratuit + abonnement optionnel. Il n'y a pas beaucoup de modèles viables en domotique, et les deux restent honnêtes.",
+      },
+    ],
+    whyNotBoth: {
+      title: "Et pourquoi pas les deux ?",
+      paragraphs: [
+        "Voici ce que la plupart des comparatifs oublient : vous n'êtes pas obligé de choisir. Vous pouvez faire tourner Gladys Assistant et Home Assistant en même temps sur la même installation.",
+        "Avec Zigbee2MQTT, une seule instance Zigbee peut parler à la fois à Gladys et à Home Assistant — le même appareil apparaît dans les deux interfaces. Même chose avec Matter : un appareil Matter associé à un hub (comme une Apple TV) peut être contrôlé depuis les deux. On peut avoir plusieurs contrôleurs en même temps.",
+        "Vous pouvez même utiliser Matterbridge pour exposer tous vos appareils Home Assistant sur un réseau Matter, puis les récupérer dans Gladys — en utilisant Home Assistant comme backend et Gladys comme frontend. Et bien sûr, les deux exposent des API riches, donc ils peuvent communiquer en MQTT ou HTTP.",
+        "Donc si vous aimez l'interface de Gladys mais avez besoin d'une intégration spécifique de Home Assistant, faites tourner les deux côte à côte. Il n'y a vraiment pas d'excuse — tout est possible.",
+      ],
+    },
+    faqTitle: "Questions fréquentes",
+    cta: {
+      title: "Prêt à essayer Gladys Assistant ?",
+      text: "Gladys est gratuite, open source, et s'installe en une seule commande Docker. Auto-hébergée, respectueuse de votre vie privée, sans cloud obligatoire.",
+      primary: { label: "Commencer", href: "/docs/" },
+      secondary: { label: "Voir les intégrations", href: "/docs/integrations/" },
+    },
+    videoTitle: "Voir le comparatif en vidéo",
+  },
+};
+
+export const comparisonFaqEn = [
+  {
+    question: "Is Gladys Assistant a fork of Home Assistant?",
+    answer:
+      "No. Gladys is an independent project, created in 2013 — the same year as Home Assistant — but with a completely different stack: Node.js and Preact for Gladys, versus Python and Lit for Home Assistant.",
+  },
+  {
+    question: "Which is easier for beginners, Gladys or Home Assistant?",
+    answer:
+      "Gladys is generally easier for beginners: there are no configuration files and no YAML — everything is configured by clicking in the interface. Home Assistant is more powerful but some parts still require editing YAML.",
+  },
+  {
+    question: "Does Gladys have as many integrations as Home Assistant?",
+    answer:
+      "No. Gladys has about 35 native integrations focused on open standards (Zigbee, Matter, MQTT), while Home Assistant has 2000+. But 35 native integrations still means thousands of compatible devices through Zigbee and Matter.",
+  },
+  {
+    question: "Can I run Gladys and Home Assistant at the same time?",
+    answer:
+      "Yes. With Zigbee2MQTT or Matter multi-admin, the same devices can appear in both. You can even use Matterbridge to expose Home Assistant devices to Gladys, or connect the two over MQTT or HTTP.",
+  },
+  {
+    question: "Is Gladys free like Home Assistant?",
+    answer:
+      "Yes. Both are 100% free and open-source at their core. Each offers an optional paid subscription: Gladys Plus for Gladys, and Nabu Casa Cloud for Home Assistant.",
+  },
+  {
+    question: "Is Home Assistant better than Gladys Assistant?",
+    answer:
+      "Neither is objectively better — it depends on your profile. Choose Home Assistant if you're a power user who wants maximum integrations and loves to tinker. Choose Gladys if you want a simple, stable, no-configuration experience.",
+  },
+];
+
+export const comparisonFaqFr = [
+  {
+    question: "Gladys Assistant est-il un fork de Home Assistant ?",
+    answer:
+      "Non. Gladys est un projet indépendant, créé en 2013 — la même année que Home Assistant — mais avec une stack complètement différente : Node.js et Preact pour Gladys, contre Python et Lit pour Home Assistant.",
+  },
+  {
+    question: "Lequel est le plus simple pour un débutant, Gladys ou Home Assistant ?",
+    answer:
+      "Gladys est généralement plus simple pour débuter : pas de fichiers de configuration ni de YAML, tout se configure au clic dans l'interface. Home Assistant est plus puissant mais certaines parties demandent encore d'éditer du YAML.",
+  },
+  {
+    question: "Gladys a-t-il autant d'intégrations que Home Assistant ?",
+    answer:
+      "Non. Gladys propose environ 35 intégrations natives centrées sur les standards ouverts (Zigbee, Matter, MQTT), là où Home Assistant en a plus de 2000. Mais 35 intégrations natives, cela représente déjà des milliers d'appareils compatibles via Zigbee et Matter.",
+  },
+  {
+    question: "Puis-je faire tourner Gladys et Home Assistant en même temps ?",
+    answer:
+      "Oui. Avec Zigbee2MQTT ou le multi-admin Matter, les mêmes appareils peuvent apparaître dans les deux. Vous pouvez même utiliser Matterbridge pour exposer les appareils de Home Assistant dans Gladys, ou connecter les deux en MQTT ou HTTP.",
+  },
+  {
+    question: "Gladys est-il gratuit comme Home Assistant ?",
+    answer:
+      "Oui. Les deux sont 100 % gratuits et open source dans leur cœur. Chacun propose un abonnement optionnel : Gladys Plus pour Gladys, et Nabu Casa Cloud pour Home Assistant.",
+  },
+  {
+    question: "Home Assistant est-il meilleur que Gladys Assistant ?",
+    answer:
+      "Aucun n'est objectivement meilleur — cela dépend de votre profil. Choisissez Home Assistant si vous êtes un power user qui veut un maximum d'intégrations et aime bidouiller. Choisissez Gladys si vous voulez une expérience simple, stable et sans configuration.",
+  },
+];
+
+export { YOUTUBE_VIDEO_ID };
+export default comparisonContent;

--- a/src/data/comparisonData.js
+++ b/src/data/comparisonData.js
@@ -3,8 +3,9 @@
 // of <Translate> ids, because the page is long-form prose that is easier to
 // maintain and keep in sync when both languages live side by side.
 //
-// The comparison is written in the founder's voice and intentionally honest
-// about Gladys' weaknesses — it mirrors the "honest comparison" YouTube video.
+// Tone: this lives on Gladys' own site, so the comparison is fair and honest
+// but allowed to lean slightly in Gladys' favor (unlike the deliberately
+// neutral YouTube video it's based on).
 
 // "Home Assistant vs Gladys Assistant" YouTube video. Rendered as an embedded
 // video in a dedicated section on the comparison page.
@@ -15,15 +16,15 @@ const comparisonContent = {
     meta: {
       title: "Home Assistant vs Gladys Assistant: an honest comparison (2026)",
       description:
-        "Home Assistant or Gladys Assistant? An honest comparison by Gladys' founder: installation, ease of use, integrations, automations, community and pricing — to pick the right open-source home automation platform.",
+        "Home Assistant or Gladys Assistant? A fair comparison by Gladys' founder: installation, ease of use, integrations, automations, community and pricing, to pick the right open-source home automation platform.",
     },
     hero: {
       title: "Home Assistant vs Gladys Assistant",
       subtitle: "An honest comparison between two open-source home assistants",
       intro: [
         "Still hesitating between Home Assistant and Gladys Assistant? This comparison will save you hours.",
-        "Full transparency: I'm Pierre-Gilles, the creator of Gladys Assistant. My goal here isn't to convince you to use Gladys — it's to promote open-source home automation and help you pick the solution that fits your profile. I'll be 100% honest about the strengths and weaknesses of each.",
-        "Both projects started in 2013, right after the first Raspberry Pi came out. They look similar, but they're actually quite different — and that difference is exactly what should guide your choice.",
+        "Full transparency: I'm Pierre-Gilles, the creator of Gladys Assistant, so I'm obviously biased. But I'll be fair about both projects. Here's how they really compare, and why I believe Gladys is the better fit for most people who want a smart home that simply works.",
+        "Both projects started in 2013, right after the first Raspberry Pi came out. They look similar at first glance, but they're built on very different philosophies, and that difference is exactly what should guide your choice.",
       ],
     },
     verdict: {
@@ -32,9 +33,9 @@ const comparisonContent = {
         title: "Choose Gladys Assistant if…",
         points: [
           "You want something simple, fast to set up, and that just works.",
-          "You prefer a clean interface where everything happens with clicks — no configuration files, no YAML.",
+          "You prefer a clean interface where everything happens with clicks, with no configuration files and no YAML.",
           "You value stability: updates are fully automatic and atomic.",
-          "You speak French, or want direct support from the founder.",
+          "You want a responsive project where your feedback actually shapes the product.",
         ],
       },
       ha: {
@@ -43,7 +44,7 @@ const comparisonContent = {
           "You own very specific or niche devices that need a dedicated integration.",
           "You're a power user who loves to tinker and customize to the extreme.",
           "You're comfortable editing YAML and going under the hood.",
-          "You want the largest possible catalog of integrations.",
+          "You want the largest possible catalog of integrations, even if quality varies.",
         ],
       },
     },
@@ -55,23 +56,23 @@ const comparisonContent = {
       { feature: "Frontend", gladys: "Preact", ha: "Lit + Web Components" },
       {
         feature: "Installation",
-        gladys: "One Docker command, or a French starter kit (mini-PC) pre-installed",
+        gladys: "One Docker command, rich docs and videos, or a starter kit pre-installed",
         ha: "Home Assistant OS, the HA Green box, or Docker",
       },
       {
-        feature: "Ready-to-flash OS image",
-        gladys: "No — bring your own Linux + Docker",
-        ha: "Yes (Home Assistant OS)",
+        feature: "Setup difficulty",
+        gladys: "Beginner-friendly, guided step by step",
+        ha: "Steeper learning curve",
       },
       {
         feature: "Configuration files",
-        gladys: "None — everything is in the interface",
+        gladys: "None: everything is in the interface",
         ha: "YAML needed for some parts",
       },
       {
-        feature: "Native integrations",
-        gladys: "~35, focused on open standards (Zigbee, Matter, MQTT)",
-        ha: "2000+",
+        feature: "Integrations",
+        gladys: "Curated and polished, built around open standards (Zigbee, Matter, MQTT)",
+        ha: "Huge catalog, community-built, quality varies",
       },
       {
         feature: "Supported devices",
@@ -80,13 +81,8 @@ const comparisonContent = {
       },
       {
         feature: "Automations",
-        gladys: "A single \"Scenes\" tab, visual editor, Node-RED",
+        gladys: "One simple \"Scenes\" tab, visual editor, Node-RED",
         ha: "Automations / Scenes / Scripts / Blueprints, visual editor, YAML, Node-RED",
-      },
-      {
-        feature: "Share automations",
-        gladys: "No",
-        ha: "Yes (YAML blueprints)",
       },
       {
         feature: "Native alarm mode",
@@ -104,9 +100,9 @@ const comparisonContent = {
         ha: "Frequent, can occasionally break things",
       },
       {
-        feature: "Community",
-        gladys: "Mostly French (FR + EN forum), direct founder support",
-        ha: "Huge global community + HACF (French community)",
+        feature: "Support",
+        gladys: "Direct answers from the maker, active community",
+        ha: "Large community, community-driven support",
       },
       {
         feature: "Pricing",
@@ -124,97 +120,97 @@ const comparisonContent = {
         id: "installation",
         title: "Installation",
         gladys: [
-          "Gladys installs with a single Docker command — there's a `docker run` and a `docker-compose` file you can copy, paste and launch. The only requirement is having Docker installed.",
-          "There's also an official starter kit: a Beelink mini-PC with Gladys pre-installed. You plug it in, follow the quick-start guide, and you're done. I don't make real margin on it — it just makes Gladys accessible to people who don't want to install it themselves.",
-          "The trade-off: there's no ready-to-flash OS image. You bring your own Linux (Ubuntu, Debian, whatever) and run the container. The upside is you stay free to use your mini-PC, NAS or Raspberry Pi for other things too.",
+          "Gladys is genuinely simple to install. It runs with a single Docker command (a `docker run` line or a `docker-compose` file you copy, paste and launch), and the documentation walks you through every step with screenshots and installation videos.",
+          "If you'd rather skip setup entirely, the official starter kit is a Beelink mini-PC that arrives with Gladys already installed and configured. You plug it in, follow the quick-start guide, and you're up and running in minutes.",
+          "And because Gladys is just a container, you stay free to use your mini-PC, NAS or Raspberry Pi for other things too.",
         ],
         ha: [
-          "Home Assistant offers Home Assistant OS, which is very polished — you install it like you'd install Ubuntu and you get Home Assistant running. They also sell the Home Assistant Green box with everything pre-installed.",
-          "It's relatively easy if you buy their box. But without it, I found it wasn't always obvious which installation method was the simplest — they tend to push Home Assistant OS over the plain Docker route.",
+          "Home Assistant offers Home Assistant OS, which is polished, and the Home Assistant Green box arrives ready to use.",
+          "It's straightforward if you buy their box. Without it, though, it's not always obvious which installation method is the simplest, since they tend to push Home Assistant OS over the plain Docker route.",
         ],
         takeaway:
-          "Both are easy if you buy their hardware. Gladys is simplest if you already know Docker; Home Assistant OS is great if you want a turnkey appliance.",
+          "Both are beginner-friendly if you buy their hardware. But Gladys is especially easy to install yourself, thanks to a one-line Docker setup, rich documentation and step-by-step videos.",
       },
       {
         id: "interface",
         title: "Interface & ease of use",
         gladys: [
           "Gladys has a clean, intuitive interface. The whole philosophy is to think about the user before the technical implementation: you never have to dig into logs or edit a file on disk. Everything happens with the mouse.",
-          "You can build as many dashboards as you want — one per room, or by theme (energy, security…). No configuration files, because there are none.",
-          "The honest downside: there are fewer options for power users. Gladys is like a consumer product — you can arrange the widgets you're given, but if a widget is missing, it has to be developed (it's open-source, so you can contribute one).",
+          "You can build as many dashboards as you want, one per room or by theme (energy, security, and so on), with no configuration files because there simply aren't any.",
+          "Gladys deliberately keeps things focused: you arrange the widgets you actually need instead of wading through endless options. And since it's open-source, anything missing can be added by the community.",
         ],
         ha: [
-          "Home Assistant has a modern Material Design interface that's very clean and highly customizable. The dashboard is fully editable with tons of cards and options.",
-          "But you'll often see, on the forums, that some parts still require editing YAML files — which can be intimidating for a beginner.",
+          "Home Assistant has a modern Material Design interface that's clean and highly customizable. The dashboard is fully editable with tons of cards and options.",
+          "But you'll often see, on the forums, that some parts still require editing YAML files, which can be intimidating for a beginner.",
         ],
         takeaway:
-          "Gladys wins on simplicity: a beautiful interface with zero configuration. Home Assistant wins on customization if you like to tinker.",
+          "For a beautiful experience that works out of the box, Gladys is hard to beat. Home Assistant gives you more knobs if you enjoy customizing every last detail.",
       },
       {
         id: "integrations",
         title: "Integrations & compatibility",
         gladys: [
-          "Gladys has a limited, curated set: roughly 35 native integrations, focused on open standards like Zigbee, Matter and MQTT. They're carefully built and tested end-to-end, designed like a consumer product rather than by developers for developers.",
-          "35 native integrations doesn't mean 35 compatible devices: through Zigbee alone there are thousands of compatible devices. The bet is that open standards — Matter especially — will dominate, so I invest heavily in those and very little in closed, cloud-only ecosystems.",
-          "For devices that aren't Matter yet, projects like Matterbridge can bridge them onto a Matter network — including a Home Assistant plugin.",
+          "Gladys focuses on what matters: a curated set of integrations built around open standards like Zigbee, Matter and MQTT. Each one is carefully built and tested end to end, designed like a polished consumer product rather than by developers for developers.",
+          "Through Zigbee and Matter alone, that already means thousands of compatible devices. The bet is that open standards, Matter especially, will dominate, so Gladys invests heavily where the market is heading, not in closed, cloud-only ecosystems that lock you in.",
+          "For anything not natively supported yet, Matterbridge can bridge devices onto a Matter network, including a Home Assistant plugin.",
         ],
         ha: [
-          "Home Assistant has 2000+ integrations — an incredible number, with a very active community constantly adding more. This is where it's genuinely unbeatable.",
-          "The flip side is variable quality: some integrations are excellent, others less so, and it's up to you to find and test the ones you need.",
+          "Home Assistant has a massive catalog with thousands of community integrations, so even niche devices are often supported out of the box.",
+          "The flip side is variable quality: some integrations are excellent, others less so, and it's up to you to find the right one and test that it works.",
         ],
         takeaway:
-          "Home Assistant is unbeatable on sheer numbers. Gladys focuses on the essentials and bets on Matter & Zigbee for the future — the compatibility gap should shrink as everyone adopts Matter.",
+          "If you value integrations that just work and are built to last, Gladys' curated approach is hard to beat. If you own very niche hardware and enjoy testing community add-ons, Home Assistant's sheer catalog is appealing. As the whole industry adopts Matter, the gap keeps shrinking.",
       },
       {
         id: "automations",
         title: "Automations & scenes",
         gladys: [
           "Everything lives in a single \"Scenes\" tab. A scene can be a manual sequence of actions you trigger from your dashboard, or a full automation with triggers, conditions and actions.",
-          "There's a visual editor similar to Home Assistant's. You start with a trigger (optional), then chain as many conditions and actions as you want, and you can mix them — a condition leading to actions, then more conditions. It's quite powerful.",
-          "If Gladys isn't enough, you can offload complex logic to Node-RED and connect it via MQTT or HTTP. The honest downside: there's no built-in way to share a scene with others.",
+          "The visual editor is intuitive: you start with a trigger (optional), then chain as many conditions and actions as you want, and you can mix them freely, with a condition leading to actions, then more conditions. It's surprisingly powerful while staying easy to read.",
+          "And if you ever need to go further, you can offload complex logic to Node-RED and connect it to Gladys over MQTT or HTTP.",
         ],
         ha: [
           "Home Assistant has a visual editor too, plus shareable YAML blueprints and a Node-RED integration to go further.",
-          "It splits things into four tabs — Automations, Scenes, Scripts and Blueprints — which can feel like four versions of the same thing when you're starting out. There's surely a good reason, but it adds a learning curve.",
+          "It splits things into four tabs (Automations, Scenes, Scripts and Blueprints), which can feel like four versions of the same thing when you're starting out and adds to the learning curve.",
         ],
         takeaway:
-          "Same core concept, two philosophies. Gladys keeps it in one simple place; Home Assistant is more complete with shareable blueprints.",
+          "Gladys keeps everything in one simple, powerful place, while Home Assistant spreads it across four tabs. For most people, Gladys' single Scenes tab is faster to learn and just as capable for everyday automations.",
       },
       {
         id: "community",
         title: "Community & support",
         gladys: [
-          "Gladys' community is mostly French, with an English-translated forum and some international users. As a French-born project, that's where it shines for proximity.",
-          "You also get direct support from the founder. If you have a question — even a deep one about the code — you can email me, post on the forum, or reach out on social media. I always answer.",
+          "Gladys is a project that genuinely listens. There's an active community on the forum, and a roadmap shaped by real user feedback rather than by what's easiest to build.",
+          "Best of all, you get direct support from the founder. If you have a question, even a deep one about the code, you can email me, post on the forum, or reach out on social media, and you'll get a personal answer. That kind of access is rare.",
         ],
         ha: [
-          "Home Assistant has a massive global community with a huge forum, plus HACF, a French-speaking community where you can get help in French.",
-          "It's on another scale entirely — but most of the developer communication happens in English, since it's an American-rooted project.",
+          "Home Assistant has a huge global community and a massive forum, so you'll usually find someone who has already solved your problem.",
+          "With that scale, though, support is community-driven rather than personal, and most of the developer communication happens in English.",
         ],
         takeaway:
-          "Home Assistant wins on sheer scale. Gladys wins on proximity and French-language support, with direct access to the maker.",
+          "Home Assistant wins on sheer size. But Gladys offers something rarer: a responsive project where the maker listens and answers you personally.",
       },
       {
         id: "pricing",
         title: "Pricing & business model",
         gladys: [
           "Gladys is 100% free and open-source at its core, forever. There's an optional Gladys Plus subscription for remote access, encrypted automated backups, voice assistants (Google Home, Alexa), AI and Enedis energy data.",
-          "I also sell starter kits, but not to make margin — just to make Gladys more accessible. My business model is really the subscription.",
+          "I also sell starter kits, not to make margin but to make Gladys more accessible. The business model is really the subscription, with no investors, no ads and no data resale.",
         ],
         ha: [
-          "Home Assistant is also 100% free and open-source at its core, with an optional Nabu Casa Cloud subscription (remote access, voice…) and a growing line of hardware like the HA Green box.",
+          "Home Assistant is also 100% free and open-source at its core, with an optional Nabu Casa Cloud subscription (remote access, voice) and a growing line of hardware like the HA Green box.",
         ],
         takeaway:
-          "Both have a transparent, very similar model: free open-source core + optional subscription. There aren't many viable business models in home automation, and both keep it honest.",
+          "Both have a transparent, very similar model: a free open-source core plus an optional subscription. Either way, you're funding an independent project rather than a data-hungry tech giant.",
       },
     ],
     whyNotBoth: {
       title: "Why not both?",
       paragraphs: [
         "Here's the part most comparisons miss: you don't have to choose. You can run Gladys Assistant and Home Assistant on the same setup at the same time.",
-        "With Zigbee2MQTT, a single Zigbee instance can talk to both Gladys and Home Assistant — the same device shows up in both interfaces. The same goes for Matter: a Matter device paired to a hub (like an Apple TV) can be controlled from both. You can have several controllers at once.",
-        "You can even use Matterbridge to expose all your Home Assistant devices onto a Matter network, then pull them into Gladys — effectively using Home Assistant as a backend and Gladys as your frontend. And of course both expose rich APIs, so they can talk over MQTT or HTTP.",
-        "So if you love the Gladys interface but need a niche Home Assistant integration, run them side by side. There's really no excuse — everything is possible.",
+        "With Zigbee2MQTT, a single Zigbee instance can talk to both Gladys and Home Assistant, so the same device shows up in both interfaces. The same goes for Matter: a device paired to a hub (like an Apple TV) can be controlled from both. You can have several controllers at once.",
+        "You can even use Matterbridge to expose all your Home Assistant devices onto a Matter network, then pull them into Gladys, effectively using Home Assistant as a backend and Gladys as your interface. And of course both expose rich APIs, so they can talk over MQTT or HTTP.",
+        "So if you love the Gladys interface but need a niche Home Assistant integration, run them side by side. There's really no excuse: everything is possible.",
       ],
     },
     faqTitle: "Frequently asked questions",
@@ -231,15 +227,15 @@ const comparisonContent = {
     meta: {
       title: "Home Assistant vs Gladys Assistant : le comparatif honnête (2026)",
       description:
-        "Home Assistant ou Gladys Assistant ? Comparatif honnête par le créateur de Gladys : installation, simplicité, intégrations, automatisations, communauté et prix — pour choisir la bonne solution domotique open source.",
+        "Home Assistant ou Gladys Assistant ? Comparatif honnête par le créateur de Gladys : installation, simplicité, intégrations, automatisations, communauté et prix, pour choisir la bonne solution domotique open source.",
     },
     hero: {
       title: "Home Assistant vs Gladys Assistant",
       subtitle: "Un comparatif honnête entre deux assistants domotiques open source",
       intro: [
         "Vous hésitez encore entre Home Assistant et Gladys Assistant ? Ce comparatif va vous faire gagner des heures.",
-        "En toute transparence : je suis Pierre-Gilles, le créateur de Gladys Assistant. Mon but ici n'est pas de vous convaincre d'utiliser Gladys, mais de mettre en avant l'open source et de vous aider à choisir la solution la plus adaptée à votre profil. Je serai 100 % honnête sur les forces et les faiblesses de chacune.",
-        "Les deux projets sont nés en 2013, juste après la sortie du premier Raspberry Pi. Ils se ressemblent, mais ils sont en réalité très différents — et c'est justement cette différence qui doit guider votre choix.",
+        "En toute transparence : je suis Pierre-Gilles, le créateur de Gladys Assistant, donc je suis forcément un peu partial. Mais je serai juste envers les deux projets. Voici comment ils se comparent vraiment, et pourquoi je pense que Gladys est le meilleur choix pour la plupart des gens qui veulent une maison connectée qui fonctionne, tout simplement.",
+        "Les deux projets sont nés en 2013, juste après la sortie du premier Raspberry Pi. Ils se ressemblent au premier abord, mais ils reposent sur des philosophies très différentes, et c'est justement cette différence qui doit guider votre choix.",
       ],
     },
     verdict: {
@@ -248,9 +244,9 @@ const comparisonContent = {
         title: "Choisissez Gladys Assistant si…",
         points: [
           "Vous voulez quelque chose de simple, rapide à prendre en main, et qui fonctionne.",
-          "Vous préférez une interface épurée où tout se fait au clic — pas de fichiers de configuration, pas de YAML.",
+          "Vous préférez une interface épurée où tout se fait au clic, sans fichiers de configuration ni YAML.",
           "Vous tenez à la stabilité : les mises à jour sont totalement automatiques et atomiques.",
-          "Vous parlez français, ou vous voulez le support direct du fondateur.",
+          "Vous voulez un projet à l'écoute, où vos retours façonnent vraiment le produit.",
         ],
       },
       ha: {
@@ -259,7 +255,7 @@ const comparisonContent = {
           "Vous avez des équipements très spécifiques qui demandent une intégration dédiée.",
           "Vous êtes un power user qui adore bidouiller et personnaliser à l'extrême.",
           "Vous êtes à l'aise avec le YAML et aller sous le capot.",
-          "Vous voulez le plus grand catalogue d'intégrations possible.",
+          "Vous voulez le plus grand catalogue d'intégrations possible, même si la qualité est variable.",
         ],
       },
     },
@@ -271,23 +267,23 @@ const comparisonContent = {
       { feature: "Frontend", gladys: "Preact", ha: "Lit + Web Components" },
       {
         feature: "Installation",
-        gladys: "Une commande Docker, ou un kit de démarrage français (mini-PC) pré-installé",
+        gladys: "Une commande Docker, doc et vidéos riches, ou un kit de démarrage pré-installé",
         ha: "Home Assistant OS, la box HA Green, ou Docker",
       },
       {
-        feature: "Image OS prête à flasher",
-        gladys: "Non — votre Linux + Docker",
-        ha: "Oui (Home Assistant OS)",
+        feature: "Difficulté de prise en main",
+        gladys: "Accessible aux débutants, guidée pas à pas",
+        ha: "Courbe d'apprentissage plus raide",
       },
       {
         feature: "Fichiers de configuration",
-        gladys: "Aucun — tout est dans l'interface",
+        gladys: "Aucun : tout est dans l'interface",
         ha: "YAML nécessaire pour certaines parties",
       },
       {
-        feature: "Intégrations natives",
-        gladys: "~35, centrées sur les standards ouverts (Zigbee, Matter, MQTT)",
-        ha: "2000+",
+        feature: "Intégrations",
+        gladys: "Soignées et abouties, centrées sur les standards ouverts (Zigbee, Matter, MQTT)",
+        ha: "Catalogue immense, communautaire, qualité variable",
       },
       {
         feature: "Appareils supportés",
@@ -298,11 +294,6 @@ const comparisonContent = {
         feature: "Automatisations",
         gladys: "Un seul onglet « Scènes », éditeur visuel, Node-RED",
         ha: "Automatisations / Scènes / Scripts / Blueprints, éditeur visuel, YAML, Node-RED",
-      },
-      {
-        feature: "Partage d'automatisations",
-        gladys: "Non",
-        ha: "Oui (blueprints YAML)",
       },
       {
         feature: "Mode alarme natif",
@@ -320,9 +311,9 @@ const comparisonContent = {
         ha: "Fréquentes, peuvent parfois casser des choses",
       },
       {
-        feature: "Communauté",
-        gladys: "Majoritairement française (forum FR + EN), support direct du fondateur",
-        ha: "Énorme communauté mondiale + HACF (communauté française)",
+        feature: "Support",
+        gladys: "Réponses directes du créateur, communauté active",
+        ha: "Grande communauté, support communautaire",
       },
       {
         feature: "Modèle économique",
@@ -340,97 +331,97 @@ const comparisonContent = {
         id: "installation",
         title: "Installation",
         gladys: [
-          "Gladys s'installe en une seule commande Docker — un `docker run` ou un fichier `docker-compose` que vous copiez, collez et lancez. La seule chose nécessaire, c'est d'avoir Docker installé.",
-          "Il existe aussi un kit de démarrage officiel : un mini-PC Beelink avec Gladys déjà installée. Vous le branchez, suivez le guide de démarrage rapide, et c'est prêt. Je ne fais pas vraiment de marge dessus — c'est juste pour rendre Gladys accessible à ceux qui ne veulent pas l'installer eux-mêmes.",
-          "Le compromis : pas d'image OS prête à flasher. C'est à vous d'installer un Linux (Ubuntu, Debian, ce que vous voulez) puis de lancer le conteneur. L'avantage, c'est que vous restez libre d'utiliser votre mini-PC, NAS ou Raspberry Pi pour autre chose.",
+          "Gladys est vraiment simple à installer. Elle se lance en une seule commande Docker (une ligne `docker run` ou un fichier `docker-compose` que vous copiez, collez et lancez), et la documentation vous guide à chaque étape avec des captures d'écran et des vidéos d'installation.",
+          "Et si vous préférez éviter toute installation, le kit de démarrage officiel est un mini-PC Beelink qui arrive avec Gladys déjà installée et configurée. Vous le branchez, suivez le guide de démarrage rapide, et c'est opérationnel en quelques minutes.",
+          "Comme Gladys n'est qu'un conteneur, vous restez libre d'utiliser votre mini-PC, NAS ou Raspberry Pi pour autre chose en parallèle.",
         ],
         ha: [
-          "Home Assistant propose Home Assistant OS, très abouti — vous l'installez comme vous installeriez Ubuntu et vous avez Home Assistant qui tourne. Ils vendent aussi la box Home Assistant Green avec tout pré-installé.",
-          "C'est relativement facile si vous achetez leur box. Mais sans elle, j'ai trouvé que ce n'était pas toujours clair quelle était la méthode la plus simple — ils mettent un peu de côté la voie Docker pour pousser Home Assistant OS.",
+          "Home Assistant propose Home Assistant OS, très abouti, et la box Home Assistant Green qui arrive prête à l'emploi.",
+          "C'est simple si vous achetez leur box. Sans elle, en revanche, ce n'est pas toujours clair quelle est la méthode la plus simple, car ils mettent un peu de côté la voie Docker pour pousser Home Assistant OS.",
         ],
         takeaway:
-          "Les deux sont faciles si vous achetez leur matériel. Gladys est le plus simple si vous connaissez déjà Docker ; Home Assistant OS est idéal si vous voulez une solution clé en main.",
+          "Les deux sont accessibles si vous achetez leur matériel. Mais Gladys est particulièrement facile à installer soi-même, grâce à une commande Docker unique, une documentation riche et des vidéos pas à pas.",
       },
       {
         id: "interface",
         title: "Interface & prise en main",
         gladys: [
           "Gladys a une interface épurée et intuitive. Toute la philosophie, c'est de penser à l'utilisateur avant la technique : vous n'avez jamais à aller chercher dans les logs ou à éditer un fichier sur le disque. Tout se passe à la souris.",
-          "Vous pouvez créer autant de tableaux de bord que vous voulez — un par pièce, ou par thématique (énergie, sécurité…). Pas de fichiers de configuration, parce qu'il n'y en a pas.",
-          "Le revers honnête : il y a moins d'options pour les power users. Gladys est comme un produit grand public — vous disposez les widgets fournis comme vous voulez, mais s'il manque un widget, il faut le développer (c'est open source, vous pouvez en proposer un).",
+          "Vous pouvez créer autant de tableaux de bord que vous voulez, un par pièce ou par thématique (énergie, sécurité…), sans fichiers de configuration puisqu'il n'y en a pas.",
+          "Gladys reste volontairement concentrée : vous disposez les widgets dont vous avez réellement besoin, sans vous noyer dans des options à n'en plus finir. Et comme c'est open source, ce qui manque peut être ajouté par la communauté.",
         ],
         ha: [
-          "Home Assistant a une interface moderne en Material Design, très propre et hautement personnalisable. Le tableau de bord est entièrement éditable, avec une multitude de cartes et d'options.",
-          "Mais on remarque souvent, sur les forums, que certaines parties demandent encore d'éditer des fichiers YAML — ce qui peut être intimidant pour un débutant.",
+          "Home Assistant a une interface moderne en Material Design, propre et hautement personnalisable. Le tableau de bord est entièrement éditable, avec une multitude de cartes et d'options.",
+          "Mais on remarque souvent, sur les forums, que certaines parties demandent encore d'éditer des fichiers YAML, ce qui peut être intimidant pour un débutant.",
         ],
         takeaway:
-          "Gladys gagne sur la simplicité : une belle interface sans aucune configuration. Home Assistant gagne sur la personnalisation si vous aimez bidouiller.",
+          "Pour une belle expérience qui fonctionne dès le départ, Gladys est difficile à battre. Home Assistant offre plus de réglages si vous aimez tout personnaliser dans les moindres détails.",
       },
       {
         id: "integrations",
         title: "Intégrations & compatibilité",
         gladys: [
-          "Gladys a un set limité et soigné : environ 35 intégrations natives, centrées sur les standards ouverts comme Zigbee, Matter et MQTT. Elles sont testées de bout en bout et pensées comme un produit grand public, pas par des développeurs pour des développeurs.",
-          "35 intégrations natives ne veut pas dire 35 appareils compatibles : rien qu'en Zigbee, il y a des milliers d'appareils compatibles. Le pari, c'est que les standards ouverts — Matter en particulier — vont dominer ; j'y investis donc beaucoup, et très peu dans les écosystèmes fermés et cloud-only.",
-          "Pour les appareils qui ne sont pas encore Matter, des projets comme Matterbridge permettent de les relier à un réseau Matter — y compris via un plugin Home Assistant.",
+          "Gladys se concentre sur l'essentiel : un ensemble d'intégrations soignées, construites autour des standards ouverts comme Zigbee, Matter et MQTT. Chacune est testée de bout en bout et pensée comme un produit grand public abouti, pas par des développeurs pour des développeurs.",
+          "Rien qu'avec Zigbee et Matter, cela représente déjà des milliers d'appareils compatibles. Le pari, c'est que les standards ouverts, Matter en particulier, vont dominer ; Gladys investit donc là où va le marché, et non dans les écosystèmes fermés et cloud-only qui vous enferment.",
+          "Pour tout ce qui n'est pas encore supporté nativement, Matterbridge permet de relier des appareils à un réseau Matter, y compris via un plugin Home Assistant.",
         ],
         ha: [
-          "Home Assistant compte plus de 2000 intégrations — un nombre fou, avec une communauté très active qui en ajoute en permanence. C'est là qu'il est vraiment imbattable.",
-          "La contrepartie, c'est une qualité variable : certaines intégrations sont excellentes, d'autres moins, et c'est à vous de découvrir et tester celles dont vous avez besoin.",
+          "Home Assistant dispose d'un catalogue immense, avec des milliers d'intégrations communautaires, si bien que même les appareils de niche sont souvent supportés directement.",
+          "La contrepartie, c'est une qualité variable : certaines intégrations sont excellentes, d'autres moins, et c'est à vous de trouver la bonne et de vérifier qu'elle fonctionne.",
         ],
         takeaway:
-          "Home Assistant est imbattable en nombre. Gladys se concentre sur l'essentiel et mise sur Matter & Zigbee pour l'avenir — l'écart de compatibilité devrait se réduire à mesure que tout le monde adopte Matter.",
+          "Si vous voulez des intégrations qui fonctionnent et durent, l'approche soignée de Gladys est difficile à battre. Si vous avez du matériel très spécifique et aimez tester des modules communautaires, le catalogue de Home Assistant est attirant. Et avec l'adoption de Matter par toute l'industrie, l'écart se réduit sans cesse.",
       },
       {
         id: "automatisations",
         title: "Automatisations & scènes",
         gladys: [
           "Tout est dans un seul onglet « Scènes ». Une scène peut être une suite d'actions que vous lancez manuellement depuis votre tableau de bord, ou un scénario complet avec déclencheur, conditions et actions.",
-          "Il y a un éditeur visuel proche de celui de Home Assistant. Vous partez d'un déclencheur (optionnel), puis vous enchaînez autant de conditions et d'actions que vous voulez, et vous pouvez les mélanger — une condition menant à des actions, puis d'autres conditions. C'est assez puissant.",
-          "Si Gladys ne suffit pas, vous pouvez déporter la logique complexe vers Node-RED et le connecter en MQTT ou HTTP. Le revers honnête : il n'y a pas de moyen natif de partager une scène avec d'autres.",
+          "L'éditeur visuel est intuitif : vous partez d'un déclencheur (optionnel), puis vous enchaînez autant de conditions et d'actions que vous voulez, et vous pouvez les mélanger librement, avec une condition menant à des actions, puis d'autres conditions. C'est étonnamment puissant tout en restant facile à lire.",
+          "Et si vous avez besoin d'aller plus loin, vous pouvez déporter la logique complexe vers Node-RED et le connecter à Gladys en MQTT ou HTTP.",
         ],
         ha: [
           "Home Assistant a aussi un éditeur visuel, des blueprints YAML partageables, et une intégration Node-RED pour aller plus loin.",
-          "Il découpe les choses en quatre onglets — Automatisations, Scènes, Scripts et Blueprints — ce qui peut donner l'impression de quatre fois la même chose quand on débute. Il y a sûrement une bonne raison, mais ça ajoute une courbe d'apprentissage.",
+          "Il découpe les choses en quatre onglets (Automatisations, Scènes, Scripts et Blueprints), ce qui peut donner l'impression de quatre fois la même chose quand on débute et alourdit la courbe d'apprentissage.",
         ],
         takeaway:
-          "Même concept de base, deux philosophies. Gladys regroupe tout en un seul endroit simple ; Home Assistant est plus complet avec ses blueprints partageables.",
+          "Gladys regroupe tout en un seul endroit simple et puissant, là où Home Assistant l'éparpille sur quatre onglets. Pour la plupart des gens, l'onglet Scènes unique de Gladys s'apprend plus vite et fait tout aussi bien le travail au quotidien.",
       },
       {
         id: "communaute",
         title: "Communauté & support",
         gladys: [
-          "La communauté de Gladys est majoritairement française, avec un forum traduit en anglais et quelques utilisateurs internationaux. En tant que projet né en France, c'est là qu'elle brille pour la proximité.",
-          "Vous avez aussi le support direct du fondateur. Si vous avez une question — même très pointue sur le code — vous pouvez m'envoyer un mail, poster sur le forum ou me contacter sur les réseaux. Je réponds toujours.",
+          "Gladys est un projet qui est vraiment à l'écoute. Le forum est animé par une communauté active, et la feuille de route est façonnée par les retours réels des utilisateurs plutôt que par ce qui est le plus facile à développer.",
+          "Comme c'est un projet né en France, vous y trouvez une communauté francophone soudée et un support en français. Et surtout, vous avez le support direct du fondateur : pour toute question, même très pointue sur le code, vous pouvez m'envoyer un mail, poster sur le forum ou me contacter sur les réseaux, et vous aurez une réponse personnelle. Cet accès est rare.",
         ],
         ha: [
-          "Home Assistant a une communauté mondiale énorme avec un forum gigantesque, plus HACF, une communauté francophone où vous pouvez obtenir de l'aide en français.",
-          "C'est une tout autre ampleur — mais l'essentiel de la communication développeur se fait en anglais, car c'est un projet d'origine américaine.",
+          "Home Assistant a une communauté mondiale énorme et un forum gigantesque, donc vous trouverez généralement quelqu'un qui a déjà résolu votre problème.",
+          "Avec cette ampleur, le support reste cependant communautaire plutôt que personnel, et l'essentiel de la communication développeur se fait en anglais.",
         ],
         takeaway:
-          "Home Assistant gagne sur l'ampleur. Gladys gagne sur la proximité et le support en français, avec un accès direct au créateur.",
+          "Home Assistant gagne sur l'ampleur. Mais Gladys offre quelque chose de plus rare : un projet réactif, à l'écoute, où le créateur vous répond personnellement, en français.",
       },
       {
         id: "prix",
         title: "Prix & modèle économique",
         gladys: [
           "Gladys est 100 % gratuite et open source dans son cœur, pour toujours. Il existe un abonnement optionnel Gladys Plus pour l'accès distant, les sauvegardes automatisées chiffrées, les assistants vocaux (Google Home, Alexa), l'IA et les données d'énergie Enedis.",
-          "Je vends aussi des kits de démarrage, mais pas pour faire de la marge — juste pour rendre Gladys plus accessible. Mon modèle économique repose vraiment sur l'abonnement.",
+          "Je vends aussi des kits de démarrage, non pas pour faire de la marge mais pour rendre Gladys plus accessible. Le modèle économique repose vraiment sur l'abonnement, sans investisseurs, sans publicité et sans revente de données.",
         ],
         ha: [
-          "Home Assistant est aussi 100 % gratuit et open source dans son cœur, avec un abonnement optionnel Nabu Casa Cloud (accès distant, vocal…) et une gamme de matériel grandissante comme la box HA Green.",
+          "Home Assistant est aussi 100 % gratuit et open source dans son cœur, avec un abonnement optionnel Nabu Casa Cloud (accès distant, vocal) et une gamme de matériel grandissante comme la box HA Green.",
         ],
         takeaway:
-          "Les deux ont un modèle transparent et très similaire : cœur open source gratuit + abonnement optionnel. Il n'y a pas beaucoup de modèles viables en domotique, et les deux restent honnêtes.",
+          "Les deux ont un modèle transparent et très similaire : un cœur open source gratuit plus un abonnement optionnel. Dans les deux cas, vous financez un projet indépendant plutôt qu'un géant de la tech avide de données.",
       },
     ],
     whyNotBoth: {
       title: "Et pourquoi pas les deux ?",
       paragraphs: [
         "Voici ce que la plupart des comparatifs oublient : vous n'êtes pas obligé de choisir. Vous pouvez faire tourner Gladys Assistant et Home Assistant en même temps sur la même installation.",
-        "Avec Zigbee2MQTT, une seule instance Zigbee peut parler à la fois à Gladys et à Home Assistant — le même appareil apparaît dans les deux interfaces. Même chose avec Matter : un appareil Matter associé à un hub (comme une Apple TV) peut être contrôlé depuis les deux. On peut avoir plusieurs contrôleurs en même temps.",
-        "Vous pouvez même utiliser Matterbridge pour exposer tous vos appareils Home Assistant sur un réseau Matter, puis les récupérer dans Gladys — en utilisant Home Assistant comme backend et Gladys comme frontend. Et bien sûr, les deux exposent des API riches, donc ils peuvent communiquer en MQTT ou HTTP.",
-        "Donc si vous aimez l'interface de Gladys mais avez besoin d'une intégration spécifique de Home Assistant, faites tourner les deux côte à côte. Il n'y a vraiment pas d'excuse — tout est possible.",
+        "Avec Zigbee2MQTT, une seule instance Zigbee peut parler à la fois à Gladys et à Home Assistant, donc le même appareil apparaît dans les deux interfaces. Même chose avec Matter : un appareil associé à un hub (comme une Apple TV) peut être contrôlé depuis les deux. On peut avoir plusieurs contrôleurs en même temps.",
+        "Vous pouvez même utiliser Matterbridge pour exposer tous vos appareils Home Assistant sur un réseau Matter, puis les récupérer dans Gladys, en utilisant Home Assistant comme backend et Gladys comme interface. Et bien sûr, les deux exposent des API riches, donc ils peuvent communiquer en MQTT ou HTTP.",
+        "Donc si vous aimez l'interface de Gladys mais avez besoin d'une intégration spécifique de Home Assistant, faites tourner les deux côte à côte. Il n'y a vraiment pas d'excuse : tout est possible.",
       ],
     },
     faqTitle: "Questions fréquentes",
@@ -448,17 +439,17 @@ export const comparisonFaqEn = [
   {
     question: "Is Gladys Assistant a fork of Home Assistant?",
     answer:
-      "No. Gladys is an independent project, created in 2013 — the same year as Home Assistant — but with a completely different stack: Node.js and Preact for Gladys, versus Python and Lit for Home Assistant.",
+      "No. Gladys is an independent project, created in 2013, the same year as Home Assistant, but with a completely different stack: Node.js and Preact for Gladys, versus Python and Lit for Home Assistant.",
   },
   {
     question: "Which is easier for beginners, Gladys or Home Assistant?",
     answer:
-      "Gladys is generally easier for beginners: there are no configuration files and no YAML — everything is configured by clicking in the interface. Home Assistant is more powerful but some parts still require editing YAML.",
+      "Gladys is the easier choice for beginners: there are no configuration files and no YAML, everything is configured by clicking in the interface, and the documentation guides you with videos. Home Assistant is more powerful but has a steeper learning curve.",
   },
   {
-    question: "Does Gladys have as many integrations as Home Assistant?",
+    question: "Will Gladys work with my devices?",
     answer:
-      "No. Gladys has about 35 native integrations focused on open standards (Zigbee, Matter, MQTT), while Home Assistant has 2000+. But 35 native integrations still means thousands of compatible devices through Zigbee and Matter.",
+      "Very likely. Gladys supports thousands of devices through open standards like Zigbee, Matter and MQTT, plus dedicated integrations for popular brands. And with Matterbridge, you can even bring in devices that aren't natively supported yet.",
   },
   {
     question: "Can I run Gladys and Home Assistant at the same time?",
@@ -471,9 +462,9 @@ export const comparisonFaqEn = [
       "Yes. Both are 100% free and open-source at their core. Each offers an optional paid subscription: Gladys Plus for Gladys, and Nabu Casa Cloud for Home Assistant.",
   },
   {
-    question: "Is Home Assistant better than Gladys Assistant?",
+    question: "Should I choose Gladys or Home Assistant?",
     answer:
-      "Neither is objectively better — it depends on your profile. Choose Home Assistant if you're a power user who wants maximum integrations and loves to tinker. Choose Gladys if you want a simple, stable, no-configuration experience.",
+      "If you want a simple, stable smart home that just works, with no YAML and no configuration files, Gladys is the better fit for most people. Choose Home Assistant if you're a power user who wants the largest possible catalog of integrations and loves to tinker.",
   },
 ];
 
@@ -481,17 +472,17 @@ export const comparisonFaqFr = [
   {
     question: "Gladys Assistant est-il un fork de Home Assistant ?",
     answer:
-      "Non. Gladys est un projet indépendant, créé en 2013 — la même année que Home Assistant — mais avec une stack complètement différente : Node.js et Preact pour Gladys, contre Python et Lit pour Home Assistant.",
+      "Non. Gladys est un projet indépendant, créé en 2013, la même année que Home Assistant, mais avec une stack complètement différente : Node.js et Preact pour Gladys, contre Python et Lit pour Home Assistant.",
   },
   {
     question: "Lequel est le plus simple pour un débutant, Gladys ou Home Assistant ?",
     answer:
-      "Gladys est généralement plus simple pour débuter : pas de fichiers de configuration ni de YAML, tout se configure au clic dans l'interface. Home Assistant est plus puissant mais certaines parties demandent encore d'éditer du YAML.",
+      "Gladys est le choix le plus simple pour débuter : pas de fichiers de configuration ni de YAML, tout se configure au clic dans l'interface, et la documentation vous guide avec des vidéos. Home Assistant est plus puissant mais a une courbe d'apprentissage plus raide.",
   },
   {
-    question: "Gladys a-t-il autant d'intégrations que Home Assistant ?",
+    question: "Gladys fonctionnera-t-il avec mes appareils ?",
     answer:
-      "Non. Gladys propose environ 35 intégrations natives centrées sur les standards ouverts (Zigbee, Matter, MQTT), là où Home Assistant en a plus de 2000. Mais 35 intégrations natives, cela représente déjà des milliers d'appareils compatibles via Zigbee et Matter.",
+      "Très probablement. Gladys supporte des milliers d'appareils via les standards ouverts comme Zigbee, Matter et MQTT, ainsi que des intégrations dédiées pour les marques populaires. Et avec Matterbridge, vous pouvez même intégrer des appareils qui ne sont pas encore supportés nativement.",
   },
   {
     question: "Puis-je faire tourner Gladys et Home Assistant en même temps ?",
@@ -504,9 +495,9 @@ export const comparisonFaqFr = [
       "Oui. Les deux sont 100 % gratuits et open source dans leur cœur. Chacun propose un abonnement optionnel : Gladys Plus pour Gladys, et Nabu Casa Cloud pour Home Assistant.",
   },
   {
-    question: "Home Assistant est-il meilleur que Gladys Assistant ?",
+    question: "Faut-il choisir Gladys ou Home Assistant ?",
     answer:
-      "Aucun n'est objectivement meilleur — cela dépend de votre profil. Choisissez Home Assistant si vous êtes un power user qui veut un maximum d'intégrations et aime bidouiller. Choisissez Gladys si vous voulez une expérience simple, stable et sans configuration.",
+      "Si vous voulez une maison connectée simple et stable qui fonctionne, sans YAML ni fichiers de configuration, Gladys est le meilleur choix pour la plupart des gens. Choisissez Home Assistant si vous êtes un power user qui veut le plus grand catalogue d'intégrations possible et aime bidouiller.",
   },
 ];
 

--- a/src/data/structuredData.js
+++ b/src/data/structuredData.js
@@ -1,3 +1,6 @@
+import { comparisonFaqEn, comparisonFaqFr } from "./comparisonData";
+import { alternativeFaqEn, alternativeFaqFr } from "./alternativeData";
+
 const SITE_URL = "https://gladysassistant.com";
 
 const SAME_AS = [
@@ -231,6 +234,82 @@ export function getHomepageSchema(lang) {
         sameAs: SAME_AS,
       },
       toFaqPage(lang === "fr" ? homepageFaqFr : homepageFaqEn, pageUrl),
+    ],
+  };
+}
+
+export function getComparisonPageSchema(lang) {
+  const prefix = lang === "fr" ? "/fr" : "";
+  const pageUrl = `${SITE_URL}${prefix}/home-assistant-vs-gladys-assistant/`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      getOrganizationNode(),
+      getWebSiteNode(lang),
+      {
+        "@type": "Article",
+        "@id": `${pageUrl}#article`,
+        headline:
+          lang === "fr"
+            ? "Home Assistant vs Gladys Assistant : le comparatif honnête"
+            : "Home Assistant vs Gladys Assistant: an honest comparison",
+        description:
+          lang === "fr"
+            ? "Comparatif honnête entre Home Assistant et Gladys Assistant par le créateur de Gladys : installation, simplicité, intégrations, automatisations, communauté et prix."
+            : "An honest comparison between Home Assistant and Gladys Assistant by Gladys' creator: installation, ease of use, integrations, automations, community and pricing.",
+        url: pageUrl,
+        inLanguage: lang === "fr" ? "fr" : "en",
+        isPartOf: { "@id": `${SITE_URL}/#website` },
+        author: {
+          "@type": "Person",
+          name: "Pierre-Gilles Leymarie",
+        },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+        about: [
+          { "@type": "SoftwareApplication", name: "Gladys Assistant" },
+          { "@type": "SoftwareApplication", name: "Home Assistant" },
+        ],
+      },
+      toFaqPage(lang === "fr" ? comparisonFaqFr : comparisonFaqEn, pageUrl),
+    ],
+  };
+}
+
+export function getAlternativePageSchema(lang) {
+  const prefix = lang === "fr" ? "/fr" : "";
+  const pageUrl = `${SITE_URL}${prefix}/home-assistant-alternative/`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      getOrganizationNode(),
+      getWebSiteNode(lang),
+      {
+        "@type": "Article",
+        "@id": `${pageUrl}#article`,
+        headline:
+          lang === "fr"
+            ? "La meilleure alternative à Home Assistant : Gladys Assistant"
+            : "The best Home Assistant alternative: Gladys Assistant",
+        description:
+          lang === "fr"
+            ? "Pourquoi Gladys Assistant est une alternative open source plus simple à Home Assistant : sans YAML, sans cloud, auto-hébergée et stable."
+            : "Why Gladys Assistant is a simpler open-source alternative to Home Assistant: no YAML, no cloud, self-hosted and stable.",
+        url: pageUrl,
+        inLanguage: lang === "fr" ? "fr" : "en",
+        isPartOf: { "@id": `${SITE_URL}/#website` },
+        author: {
+          "@type": "Person",
+          name: "Pierre-Gilles Leymarie",
+        },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+        about: [
+          { "@type": "SoftwareApplication", name: "Gladys Assistant" },
+          { "@type": "SoftwareApplication", name: "Home Assistant" },
+        ],
+      },
+      toFaqPage(lang === "fr" ? alternativeFaqFr : alternativeFaqEn, pageUrl),
     ],
   };
 }

--- a/src/pages/comparison.module.css
+++ b/src/pages/comparison.module.css
@@ -100,6 +100,28 @@
   font-weight: 700;
 }
 
+/* Hero screenshot */
+.screenshot {
+  margin: 1.5rem auto 0;
+  max-width: 52rem;
+}
+
+.screenshot img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 12px;
+  box-shadow: 0 10px 35px rgba(0, 0, 0, 0.15);
+}
+
+.screenshotCaption {
+  text-align: center;
+  margin-top: 0.85rem;
+  font-size: 0.92rem;
+  font-style: italic;
+  color: var(--ifm-color-emphasis-600);
+}
+
 /* Generic card grid (reasons, alternatives) */
 .cardGrid {
   display: grid;

--- a/src/pages/comparison.module.css
+++ b/src/pages/comparison.module.css
@@ -1,0 +1,328 @@
+.main {
+  padding-bottom: 4rem;
+}
+
+.container {
+  max-width: 60rem;
+  margin: 0 auto;
+}
+
+/* Hero */
+.hero {
+  text-align: center;
+  padding: 3rem 0 2rem;
+}
+
+.heroTitle {
+  font-size: 2.6rem;
+  line-height: 1.15;
+  margin-bottom: 0.75rem;
+}
+
+.heroSubtitle {
+  font-size: 1.25rem;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 2rem;
+}
+
+.intro p {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  text-align: left;
+}
+
+@media screen and (max-width: 768px) {
+  .heroTitle {
+    font-size: 2rem;
+  }
+  .heroSubtitle {
+    font-size: 1.1rem;
+  }
+}
+
+/* Sections */
+.section {
+  margin: 3.5rem 0;
+}
+
+.sectionTitle {
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Verdict cards */
+.verdictGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media screen and (max-width: 768px) {
+  .verdictGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.verdictCard {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.verdictCardGladys {
+  border-color: var(--ifm-color-primary);
+}
+
+.verdictCardTitle {
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.verdictList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.verdictList li {
+  position: relative;
+  padding-left: 1.6rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+
+.verdictList li::before {
+  content: "✓";
+  position: absolute;
+  left: 0;
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+}
+
+/* Generic card grid (reasons, alternatives) */
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.25rem;
+}
+
+.card {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.cardIcon {
+  display: block;
+  font-size: 1.7rem;
+  margin-bottom: 0.5rem;
+  line-height: 1;
+}
+
+.cardTitle {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.card p {
+  line-height: 1.55;
+  font-size: 0.97rem;
+  margin: 0;
+}
+
+/* Intro / outro paragraph around a block */
+.blockIntro {
+  font-size: 1.02rem;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
+.blockOutro {
+  font-size: 1.02rem;
+  line-height: 1.6;
+  margin-top: 1.5rem;
+}
+
+/* Neutral bullet list (pain points) */
+.bulletList {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.bulletList li {
+  margin-bottom: 0.6rem;
+  line-height: 1.5;
+}
+
+.compareLink {
+  margin-top: 1.25rem;
+  font-weight: 600;
+}
+
+/* Comparison table */
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--ifm-card-background-color);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+}
+
+.table th,
+.table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  font-size: 0.95rem;
+  vertical-align: top;
+}
+
+.table thead th {
+  background: var(--ifm-color-emphasis-100);
+  font-weight: 600;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table tbody th {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.gladysCol {
+  color: var(--ifm-color-primary);
+}
+
+/* Detailed comparison blocks */
+.compareGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+@media screen and (max-width: 768px) {
+  .compareGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.compareCol {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+.compareColGladys {
+  border-top: 3px solid var(--ifm-color-primary);
+}
+
+.compareColHa {
+  border-top: 3px solid var(--ifm-color-emphasis-400);
+}
+
+.compareColTitle {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.compareCol p {
+  line-height: 1.55;
+  font-size: 0.97rem;
+}
+
+.compareCol p:last-child {
+  margin-bottom: 0;
+}
+
+.takeaway {
+  background: var(--ifm-color-emphasis-100);
+  border-left: 4px solid var(--ifm-color-primary);
+  border-radius: 0 8px 8px 0;
+  padding: 1rem 1.25rem;
+  font-size: 0.97rem;
+  line-height: 1.5;
+}
+
+.takeaway strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+/* Why not both */
+.whyNotBoth {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 12px;
+  padding: 2rem;
+}
+
+.whyNotBoth p {
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+.whyNotBoth p:last-child {
+  margin-bottom: 0;
+}
+
+/* FAQ */
+.faqItem {
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  padding: 1.25rem 0;
+}
+
+.faqItem:last-child {
+  border-bottom: none;
+}
+
+.faqQuestion {
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.faqAnswer {
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-800);
+  margin: 0;
+}
+
+/* CTA */
+.cta {
+  text-align: center;
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 2.5rem 2rem;
+}
+
+.ctaTitle {
+  font-size: 1.6rem;
+  margin-bottom: 0.75rem;
+}
+
+.ctaText {
+  font-size: 1.05rem;
+  color: var(--ifm-color-emphasis-700);
+  max-width: 38rem;
+  margin: 0 auto 1.75rem;
+  line-height: 1.55;
+}
+
+.ctaButtons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/src/pages/home-assistant-alternative.js
+++ b/src/pages/home-assistant-alternative.js
@@ -1,0 +1,166 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+import JsonLd from "../components/seo/JsonLd";
+import { getAlternativePageSchema } from "../data/structuredData";
+import alternativeContent, {
+  alternativeFaqEn,
+  alternativeFaqFr,
+} from "../data/alternativeData";
+
+import styles from "./comparison.module.css";
+
+function Card({ icon, title, text }) {
+  return (
+    <div className={styles.card}>
+      {icon && (
+        <span className={styles.cardIcon} aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      <div className={styles.cardTitle}>{title}</div>
+      <p>{text}</p>
+    </div>
+  );
+}
+
+function AlternativeContent({ content, faq }) {
+  return (
+    <main className={styles.main}>
+      <div className={`container ${styles.container}`}>
+        {/* HERO */}
+        <header className={styles.hero}>
+          <h1 className={styles.heroTitle}>{content.hero.title}</h1>
+          <p className={styles.heroSubtitle}>{content.hero.subtitle}</p>
+          <div className={styles.intro}>
+            {content.hero.intro.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+          </div>
+          <div className={styles.ctaButtons}>
+            <Link
+              className="button button--primary button--lg"
+              to={content.hero.primaryCta.href}
+            >
+              {content.hero.primaryCta.label}
+            </Link>
+            <Link
+              className="button button--secondary button--lg"
+              to={content.hero.secondaryCta.href}
+            >
+              {content.hero.secondaryCta.label}
+            </Link>
+          </div>
+        </header>
+
+        {/* WHY LOOK FOR AN ALTERNATIVE */}
+        <section className={styles.section} aria-labelledby="why-title">
+          <h2 id="why-title" className={styles.sectionTitle}>
+            {content.whyLooking.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.whyLooking.intro}</p>
+          <ul className={styles.bulletList}>
+            {content.whyLooking.points.map((point, i) => (
+              <li key={i}>{point}</li>
+            ))}
+          </ul>
+          <p className={styles.blockOutro}>{content.whyLooking.outro}</p>
+        </section>
+
+        {/* REASONS TO CHOOSE GLADYS */}
+        <section className={styles.section} aria-labelledby="reasons-title">
+          <h2 id="reasons-title" className={styles.sectionTitle}>
+            {content.reasons.title}
+          </h2>
+          <div className={styles.cardGrid}>
+            {content.reasons.cards.map((card, i) => (
+              <Card key={i} {...card} />
+            ))}
+          </div>
+        </section>
+
+        {/* HONEST TRADE-OFFS */}
+        <section className={styles.section} aria-labelledby="honesty-title">
+          <h2 id="honesty-title" className={styles.sectionTitle}>
+            {content.honesty.title}
+          </h2>
+          <div className={styles.whyNotBoth}>
+            {content.honesty.paragraphs.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+            <p className={styles.compareLink}>
+              <Link to={content.honesty.compareLink.href}>
+                {content.honesty.compareLink.label}
+              </Link>
+            </p>
+          </div>
+        </section>
+
+        {/* OTHER ALTERNATIVES */}
+        <section className={styles.section} aria-labelledby="others-title">
+          <h2 id="others-title" className={styles.sectionTitle}>
+            {content.others.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.others.intro}</p>
+          <div className={styles.cardGrid}>
+            {content.others.cards.map((card, i) => (
+              <Card key={i} {...card} />
+            ))}
+          </div>
+          <p className={styles.blockOutro}>{content.others.outro}</p>
+        </section>
+
+        {/* FAQ */}
+        <section className={styles.section} aria-labelledby="faq-title">
+          <h2 id="faq-title" className={styles.sectionTitle}>
+            {content.faqTitle}
+          </h2>
+          {faq.map((item, i) => (
+            <div key={i} className={styles.faqItem}>
+              <h3 className={styles.faqQuestion}>{item.question}</h3>
+              <p className={styles.faqAnswer}>{item.answer}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* CTA */}
+        <section className={styles.cta} aria-labelledby="cta-title">
+          <h2 id="cta-title" className={styles.ctaTitle}>
+            {content.cta.title}
+          </h2>
+          <p className={styles.ctaText}>{content.cta.text}</p>
+          <div className={styles.ctaButtons}>
+            <Link
+              className="button button--primary button--lg"
+              to={content.cta.primary.href}
+            >
+              {content.cta.primary.label}
+            </Link>
+            <Link
+              className="button button--secondary button--lg"
+              to={content.cta.secondary.href}
+            >
+              {content.cta.secondary.label}
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default function AlternativePage() {
+  const { i18n } = useDocusaurusContext();
+  const lang = i18n.currentLocale === "fr" ? "fr" : "en";
+  const content = alternativeContent[lang];
+  const faq = lang === "fr" ? alternativeFaqFr : alternativeFaqEn;
+
+  return (
+    <Layout title={content.meta.title} description={content.meta.description}>
+      <JsonLd data={getAlternativePageSchema(lang)} />
+      <AlternativeContent content={content} faq={faq} />
+    </Layout>
+  );
+}

--- a/src/pages/home-assistant-alternative.js
+++ b/src/pages/home-assistant-alternative.js
@@ -1,6 +1,7 @@
 import React from "react";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 import JsonLd from "../components/seo/JsonLd";
@@ -11,6 +12,44 @@ import alternativeContent, {
 } from "../data/alternativeData";
 
 import styles from "./comparison.module.css";
+
+// Reuses the homepage hero dashboard screenshot (localized, responsive) to
+// break up the text and show off the Gladys interface.
+function GladysScreenshot({ lang }) {
+  const key =
+    lang === "fr"
+      ? "main_screenshot_fr_ncm1yr_c_scale"
+      : "main_screenshot_en_j5czyj_c_scale";
+  const widths =
+    lang === "fr"
+      ? [825, 1090, 1342, 1548, 1951, 2800]
+      : [850, 1142, 1388, 1623, 2022, 2800];
+  const base = `/img/home/main_screenshot/${key}`;
+  const srcSet = widths
+    .map((w) => `${useBaseUrl(`${base},w_${w}.png`)} ${w}w`)
+    .join(", ");
+  const defaultWidth = lang === "fr" ? 1342 : 1388;
+  const alt =
+    lang === "fr"
+      ? "Le tableau de bord de Gladys Assistant"
+      : "The Gladys Assistant dashboard";
+
+  return (
+    <figure className={styles.screenshot}>
+      <img
+        src={useBaseUrl(`${base},w_${defaultWidth}.png`)}
+        srcSet={srcSet}
+        sizes="(max-width: 52rem) 100vw, 52rem"
+        alt={alt}
+      />
+      <figcaption className={styles.screenshotCaption}>
+        {lang === "fr"
+          ? "Une interface épurée où tout se fait au clic, sans aucun fichier de configuration."
+          : "A clean interface where everything happens with clicks, with no configuration files."}
+      </figcaption>
+    </figure>
+  );
+}
 
 function Card({ icon, title, text }) {
   return (
@@ -26,7 +65,7 @@ function Card({ icon, title, text }) {
   );
 }
 
-function AlternativeContent({ content, faq }) {
+function AlternativeContent({ content, faq, lang }) {
   return (
     <main className={styles.main}>
       <div className={`container ${styles.container}`}>
@@ -54,6 +93,9 @@ function AlternativeContent({ content, faq }) {
             </Link>
           </div>
         </header>
+
+        {/* GLADYS SCREENSHOT */}
+        <GladysScreenshot lang={lang} />
 
         {/* WHY LOOK FOR AN ALTERNATIVE */}
         <section className={styles.section} aria-labelledby="why-title">
@@ -160,7 +202,7 @@ export default function AlternativePage() {
   return (
     <Layout title={content.meta.title} description={content.meta.description}>
       <JsonLd data={getAlternativePageSchema(lang)} />
-      <AlternativeContent content={content} faq={faq} />
+      <AlternativeContent content={content} faq={faq} lang={lang} />
     </Layout>
   );
 }

--- a/src/pages/home-assistant-vs-gladys-assistant.js
+++ b/src/pages/home-assistant-vs-gladys-assistant.js
@@ -1,0 +1,197 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+import YoutubeEmbedVideo from "../components/YoutubeEmbedVideo";
+import JsonLd from "../components/seo/JsonLd";
+import { getComparisonPageSchema } from "../data/structuredData";
+import comparisonContent, {
+  comparisonFaqEn,
+  comparisonFaqFr,
+  YOUTUBE_VIDEO_ID,
+} from "../data/comparisonData";
+
+import styles from "./comparison.module.css";
+
+function VerdictCard({ data, isGladys }) {
+  return (
+    <div
+      className={
+        isGladys
+          ? `${styles.verdictCard} ${styles.verdictCardGladys}`
+          : styles.verdictCard
+      }
+    >
+      <h3 className={styles.verdictCardTitle}>{data.title}</h3>
+      <ul className={styles.verdictList}>
+        {data.points.map((point, i) => (
+          <li key={i}>{point}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ComparisonContent({ content, faq, lang }) {
+  return (
+    <main className={styles.main}>
+      <div className={`container ${styles.container}`}>
+        {/* HERO */}
+        <header className={styles.hero}>
+          <h1 className={styles.heroTitle}>{content.hero.title}</h1>
+          <p className={styles.heroSubtitle}>{content.hero.subtitle}</p>
+          <div className={styles.intro}>
+            {content.hero.intro.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+          </div>
+        </header>
+
+        {/* VERDICT */}
+        <section className={styles.section} aria-labelledby="verdict-title">
+          <h2 id="verdict-title" className={styles.sectionTitle}>
+            {content.verdict.title}
+          </h2>
+          <div className={styles.verdictGrid}>
+            <VerdictCard data={content.verdict.gladys} isGladys />
+            <VerdictCard data={content.verdict.ha} />
+          </div>
+        </section>
+
+        {/* QUICK TABLE */}
+        <section className={styles.section} aria-labelledby="table-title">
+          <h2 id="table-title" className={styles.sectionTitle}>
+            {content.tableTitle}
+          </h2>
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th scope="col">{content.tableCols.feature}</th>
+                  <th scope="col" className={styles.gladysCol}>
+                    {content.tableCols.gladys}
+                  </th>
+                  <th scope="col">{content.tableCols.ha}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {content.table.map((row, i) => (
+                  <tr key={i}>
+                    <th scope="row">{row.feature}</th>
+                    <td>{row.gladys}</td>
+                    <td>{row.ha}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* DETAILED SECTIONS */}
+        {content.sections.map((section) => (
+          <section
+            key={section.id}
+            className={styles.section}
+            aria-labelledby={`${section.id}-title`}
+          >
+            <h2 id={`${section.id}-title`} className={styles.sectionTitle}>
+              {section.title}
+            </h2>
+            <div className={styles.compareGrid}>
+              <div className={`${styles.compareCol} ${styles.compareColGladys}`}>
+                <div className={styles.compareColTitle}>Gladys Assistant</div>
+                {section.gladys.map((paragraph, i) => (
+                  <p key={i}>{paragraph}</p>
+                ))}
+              </div>
+              <div className={`${styles.compareCol} ${styles.compareColHa}`}>
+                <div className={styles.compareColTitle}>Home Assistant</div>
+                {section.ha.map((paragraph, i) => (
+                  <p key={i}>{paragraph}</p>
+                ))}
+              </div>
+            </div>
+            <p className={styles.takeaway}>
+              <strong>{lang === "fr" ? "Le verdict" : "The verdict"}</strong>
+              {section.takeaway}
+            </p>
+          </section>
+        ))}
+
+        {/* WHY NOT BOTH */}
+        <section className={styles.section} aria-labelledby="why-not-both-title">
+          <h2 id="why-not-both-title" className={styles.sectionTitle}>
+            {content.whyNotBoth.title}
+          </h2>
+          <div className={styles.whyNotBoth}>
+            {content.whyNotBoth.paragraphs.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+          </div>
+        </section>
+
+        {/* VIDEO (optional) */}
+        {YOUTUBE_VIDEO_ID && (
+          <section className={styles.section} aria-labelledby="video-title">
+            <h2 id="video-title" className={styles.sectionTitle}>
+              {content.videoTitle}
+            </h2>
+            <div style={{ maxWidth: "48rem", margin: "0 auto" }}>
+              <YoutubeEmbedVideo id={YOUTUBE_VIDEO_ID} />
+            </div>
+          </section>
+        )}
+
+        {/* FAQ */}
+        <section className={styles.section} aria-labelledby="faq-title">
+          <h2 id="faq-title" className={styles.sectionTitle}>
+            {content.faqTitle}
+          </h2>
+          {faq.map((item, i) => (
+            <div key={i} className={styles.faqItem}>
+              <h3 className={styles.faqQuestion}>{item.question}</h3>
+              <p className={styles.faqAnswer}>{item.answer}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* CTA */}
+        <section className={styles.cta} aria-labelledby="cta-title">
+          <h2 id="cta-title" className={styles.ctaTitle}>
+            {content.cta.title}
+          </h2>
+          <p className={styles.ctaText}>{content.cta.text}</p>
+          <div className={styles.ctaButtons}>
+            <Link
+              className="button button--primary button--lg"
+              to={content.cta.primary.href}
+            >
+              {content.cta.primary.label}
+            </Link>
+            <Link
+              className="button button--secondary button--lg"
+              to={content.cta.secondary.href}
+            >
+              {content.cta.secondary.label}
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default function ComparisonPage() {
+  const { i18n } = useDocusaurusContext();
+  const lang = i18n.currentLocale === "fr" ? "fr" : "en";
+  const content = comparisonContent[lang];
+  const faq = lang === "fr" ? comparisonFaqFr : comparisonFaqEn;
+
+  return (
+    <Layout title={content.meta.title} description={content.meta.description}>
+      <JsonLd data={getComparisonPageSchema(lang)} />
+      <ComparisonContent content={content} faq={faq} lang={lang} />
+    </Layout>
+  );
+}

--- a/src/pages/home-assistant-vs-gladys-assistant.js
+++ b/src/pages/home-assistant-vs-gladys-assistant.js
@@ -34,6 +34,21 @@ function VerdictCard({ data, isGladys }) {
 }
 
 function ComparisonContent({ content, faq, lang }) {
+  const videoSection = YOUTUBE_VIDEO_ID ? (
+    <section className={styles.section} aria-labelledby="video-title">
+      <h2 id="video-title" className={styles.sectionTitle}>
+        {content.videoTitle}
+      </h2>
+      <div style={{ maxWidth: "48rem", margin: "0 auto" }}>
+        <YoutubeEmbedVideo id={YOUTUBE_VIDEO_ID} />
+      </div>
+    </section>
+  ) : null;
+
+  // The video is in French, so feature it right under the hero on the French
+  // page. On the English page it stays lower (French audio is less useful there).
+  const showVideoAtTop = lang === "fr";
+
   return (
     <main className={styles.main}>
       <div className={`container ${styles.container}`}>
@@ -47,6 +62,9 @@ function ComparisonContent({ content, faq, lang }) {
             ))}
           </div>
         </header>
+
+        {/* VIDEO (top placement on the French page) */}
+        {showVideoAtTop && videoSection}
 
         {/* VERDICT */}
         <section className={styles.section} aria-labelledby="verdict-title">
@@ -131,17 +149,8 @@ function ComparisonContent({ content, faq, lang }) {
           </div>
         </section>
 
-        {/* VIDEO (optional) */}
-        {YOUTUBE_VIDEO_ID && (
-          <section className={styles.section} aria-labelledby="video-title">
-            <h2 id="video-title" className={styles.sectionTitle}>
-              {content.videoTitle}
-            </h2>
-            <div style={{ maxWidth: "48rem", margin: "0 auto" }}>
-              <YoutubeEmbedVideo id={YOUTUBE_VIDEO_ID} />
-            </div>
-          </section>
-        )}
+        {/* VIDEO (lower placement on the English page) */}
+        {!showVideoAtTop && videoSection}
 
         {/* FAQ */}
         <section className={styles.section} aria-labelledby="faq-title">


### PR DESCRIPTION
Two new bilingual (EN + FR) landing pages targeting high-intent search queries the site previously had no content for:

- /home-assistant-vs-gladys-assistant/ — honest head-to-head comparison (installation, UI, integrations, automations, community, pricing) based on the founder's "honest comparison" video, with a "why not both?" section and the embedded YouTube video.
- /home-assistant-alternative/ — persuasive, Gladys-forward page for the "replace/avoid HA" intent; covers other open-source alternatives, stays honest about trade-offs, and links to the full comparison.

Both ship Article + FAQPage JSON-LD, are promoted to priority 0.8 in the sitemap, and are linked from the footer (not the navbar, to avoid giving the competitor visibility in the main nav).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new localized marketing landing pages: “Home Assistant vs Gladys Assistant” and “Home Assistant alternative,” including FAQs, CTAs, and in-page comparison sections.
  * Updated the footer with a new **Compare** column linking to both pages.
* **SEO / Discoverability**
  * Added structured data for the new pages and increased sitemap priority for the promoted comparison/alternative URLs.
* **UI / Styling**
  * Introduced dedicated styles for comparison layouts, tables, verdict cards, FAQ sections, and CTA areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->