### PR TITLE
SEO/GEO: add "DIY home alarm" and "presence simulation" use-case pages (#358)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -166,6 +166,14 @@ module.exports = function createConfig() {
               label: "Reduce your electricity bill",
               to: "home-energy-monitoring/",
             },
+            {
+              label: "DIY home alarm system",
+              to: "diy-home-alarm-system/",
+            },
+            {
+              label: "Presence simulation",
+              to: "presence-simulation/",
+            },
           ],
         },
         {
@@ -307,6 +315,8 @@ module.exports = function createConfig() {
                   path === "/plus/" ||
                   path === "/starter-kit/" ||
                   path === "/ai-smart-home/" ||
+                  path === "/diy-home-alarm-system/" ||
+                  path === "/presence-simulation/" ||
                   path === "/zigbee-vs-matter-vs-zwave/" ||
                   path === "/home-energy-monitoring/" ||
                   path === "/home-assistant-vs-gladys-assistant/" ||

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -154,5 +154,13 @@
   "link.item.label.Reduce your electricity bill": {
     "message": "Réduire sa facture d'électricité",
     "description": "The label of footer link with label=Reduce your electricity bill linking to home-energy-monitoring/"
+  },
+  "link.item.label.DIY home alarm system": {
+    "message": "Alarme maison DIY",
+    "description": "The label of footer link with label=DIY home alarm system linking to diy-home-alarm-system/"
+  },
+  "link.item.label.Presence simulation": {
+    "message": "Simulation de présence",
+    "description": "The label of footer link with label=Presence simulation linking to presence-simulation/"
   }
 }

--- a/src/components/UseCasePage.js
+++ b/src/components/UseCasePage.js
@@ -1,0 +1,214 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
+import JsonLd from "./seo/JsonLd";
+
+import styles from "../pages/comparison.module.css";
+
+// Shared layout for problem-led "use-case" SEO pages (energy savings, DIY alarm,
+// presence simulation, …). Each page provides a locale-keyed `content` object
+// with the same shape, its FAQ list, and the JSON-LD schema for the page. This
+// keeps the individual page files tiny and the pages visually consistent.
+
+// Reuses the homepage hero dashboard screenshot (localized, responsive).
+function GladysScreenshot({ lang, caption }) {
+  const key =
+    lang === "fr"
+      ? "main_screenshot_fr_ncm1yr_c_scale"
+      : "main_screenshot_en_j5czyj_c_scale";
+  const widths =
+    lang === "fr"
+      ? [825, 1090, 1342, 1548, 1951, 2800]
+      : [850, 1142, 1388, 1623, 2022, 2800];
+  const base = `/img/home/main_screenshot/${key}`;
+  const srcSet = widths
+    .map((w) => `${useBaseUrl(`${base},w_${w}.png`)} ${w}w`)
+    .join(", ");
+  const defaultWidth = lang === "fr" ? 1342 : 1388;
+  const alt =
+    lang === "fr"
+      ? "Le tableau de bord de Gladys Assistant"
+      : "The Gladys Assistant dashboard";
+
+  return (
+    <figure className={styles.screenshot}>
+      <img
+        src={useBaseUrl(`${base},w_${defaultWidth}.png`)}
+        srcSet={srcSet}
+        sizes="(max-width: 52rem) 100vw, 52rem"
+        alt={alt}
+      />
+      <figcaption className={styles.screenshotCaption}>{caption}</figcaption>
+    </figure>
+  );
+}
+
+function Card({ icon, title, text }) {
+  return (
+    <div className={styles.card}>
+      {icon && (
+        <span className={styles.cardIcon} aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      <div className={styles.cardTitle}>{title}</div>
+      <p>{text}</p>
+    </div>
+  );
+}
+
+function LinkCard({ label, href, text }) {
+  return (
+    <Link to={href} className={styles.card}>
+      <div className={styles.cardTitle}>{label} →</div>
+      <p>{text}</p>
+    </Link>
+  );
+}
+
+export default function UseCasePage({ content, faq, schemaData, lang }) {
+  return (
+    <Layout title={content.meta.title} description={content.meta.description}>
+      <JsonLd data={schemaData} />
+      <main className={styles.main}>
+        <div className={`container ${styles.container}`}>
+          {/* HERO */}
+          <header className={styles.hero}>
+            <h1 className={styles.heroTitle}>{content.hero.title}</h1>
+            <p className={styles.heroSubtitle}>{content.hero.subtitle}</p>
+            <div className={styles.intro}>
+              {content.hero.intro.map((paragraph, i) => (
+                <p key={i}>{paragraph}</p>
+              ))}
+            </div>
+            <div className={styles.ctaButtons}>
+              <Link
+                className="button button--primary button--lg"
+                to={content.hero.primaryCta.href}
+              >
+                {content.hero.primaryCta.label}
+              </Link>
+              <Link
+                className="button button--secondary button--lg"
+                to={content.hero.secondaryCta.href}
+              >
+                {content.hero.secondaryCta.label}
+              </Link>
+            </div>
+          </header>
+
+          {/* SCREENSHOT */}
+          <GladysScreenshot lang={lang} caption={content.screenshotCaption} />
+
+          {/* THE PROBLEM */}
+          <section className={styles.section} aria-labelledby="problem-title">
+            <h2 id="problem-title" className={styles.sectionTitle}>
+              {content.problem.title}
+            </h2>
+            <p className={styles.blockIntro}>{content.problem.intro}</p>
+            <ul className={styles.bulletList}>
+              {content.problem.points.map((point, i) => (
+                <li key={i}>{point}</li>
+              ))}
+            </ul>
+            <p className={styles.blockOutro}>{content.problem.outro}</p>
+          </section>
+
+          {/* FEATURES */}
+          <section className={styles.section} aria-labelledby="features-title">
+            <h2 id="features-title" className={styles.sectionTitle}>
+              {content.features.title}
+            </h2>
+            <p className={styles.blockIntro}>{content.features.intro}</p>
+            <div className={styles.cardGrid}>
+              {content.features.cards.map((card, i) => (
+                <Card key={i} {...card} />
+              ))}
+            </div>
+          </section>
+
+          {/* HOW IT WORKS */}
+          <section className={styles.section} aria-labelledby="how-title">
+            <h2 id="how-title" className={styles.sectionTitle}>
+              {content.how.title}
+            </h2>
+            <p className={styles.blockIntro}>{content.how.intro}</p>
+            <ul className={styles.bulletList}>
+              {content.how.points.map((point, i) => (
+                <li key={i}>{point}</li>
+              ))}
+            </ul>
+            <p className={styles.blockOutro}>{content.how.outro}</p>
+          </section>
+
+          {/* SOLUTION / GLADYS ANGLE */}
+          <section className={styles.section} aria-labelledby="solution-title">
+            <h2 id="solution-title" className={styles.sectionTitle}>
+              {content.solution.title}
+            </h2>
+            <div className={styles.whyNotBoth}>
+              {content.solution.paragraphs.map((paragraph, i) => (
+                <p key={i}>{paragraph}</p>
+              ))}
+              <p className={styles.compareLink}>
+                <Link to={content.solution.link.href}>
+                  {content.solution.link.label}
+                </Link>
+              </p>
+            </div>
+          </section>
+
+          {/* RELATED / INTERNAL MESH */}
+          <section className={styles.section} aria-labelledby="related-title">
+            <h2 id="related-title" className={styles.sectionTitle}>
+              {content.related.title}
+            </h2>
+            <p className={styles.blockIntro}>{content.related.intro}</p>
+            <div className={styles.cardGrid}>
+              {content.related.links.map((link, i) => (
+                <LinkCard key={i} {...link} />
+              ))}
+            </div>
+          </section>
+
+          {/* FAQ */}
+          <section className={styles.section} aria-labelledby="faq-title">
+            <h2 id="faq-title" className={styles.sectionTitle}>
+              {content.faqTitle}
+            </h2>
+            {faq.map((item, i) => (
+              <div key={i} className={styles.faqItem}>
+                <h3 className={styles.faqQuestion}>{item.question}</h3>
+                <p className={styles.faqAnswer}>{item.answer}</p>
+              </div>
+            ))}
+          </section>
+
+          {/* CTA */}
+          <section className={styles.cta} aria-labelledby="cta-title">
+            <h2 id="cta-title" className={styles.ctaTitle}>
+              {content.cta.title}
+            </h2>
+            <p className={styles.ctaText}>{content.cta.text}</p>
+            <div className={styles.ctaButtons}>
+              <Link
+                className="button button--primary button--lg"
+                to={content.cta.primary.href}
+              >
+                {content.cta.primary.label}
+              </Link>
+              <Link
+                className="button button--secondary button--lg"
+                to={content.cta.secondary.href}
+              >
+                {content.cta.secondary.label}
+              </Link>
+            </div>
+          </section>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/data/alarmSystemData.js
+++ b/src/data/alarmSystemData.js
@@ -1,0 +1,334 @@
+// Content for the "DIY home alarm system" use-case page.
+// Problem-led intent ("build your own home alarm", "DIY alarm system").
+// Leans on Gladys' native alarm mode (armed / partial / panic), arming delay and
+// code, and scene-based intrusion strategies. Angle: ownership, privacy and
+// flexibility, you own a local system that behaves exactly how you design it.
+
+const alarmContent = {
+  en: {
+    meta: {
+      title: "DIY home alarm system: build your own, local and private",
+      description:
+        "Build a real DIY home alarm system with Gladys Assistant: armed, partial and panic modes, motion and door sensors, camera snapshots and instant alerts, all running locally on hardware you own, open-source and with your data kept at home.",
+    },
+    screenshotCaption:
+      "Arm, disarm and monitor your home from Gladys, locally and on your own terms.",
+    hero: {
+      title: "Build your own home alarm system, local and private",
+      subtitle:
+        "A real DIY alarm with motion sensors, door contacts, cameras and instant alerts, running locally on hardware you own.",
+      intro: [
+        "Traditional alarm systems lock you into proprietary hardware, a company's cloud, and rules you can't change. Your home security shouldn't be a black box you rent from someone else.",
+        "With Gladys Assistant you build a real alarm system from affordable, off-the-shelf sensors. It runs locally on your own machine, alerts you instantly, and behaves exactly the way you decide.",
+      ],
+      primaryCta: { label: "Get started free", href: "/docs/" },
+      secondaryCta: {
+        label: "Alarm setup guide →",
+        href: "/docs/dashboard/alarm/",
+      },
+    },
+    problem: {
+      title: "The problem with traditional alarm systems",
+      intro: "Off-the-shelf monitored alarms are convenient, but the trade-offs are steep:",
+      points: [
+        "Proprietary hardware and sensors locked to a single vendor.",
+        "Your security data and camera feeds routed through a company's cloud.",
+        "Rigid scenarios: you get their rules, not yours.",
+        "If the company changes its terms or shuts down, your system can be left useless.",
+        "You never really own the system, you rent it.",
+      ],
+      outro:
+        "A self-hosted alarm flips all of that: your rules, your hardware, your data, kept at home.",
+    },
+    features: {
+      title: "What your Gladys alarm can do",
+      intro: "You get a real alarm system, assembled from simple, affordable parts:",
+      cards: [
+        {
+          icon: "🛡️",
+          title: "Armed, partial & panic modes",
+          text: "Arm the whole house when you leave, use partial mode at night to watch only the outside, or trigger a panic alarm instantly.",
+        },
+        {
+          icon: "🚪",
+          title: "Motion & door sensors",
+          text: "Use affordable Zigbee motion detectors and door/window contacts as triggers, mix and match any brand.",
+        },
+        {
+          icon: "📷",
+          title: "Camera snapshots",
+          text: "On intrusion, have Gladys send you a camera snapshot so you can instantly see what's happening.",
+        },
+        {
+          icon: "📲",
+          title: "Instant alerts",
+          text: "Get notified on Telegram, SMS or other channels the moment something trips while the alarm is armed.",
+        },
+        {
+          icon: "🔢",
+          title: "Keypad & arming delay",
+          text: "Disarm from a wall tablet with a numeric code, and set an arming delay so you can leave before it activates.",
+        },
+        {
+          icon: "🔔",
+          title: "Sirens & deterrents",
+          text: "Sound a siren, flash the lights, or run any scene you like, the response is entirely yours to design.",
+        },
+      ],
+    },
+    how: {
+      title: "How a Gladys alarm works",
+      intro: "You assemble it from simple building blocks, no installer required:",
+      points: [
+        "Add the Alarm widget to your dashboard, with four modes: armed, disarmed, partial and panic.",
+        "Set an alarm code and an arming delay in your house settings.",
+        "Create a scene for arming (notify yourself, flash the lights), and the key one for intrusion.",
+        "The intrusion scene triggers on motion or a door opening, with a condition that the alarm is armed, then sends alerts, a camera snapshot, and sounds a siren.",
+        "Everything runs locally and reacts in real time, even if your internet is down.",
+      ],
+      outro: "Affordable sensors, your own rules, and a system you fully own.",
+    },
+    solution: {
+      title: "Local, private, and truly yours",
+      paragraphs: [
+        "Because Gladys runs on your own machine, your alarm keeps working without the internet, and your sensor data and camera feeds stay on your local network, not on a security company's servers.",
+        "The Gladys core is free and open-source, so you own your whole setup. If you want to check in from afar, optional Gladys Plus adds encrypted remote access and camera streaming, on your terms, without ever handing your data to a third party.",
+      ],
+      link: {
+        label: "Read the full alarm setup guide →",
+        href: "/docs/dashboard/alarm/",
+      },
+    },
+    related: {
+      title: "Go further",
+      intro: "Set it up, or combine it with the rest of your local smart home:",
+      links: [
+        {
+          label: "The alarm setup guide",
+          href: "/docs/dashboard/alarm/",
+          text: "Step by step: modes, arming delay, code and intrusion scenes.",
+        },
+        {
+          label: "Presence simulation",
+          href: "/presence-simulation/",
+          text: "Make your home look occupied while you're away, a perfect companion to your alarm.",
+        },
+        {
+          label: "Control your home with AI",
+          href: "/ai-smart-home/",
+          text: "Let AI check a camera on intrusion and decide whether to alert you.",
+        },
+        {
+          label: "Build a local smart home",
+          href: "/local-smart-home/",
+          text: "The bigger picture: a private, local smart home built on open standards.",
+        },
+      ],
+    },
+    faqTitle: "Frequently asked questions",
+    cta: {
+      title: "Build a home alarm you actually own",
+      text: "Gladys is free, open-source and local-first. Build a real alarm from affordable sensors, running on your own hardware with your data kept at home.",
+      primary: { label: "Get started", href: "/docs/" },
+      secondary: { label: "See the alarm guide", href: "/docs/dashboard/alarm/" },
+    },
+  },
+
+  fr: {
+    meta: {
+      title: "Alarme maison DIY : créez la vôtre, locale et privée",
+      description:
+        "Créez une vraie alarme maison DIY avec Gladys Assistant : modes armé, partiel et panique, détecteurs de mouvement et d'ouverture, photos de caméra et alertes instantanées, le tout en local sur du matériel qui vous appartient, open source et avec vos données gardées chez vous.",
+    },
+    screenshotCaption:
+      "Armez, désarmez et surveillez votre maison depuis Gladys, en local et selon vos règles.",
+    hero: {
+      title: "Créez votre propre alarme maison, locale et privée",
+      subtitle:
+        "Une vraie alarme DIY avec détecteurs de mouvement, contacts d'ouverture, caméras et alertes instantanées, qui tourne en local sur du matériel qui vous appartient.",
+      intro: [
+        "Les systèmes d'alarme classiques vous enferment dans du matériel propriétaire, le cloud d'une entreprise, et des règles que vous ne pouvez pas changer. La sécurité de votre maison ne devrait pas être une boîte noire que vous louez à quelqu'un d'autre.",
+        "Avec Gladys Assistant, vous construisez une vraie alarme à partir de capteurs abordables du commerce. Elle tourne en local sur votre propre machine, vous alerte instantanément, et se comporte exactement comme vous l'avez décidé.",
+      ],
+      primaryCta: { label: "Commencer gratuitement", href: "/docs/" },
+      secondaryCta: {
+        label: "Guide de configuration de l'alarme →",
+        href: "/docs/dashboard/alarm/",
+      },
+    },
+    problem: {
+      title: "Le problème des systèmes d'alarme classiques",
+      intro:
+        "Les alarmes télésurveillées du commerce sont pratiques, mais les compromis sont lourds :",
+      points: [
+        "Du matériel et des capteurs propriétaires, verrouillés sur un seul fournisseur.",
+        "Vos données de sécurité et vos flux de caméra qui transitent par le cloud d'une entreprise.",
+        "Des scénarios rigides : vous avez leurs règles, pas les vôtres.",
+        "Si l'entreprise change ses conditions ou ferme, votre système peut devenir inutilisable.",
+        "Vous ne possédez jamais vraiment le système : vous le louez.",
+      ],
+      outro:
+        "Une alarme auto-hébergée inverse tout cela : vos règles, votre matériel, vos données, gardées chez vous.",
+    },
+    features: {
+      title: "Ce que votre alarme Gladys peut faire",
+      intro: "Vous obtenez une vraie alarme, assemblée à partir de pièces simples et abordables :",
+      cards: [
+        {
+          icon: "🛡️",
+          title: "Modes armé, partiel & panique",
+          text: "Armez toute la maison en partant, utilisez le mode partiel la nuit pour ne surveiller que l'extérieur, ou déclenchez une alarme panique instantanément.",
+        },
+        {
+          icon: "🚪",
+          title: "Détecteurs de mouvement & d'ouverture",
+          text: "Utilisez des détecteurs de mouvement et des contacts de porte/fenêtre Zigbee abordables comme déclencheurs, toutes marques confondues.",
+        },
+        {
+          icon: "📷",
+          title: "Photos de caméra",
+          text: "En cas d'intrusion, faites en sorte que Gladys vous envoie une photo de la caméra pour voir immédiatement ce qui se passe.",
+        },
+        {
+          icon: "📲",
+          title: "Alertes instantanées",
+          text: "Soyez prévenu sur Telegram, par SMS ou d'autres canaux dès que quelque chose se déclenche quand l'alarme est armée.",
+        },
+        {
+          icon: "🔢",
+          title: "Clavier & délai d'armement",
+          text: "Désarmez depuis une tablette murale avec un code numérique, et réglez un délai d'armement pour avoir le temps de sortir.",
+        },
+        {
+          icon: "🔔",
+          title: "Sirènes & dissuasion",
+          text: "Déclenchez une sirène, faites clignoter les lumières, ou lancez n'importe quelle scène : la réponse, c'est vous qui la concevez.",
+        },
+      ],
+    },
+    how: {
+      title: "Comment fonctionne une alarme Gladys",
+      intro: "Vous l'assemblez à partir de briques simples, sans installateur :",
+      points: [
+        "Ajoutez le widget Alarme à votre tableau de bord, avec quatre modes : armé, désarmé, partiel et panique.",
+        "Définissez un code d'alarme et un délai d'armement dans les paramètres de votre maison.",
+        "Créez une scène pour l'armement (vous prévenir, faire clignoter les lumières), et la scène clé : l'intrusion.",
+        "La scène d'intrusion se déclenche sur un mouvement ou une ouverture de porte, avec une condition « alarme armée », puis envoie des alertes, une photo de caméra, et déclenche une sirène.",
+        "Tout tourne en local et réagit en temps réel, même si votre internet est coupé.",
+      ],
+      outro: "Des capteurs abordables, vos propres règles, et un système qui vous appartient entièrement.",
+    },
+    solution: {
+      title: "Locale, privée, et vraiment à vous",
+      paragraphs: [
+        "Comme Gladys tourne sur votre propre machine, votre alarme continue de fonctionner sans internet, et vos données de capteurs et flux de caméra restent sur votre réseau local, pas sur les serveurs d'une société de sécurité.",
+        "Le cœur de Gladys est gratuit et open source : vous possédez l'ensemble de votre installation. Si vous voulez garder un œil à distance, l'option Gladys Plus ajoute l'accès distant chiffré et le streaming caméra, à vos conditions, sans jamais confier vos données à un tiers.",
+      ],
+      link: {
+        label: "Lire le guide complet de configuration de l'alarme →",
+        href: "/docs/dashboard/alarm/",
+      },
+    },
+    related: {
+      title: "Aller plus loin",
+      intro: "Mettez-la en place, ou combinez-la avec le reste de votre maison connectée locale :",
+      links: [
+        {
+          label: "Le guide de configuration de l'alarme",
+          href: "/docs/dashboard/alarm/",
+          text: "Pas à pas : modes, délai d'armement, code et scènes d'intrusion.",
+        },
+        {
+          label: "La simulation de présence",
+          href: "/presence-simulation/",
+          text: "Faites croire que votre maison est occupée pendant votre absence, le compagnon idéal de votre alarme.",
+        },
+        {
+          label: "Contrôler sa maison avec l'IA",
+          href: "/ai-smart-home/",
+          text: "Laissez l'IA vérifier une caméra en cas d'intrusion et décider de vous alerter ou non.",
+        },
+        {
+          label: "Créer une maison connectée locale",
+          href: "/local-smart-home/",
+          text: "La vue d'ensemble : une maison connectée locale et privée bâtie sur des standards ouverts.",
+        },
+      ],
+    },
+    faqTitle: "Questions fréquentes",
+    cta: {
+      title: "Créez une alarme maison qui vous appartient vraiment",
+      text: "Gladys est gratuite, open source et locale d'abord. Construisez une vraie alarme à partir de capteurs abordables, sur votre propre matériel et avec vos données gardées chez vous.",
+      primary: { label: "Commencer", href: "/docs/" },
+      secondary: { label: "Voir le guide de l'alarme", href: "/docs/dashboard/alarm/" },
+    },
+  },
+};
+
+export const alarmFaqEn = [
+  {
+    question: "Can I build my own home alarm system?",
+    answer:
+      "Yes. With Gladys Assistant you build a real alarm system, with armed, partial and panic modes, from off-the-shelf sensors. It runs locally on your own machine, on hardware you own, with no proprietary lock-in.",
+  },
+  {
+    question: "What hardware do I need for a DIY alarm?",
+    answer:
+      "Affordable Zigbee motion detectors and door/window contacts as triggers, optionally a camera and a siren. You can mix and match brands, there's no proprietary kit to buy.",
+  },
+  {
+    question: "Does the alarm work without internet?",
+    answer:
+      "Yes. Gladys runs locally, so the alarm detects intrusions and reacts in real time even if your internet is down. Only remote notifications and remote access need a connection.",
+  },
+  {
+    question: "How does Gladys alert me of an intrusion?",
+    answer:
+      "Through scenes. When a sensor trips while the alarm is armed, Gladys can send you a Telegram or SMS alert and a camera snapshot, sound a siren, flash the lights, or run any other action you design.",
+  },
+  {
+    question: "Is a DIY alarm as good as a professional one?",
+    answer:
+      "A Gladys alarm is very capable and flexible, but it's a system you build and maintain yourself. For many people a well-built local alarm is plenty; if you want professional monitoring too, you can combine both.",
+  },
+  {
+    question: "Is my security data private?",
+    answer:
+      "Yes. Gladys is self-hosted, so your sensor data and camera feeds stay on your local network, with no mandatory cloud and no data resale.",
+  },
+];
+
+export const alarmFaqFr = [
+  {
+    question: "Puis-je créer ma propre alarme maison ?",
+    answer:
+      "Oui. Avec Gladys Assistant, vous construisez une vraie alarme, avec des modes armé, partiel et panique, à partir de capteurs du commerce. Elle tourne en local sur votre propre machine, sur du matériel qui vous appartient, sans verrouillage propriétaire.",
+  },
+  {
+    question: "Quel matériel faut-il pour une alarme DIY ?",
+    answer:
+      "Des détecteurs de mouvement et des contacts de porte/fenêtre Zigbee abordables comme déclencheurs, et en option une caméra et une sirène. Vous pouvez mélanger les marques : aucun kit propriétaire à acheter.",
+  },
+  {
+    question: "L'alarme fonctionne-t-elle sans internet ?",
+    answer:
+      "Oui. Gladys tourne en local : l'alarme détecte les intrusions et réagit en temps réel même si votre internet est coupé. Seules les notifications et l'accès à distance nécessitent une connexion.",
+  },
+  {
+    question: "Comment Gladys m'alerte-t-elle d'une intrusion ?",
+    answer:
+      "Via des scènes. Quand un capteur se déclenche alors que l'alarme est armée, Gladys peut vous envoyer une alerte Telegram ou SMS et une photo de caméra, déclencher une sirène, faire clignoter les lumières, ou lancer n'importe quelle autre action que vous concevez.",
+  },
+  {
+    question: "Une alarme DIY vaut-elle une alarme professionnelle ?",
+    answer:
+      "Une alarme Gladys est très capable et flexible, mais c'est un système que vous construisez et maintenez vous-même. Pour beaucoup de gens, une bonne alarme locale suffit largement ; si vous voulez aussi une télésurveillance professionnelle, vous pouvez combiner les deux.",
+  },
+  {
+    question: "Mes données de sécurité sont-elles privées ?",
+    answer:
+      "Oui. Gladys est auto-hébergée : vos données de capteurs et vos flux de caméra restent sur votre réseau local, sans cloud obligatoire et sans revente de données.",
+  },
+];
+
+export default alarmContent;

--- a/src/data/presenceSimulationData.js
+++ b/src/data/presenceSimulationData.js
@@ -1,0 +1,332 @@
+// Content for the "presence simulation" use-case page.
+// Problem-led intent ("presence simulation", "make my house look occupied").
+// Honest framing: Gladys has no single "presence simulation" button, you build
+// it from scenes (random lights, shutters, scheduled triggers). Pairs naturally
+// with the DIY alarm page. Local, private, free and open-source.
+
+const presenceContent = {
+  en: {
+    meta: {
+      title: "Presence simulation: make your home look occupied while away",
+      description:
+        "Set up presence simulation with Gladys Assistant: randomly turn lights, shutters and TV on and off while you're away to deter burglars, all built from local scenes, free, open-source and private.",
+    },
+    screenshotCaption:
+      "Build presence simulation from scenes in Gladys, running locally on your own machine.",
+    hero: {
+      title: "Presence simulation: make your home look lived-in",
+      subtitle:
+        "Randomly switch lights, shutters and devices while you're away, so an empty house looks occupied, all from local scenes you fully control.",
+      intro: [
+        "An empty home is an easy target. The single most effective, low-cost deterrent against burglary is making the house look occupied while you're away.",
+        "With Gladys Assistant you build presence simulation from scenes: lights and shutters that turn on and off at believable times, even at random, running locally on your own machine, free and open-source.",
+      ],
+      primaryCta: { label: "Get started free", href: "/docs/" },
+      secondaryCta: {
+        label: "Learn about scenes →",
+        href: "/docs/scenes/intro/",
+      },
+    },
+    problem: {
+      title: "Why an empty home is a target",
+      intro: "Burglars look for homes that are clearly unoccupied. The classic tells are easy to spot:",
+      points: [
+        "Lights that stay off every single evening while you're on holiday.",
+        "Shutters or blinds that never move for days on end.",
+        "No sign of life: no TV glow, no changing patterns, nothing.",
+        "A predictable, dark, static house, exactly what an opportunist is hoping for.",
+      ],
+      outro:
+        "Presence simulation removes those tells by recreating the small, irregular signs that someone is home.",
+    },
+    features: {
+      title: "What presence simulation can do",
+      intro: "You decide how lived-in your home should look, with simple scenes you fully control:",
+      cards: [
+        {
+          icon: "💡",
+          title: "Random light cycles",
+          text: "Turn lights on and off in different rooms at varying, believable times in the evening, not on an obvious fixed schedule.",
+        },
+        {
+          icon: "🪟",
+          title: "Shutters & blinds",
+          text: "Open and close motorized shutters in the morning and evening so the outside of the house behaves as if someone's there.",
+        },
+        {
+          icon: "🌅",
+          title: "Sunset-aware timing",
+          text: "Trigger scenes relative to local sunset and sunrise, so the simulation tracks the seasons automatically.",
+        },
+        {
+          icon: "📺",
+          title: "TV & ambient devices",
+          text: "Switch on a TV, a smart speaker or a lamp behind the curtains to add a convincing glow and sound of life.",
+        },
+        {
+          icon: "🎲",
+          title: "Randomized patterns",
+          text: "Add randomness to timing and which rooms light up, so the pattern never looks automated from the street.",
+        },
+        {
+          icon: "🗓️",
+          title: "Only when you're away",
+          text: "Tie the whole thing to a 'house empty' state, so simulation runs only when nobody is actually home.",
+        },
+      ],
+    },
+    how: {
+      title: "How to build presence simulation in Gladys",
+      intro: "There's no single button for it, you assemble it from scenes, which is exactly what makes it flexible:",
+      points: [
+        "Create a 'house empty' condition based on presence (phones off the network, or a manual 'away' switch).",
+        "Build a scene that turns a light on, waits a random delay, then turns it off, and repeats across a few rooms.",
+        "Schedule scenes to run in the evening, relative to sunset, only while the house is empty.",
+        "Add shutters opening in the morning and closing at night to complete the illusion.",
+        "Everything runs locally on your machine and keeps working even if your internet drops.",
+      ],
+      outro: "Your rules, your timing, your home, with no schedule living in someone else's cloud.",
+    },
+    solution: {
+      title: "Local, private, and free to run",
+      paragraphs: [
+        "Because Gladys runs on your own machine, your presence simulation keeps working without the internet, and nobody outside your home knows your schedule or when you're away.",
+        "The Gladys core is free and open-source, so presence simulation costs nothing beyond the devices you already own. It pairs perfectly with a DIY alarm: simulation deters, the alarm reacts.",
+      ],
+      link: {
+        label: "Learn how scenes work →",
+        href: "/docs/scenes/intro/",
+      },
+    },
+    related: {
+      title: "Go further",
+      intro: "Combine presence simulation with the rest of your local smart home:",
+      links: [
+        {
+          label: "DIY home alarm system",
+          href: "/diy-home-alarm-system/",
+          text: "The natural companion: simulation deters, a local alarm detects and alerts.",
+        },
+        {
+          label: "How scenes work",
+          href: "/docs/scenes/intro/",
+          text: "The building blocks: triggers, conditions, actions and randomness.",
+        },
+        {
+          label: "Control your home with AI",
+          href: "/ai-smart-home/",
+          text: "Let AI make your automations smarter and more natural over time.",
+        },
+        {
+          label: "Build a local smart home",
+          href: "/local-smart-home/",
+          text: "The bigger picture: a private, local smart home built on open standards.",
+        },
+      ],
+    },
+    faqTitle: "Frequently asked questions",
+    cta: {
+      title: "Make your home look lived-in while you're away",
+      text: "Gladys is free, open-source and local-first. Build presence simulation from scenes, free and open-source, with your schedule kept private.",
+      primary: { label: "Get started", href: "/docs/" },
+      secondary: { label: "Learn about scenes", href: "/docs/scenes/intro/" },
+    },
+  },
+
+  fr: {
+    meta: {
+      title: "Simulation de présence : faites croire que votre maison est occupée",
+      description:
+        "Mettez en place une simulation de présence avec Gladys Assistant : allumez et éteignez aléatoirement lumières, volets et TV pendant votre absence pour dissuader les cambrioleurs, le tout avec des scènes locales, gratuites, open source et privées.",
+    },
+    screenshotCaption:
+      "Construisez la simulation de présence à partir de scènes dans Gladys, en local sur votre propre machine.",
+    hero: {
+      title: "Simulation de présence : donnez l'impression d'une maison habitée",
+      subtitle:
+        "Allumez et éteignez aléatoirement lumières, volets et appareils pendant votre absence, pour qu'une maison vide paraisse occupée, le tout avec des scènes locales que vous maîtrisez entièrement.",
+      intro: [
+        "Une maison vide est une cible facile. Le moyen de dissuasion le plus efficace et le moins coûteux contre les cambriolages, c'est de faire croire que la maison est occupée pendant votre absence.",
+        "Avec Gladys Assistant, vous construisez la simulation de présence à partir de scènes : des lumières et des volets qui s'allument et s'éteignent à des heures crédibles, voire aléatoires, en local sur votre propre machine, gratuitement et en open source.",
+      ],
+      primaryCta: { label: "Commencer gratuitement", href: "/docs/" },
+      secondaryCta: {
+        label: "Découvrir les scènes →",
+        href: "/docs/scenes/intro/",
+      },
+    },
+    problem: {
+      title: "Pourquoi une maison vide est une cible",
+      intro:
+        "Les cambrioleurs repèrent les maisons clairement inoccupées. Les signes classiques sont faciles à repérer :",
+      points: [
+        "Des lumières qui restent éteintes tous les soirs pendant vos vacances.",
+        "Des volets ou des stores qui ne bougent pas pendant des jours.",
+        "Aucun signe de vie : pas de lueur de télé, aucun changement, rien.",
+        "Une maison prévisible, sombre et figée : exactement ce qu'un opportuniste espère.",
+      ],
+      outro:
+        "La simulation de présence supprime ces signes en recréant les petits indices irréguliers qui montrent que quelqu'un est là.",
+    },
+    features: {
+      title: "Ce que la simulation de présence peut faire",
+      intro: "Vous décidez à quel point votre maison doit paraître habitée, avec des scènes simples que vous maîtrisez totalement :",
+      cards: [
+        {
+          icon: "💡",
+          title: "Cycles de lumière aléatoires",
+          text: "Allumez et éteignez les lumières de différentes pièces à des heures variables et crédibles le soir, pas selon un horaire fixe évident.",
+        },
+        {
+          icon: "🪟",
+          title: "Volets & stores",
+          text: "Ouvrez et fermez les volets motorisés le matin et le soir pour que l'extérieur de la maison se comporte comme si quelqu'un était là.",
+        },
+        {
+          icon: "🌅",
+          title: "Horaires liés au coucher du soleil",
+          text: "Déclenchez les scènes par rapport au lever et au coucher du soleil locaux, pour que la simulation suive automatiquement les saisons.",
+        },
+        {
+          icon: "📺",
+          title: "TV & appareils d'ambiance",
+          text: "Allumez une télé, une enceinte connectée ou une lampe derrière les rideaux pour ajouter une lueur et des sons de vie convaincants.",
+        },
+        {
+          icon: "🎲",
+          title: "Schémas aléatoires",
+          text: "Ajoutez de l'aléatoire dans les horaires et les pièces allumées, pour que le schéma ne paraisse jamais automatisé depuis la rue.",
+        },
+        {
+          icon: "🗓️",
+          title: "Uniquement en votre absence",
+          text: "Reliez le tout à un état « maison vide », pour que la simulation ne tourne que lorsque personne n'est réellement là.",
+        },
+      ],
+    },
+    how: {
+      title: "Comment construire une simulation de présence dans Gladys",
+      intro: "Il n'y a pas de bouton unique : vous l'assemblez à partir de scènes, et c'est justement ce qui la rend flexible :",
+      points: [
+        "Créez une condition « maison vide » basée sur la présence (téléphones absents du réseau, ou un interrupteur « absent » manuel).",
+        "Construisez une scène qui allume une lumière, attend un délai aléatoire, puis l'éteint, et répétez sur plusieurs pièces.",
+        "Programmez les scènes pour qu'elles tournent le soir, par rapport au coucher du soleil, uniquement quand la maison est vide.",
+        "Ajoutez l'ouverture des volets le matin et leur fermeture le soir pour compléter l'illusion.",
+        "Tout tourne en local sur votre machine et continue de fonctionner même si votre internet est coupé.",
+      ],
+      outro: "Vos règles, vos horaires, votre maison : sans planning hébergé dans le cloud de quelqu'un d'autre.",
+    },
+    solution: {
+      title: "Locale, privée, et gratuite à faire tourner",
+      paragraphs: [
+        "Comme Gladys tourne sur votre propre machine, votre simulation de présence continue de fonctionner sans internet, et personne en dehors de chez vous ne connaît votre planning ni vos moments d'absence.",
+        "Le cœur de Gladys est gratuit et open source : la simulation de présence ne coûte rien au-delà des appareils que vous possédez déjà. Elle se marie parfaitement avec une alarme DIY : la simulation dissuade, l'alarme réagit.",
+      ],
+      link: {
+        label: "Comprendre le fonctionnement des scènes →",
+        href: "/docs/scenes/intro/",
+      },
+    },
+    related: {
+      title: "Aller plus loin",
+      intro: "Combinez la simulation de présence avec le reste de votre maison connectée locale :",
+      links: [
+        {
+          label: "Alarme maison DIY",
+          href: "/diy-home-alarm-system/",
+          text: "Le compagnon naturel : la simulation dissuade, l'alarme locale détecte et alerte.",
+        },
+        {
+          label: "Comment fonctionnent les scènes",
+          href: "/docs/scenes/intro/",
+          text: "Les briques de base : déclencheurs, conditions, actions et aléatoire.",
+        },
+        {
+          label: "Contrôler sa maison avec l'IA",
+          href: "/ai-smart-home/",
+          text: "Laissez l'IA rendre vos automatisations plus intelligentes et naturelles au fil du temps.",
+        },
+        {
+          label: "Créer une maison connectée locale",
+          href: "/local-smart-home/",
+          text: "La vue d'ensemble : une maison connectée locale et privée bâtie sur des standards ouverts.",
+        },
+      ],
+    },
+    faqTitle: "Questions fréquentes",
+    cta: {
+      title: "Faites croire que votre maison est habitée pendant votre absence",
+      text: "Gladys est gratuite, open source et locale d'abord. Construisez une simulation de présence à partir de scènes, gratuitement et en open source, avec votre planning gardé privé.",
+      primary: { label: "Commencer", href: "/docs/" },
+      secondary: { label: "Découvrir les scènes", href: "/docs/scenes/intro/" },
+    },
+  },
+};
+
+export const presenceFaqEn = [
+  {
+    question: "What is presence simulation?",
+    answer:
+      "Presence simulation makes an empty home look occupied by automatically turning lights, shutters and other devices on and off at believable times. It's one of the cheapest, most effective deterrents against burglary while you're away.",
+  },
+  {
+    question: "Does Gladys have a presence simulation feature?",
+    answer:
+      "Gladys doesn't have a single dedicated button, you build presence simulation from scenes. That's what makes it powerful: you control exactly which devices act, when, and how randomly, instead of a fixed canned mode.",
+  },
+  {
+    question: "How do I make the simulation look realistic?",
+    answer:
+      "Use random delays and vary which rooms light up, trigger scenes relative to sunset, and move shutters in the morning and evening. Irregular, sunset-aware patterns look far more convincing than a fixed daily schedule.",
+  },
+  {
+    question: "Does presence simulation work without internet?",
+    answer:
+      "Yes. Gladys runs locally, so your scenes keep firing even if your internet connection drops, and your schedule never leaves your home.",
+  },
+  {
+    question: "Can I run simulation only when I'm away?",
+    answer:
+      "Yes. Tie your scenes to a 'house empty' state, based on phone presence on the network or a manual 'away' switch, so the simulation runs only when nobody is actually home.",
+  },
+  {
+    question: "Does it cost anything?",
+    answer:
+      "No. The Gladys core is free and open-source, and presence simulation uses devices you already own, so there's nothing extra to pay.",
+  },
+];
+
+export const presenceFaqFr = [
+  {
+    question: "Qu'est-ce que la simulation de présence ?",
+    answer:
+      "La simulation de présence fait paraître une maison vide occupée en allumant et éteignant automatiquement lumières, volets et autres appareils à des heures crédibles. C'est l'un des moyens de dissuasion les plus économiques et efficaces contre les cambriolages pendant votre absence.",
+  },
+  {
+    question: "Gladys a-t-elle une fonction de simulation de présence ?",
+    answer:
+      "Gladys n'a pas de bouton dédié unique : vous construisez la simulation de présence à partir de scènes. C'est ce qui la rend puissante : vous contrôlez exactement quels appareils agissent, quand, et avec quelle part d'aléatoire, au lieu d'un mode figé.",
+  },
+  {
+    question: "Comment rendre la simulation réaliste ?",
+    answer:
+      "Utilisez des délais aléatoires et variez les pièces allumées, déclenchez les scènes par rapport au coucher du soleil, et bougez les volets le matin et le soir. Des schémas irréguliers et calés sur le soleil paraissent bien plus convaincants qu'un horaire quotidien fixe.",
+  },
+  {
+    question: "La simulation de présence fonctionne-t-elle sans internet ?",
+    answer:
+      "Oui. Gladys tourne en local : vos scènes continuent de se déclencher même si votre connexion internet est coupée, et votre planning ne quitte jamais votre domicile.",
+  },
+  {
+    question: "Puis-je lancer la simulation uniquement quand je suis absent ?",
+    answer:
+      "Oui. Reliez vos scènes à un état « maison vide », basé sur la présence des téléphones sur le réseau ou un interrupteur « absent » manuel, pour que la simulation ne tourne que lorsque personne n'est réellement là.",
+  },
+  {
+    question: "Est-ce que ça coûte quelque chose ?",
+    answer:
+      "Non. Le cœur de Gladys est gratuit et open source, et la simulation de présence utilise des appareils que vous possédez déjà : rien de plus à payer.",
+  },
+];
+
+export default presenceContent;

--- a/src/data/structuredData.js
+++ b/src/data/structuredData.js
@@ -23,6 +23,8 @@ import {
 import { aiSmartHomeFaqEn, aiSmartHomeFaqFr } from "./aiSmartHomeData";
 import { protocolsFaqEn, protocolsFaqFr } from "./protocolsComparisonData";
 import { energyFaqEn, energyFaqFr } from "./energyMonitoringData";
+import { alarmFaqEn, alarmFaqFr } from "./alarmSystemData";
+import { presenceFaqEn, presenceFaqFr } from "./presenceSimulationData";
 
 const SITE_URL = "https://gladysassistant.com";
 
@@ -658,6 +660,84 @@ export function getEnergyMonitoringPageSchema(lang) {
         ],
       },
       toFaqPage(lang === "fr" ? energyFaqFr : energyFaqEn, pageUrl),
+    ],
+  };
+}
+
+export function getAlarmSystemPageSchema(lang) {
+  const prefix = lang === "fr" ? "/fr" : "";
+  const pageUrl = `${SITE_URL}${prefix}/diy-home-alarm-system/`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      getOrganizationNode(),
+      getWebSiteNode(lang),
+      {
+        "@type": "Article",
+        "@id": `${pageUrl}#article`,
+        headline:
+          lang === "fr"
+            ? "Alarme maison DIY : créez la vôtre, locale et privée"
+            : "DIY home alarm system: build your own, local and private",
+        description:
+          lang === "fr"
+            ? "Créez une vraie alarme maison DIY avec Gladys : modes armé, partiel et panique, détecteurs de mouvement et d'ouverture, photos de caméra et alertes instantanées, en local sur du matériel qui vous appartient et avec vos données gardées chez vous."
+            : "Build a real DIY home alarm system with Gladys: armed, partial and panic modes, motion and door sensors, camera snapshots and instant alerts, all running locally on hardware you own with your data kept at home.",
+        url: pageUrl,
+        inLanguage: lang === "fr" ? "fr" : "en",
+        isPartOf: { "@id": `${SITE_URL}/#website` },
+        author: {
+          "@type": "Person",
+          name: "Pierre-Gilles Leymarie",
+        },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+        about: [
+          { "@type": "Thing", name: "DIY home alarm system" },
+          { "@type": "Thing", name: "Local private home security" },
+          { "@type": "SoftwareApplication", name: "Gladys Assistant" },
+        ],
+      },
+      toFaqPage(lang === "fr" ? alarmFaqFr : alarmFaqEn, pageUrl),
+    ],
+  };
+}
+
+export function getPresenceSimulationPageSchema(lang) {
+  const prefix = lang === "fr" ? "/fr" : "";
+  const pageUrl = `${SITE_URL}${prefix}/presence-simulation/`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      getOrganizationNode(),
+      getWebSiteNode(lang),
+      {
+        "@type": "Article",
+        "@id": `${pageUrl}#article`,
+        headline:
+          lang === "fr"
+            ? "Simulation de présence : faites croire que votre maison est occupée"
+            : "Presence simulation: make your home look occupied while away",
+        description:
+          lang === "fr"
+            ? "Mettez en place une simulation de présence avec Gladys : allumez et éteignez aléatoirement lumières, volets et TV pendant votre absence pour dissuader les cambrioleurs, avec des scènes locales, gratuites et privées."
+            : "Set up presence simulation with Gladys: randomly turn lights, shutters and TV on and off while you're away to deter burglars, all built from local scenes, free and private.",
+        url: pageUrl,
+        inLanguage: lang === "fr" ? "fr" : "en",
+        isPartOf: { "@id": `${SITE_URL}/#website` },
+        author: {
+          "@type": "Person",
+          name: "Pierre-Gilles Leymarie",
+        },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+        about: [
+          { "@type": "Thing", name: "Presence simulation" },
+          { "@type": "Thing", name: "Burglary deterrence" },
+          { "@type": "SoftwareApplication", name: "Gladys Assistant" },
+        ],
+      },
+      toFaqPage(lang === "fr" ? presenceFaqFr : presenceFaqEn, pageUrl),
     ],
   };
 }

