### PR TITLE
SEO: fix Google merchant-listing warnings on the Gladys Plus page

### DIFF
--- a/src/data/structuredData.js
+++ b/src/data/structuredData.js
@@ -752,14 +752,28 @@ export function getPlusPageSchema(lang) {
       getOrganizationNode(),
       getWebSiteNode(lang),
       {
-        "@type": "Product",
-        "@id": `${pageUrl}#product`,
+        // Gladys Plus is a digital subscription, not a shippable retail
+        // product. We model it as a Service (with priced Offers) rather than a
+        // Product, so Google doesn't treat it as a merchant/shopping listing
+        // and require shipping & return-policy fields that don't apply.
+        "@type": "Service",
+        "@id": `${pageUrl}#service`,
         name: "Gladys Plus",
+        serviceType:
+          lang === "fr"
+            ? "Abonnement domotique"
+            : "Home automation subscription",
         description:
           lang === "fr"
             ? "Abonnement optionnel pour Gladys Assistant : accès distant chiffré, sauvegardes, IA, Enedis et serveur MCP."
             : "Optional subscription for Gladys Assistant: encrypted remote access, backups, AI, Enedis, and MCP server.",
-        brand: { "@id": `${SITE_URL}/#organization` },
+        image: [
+          `${SITE_URL}/img/presentation/gladys-assistant-og-image-2026-${
+            lang === "fr" ? "fr" : "en"
+          }.jpg`,
+        ],
+        brand: { "@type": "Brand", name: "Gladys Assistant" },
+        provider: { "@id": `${SITE_URL}/#organization` },
         offers: [
           {
             "@type": "Offer",


### PR DESCRIPTION
Google Search Console flagged the Gladys Plus page for merchant-listing structured-data issues (missing image, missing shippingDetails and hasMerchantReturnPolicy in offers, invalid brand type). These came from typing the page's JSON-LD as a Product, which Google treats as a shopping/merchant listing and expects e-commerce fields for.

Gladys Plus is a digital subscription, not a shippable retail product, so model it as a Service (keeping the priced Offers) instead of a Product. This removes the shipping/return requirements entirely. Also add an image and fix brand to a proper Brand object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Gladys Plus structured data to better match the page content and improve how it’s interpreted by search engines.
  * Added richer localized details, including service type, images, and organization information, while keeping pricing information unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->