--- a/src/pages/diy-home-alarm-system.js
+++ b/src/pages/diy-home-alarm-system.js
@@ -1,0 +1,22 @@
+import React from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+import UseCasePage from "../components/UseCasePage";
+import { getAlarmSystemPageSchema } from "../data/structuredData";
+import alarmContent, { alarmFaqEn, alarmFaqFr } from "../data/alarmSystemData";
+
+export default function DiyHomeAlarmSystemPage() {
+  const { i18n } = useDocusaurusContext();
+  const lang = i18n.currentLocale === "fr" ? "fr" : "en";
+  const content = alarmContent[lang];
+  const faq = lang === "fr" ? alarmFaqFr : alarmFaqEn;
+
+  return (
+    <UseCasePage
+      content={content}
+      faq={faq}
+      schemaData={getAlarmSystemPageSchema(lang)}
+      lang={lang}
+    />
+  );
+}

--- a/src/pages/presence-simulation.js
+++ b/src/pages/presence-simulation.js
@@ -1,0 +1,25 @@
+import React from "react";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+import UseCasePage from "../components/UseCasePage";
+import { getPresenceSimulationPageSchema } from "../data/structuredData";
+import presenceContent, {
+  presenceFaqEn,
+  presenceFaqFr,
+} from "../data/presenceSimulationData";
+
+export default function PresenceSimulationPage() {
+  const { i18n } = useDocusaurusContext();
+  const lang = i18n.currentLocale === "fr" ? "fr" : "en";
+  const content = presenceContent[lang];
+  const faq = lang === "fr" ? presenceFaqFr : presenceFaqEn;
+
+  return (
+    <UseCasePage
+      content={content}
+      faq={faq}
+      schemaData={getPresenceSimulationPageSchema(lang)}
+      lang={lang}
+    />
+  );
+}


### PR DESCRIPTION
Two problem-led use-case landing pages built on a shared UseCasePage component:

- /diy-home-alarm-system/ — build a real alarm (armed/partial/panic, motion & door sensors, camera snapshots, instant alerts, keypad, sirens) with no subscription, local and open-source.
- /presence-simulation/ — make an empty home look occupied via scenes (random lights, shutters, sunset-aware timing), honest "built from scenes" framing.

Both pages: EN + FR content, Article + FAQPage JSON-LD, footer Guides links, sitemap priority 0.8, and internal mesh (the two cross-link, plus links to the alarm/scenes docs, AI and local pillars).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new public landing pages for DIY home alarm systems and presence simulation, with localized content in English and French.
  * Expanded the footer with direct links to both new pages.
  * Added structured data and FAQ content to improve how these pages appear in search results.

* **Bug Fixes**
  * Updated sitemap priority handling so the new pages are treated as promoted pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->