### PR TITLE
SEO: optimize Somfy/TaHoma doc for the "Somfy Matter" query cluster

### DIFF
--- a/docs/integrations/somfy-tahoma.md
+++ b/docs/integrations/somfy-tahoma.md
@@ -1,9 +1,17 @@
 ---
 id: somfy-tahoma
-title: Integrating Somfy devices with Gladys via Matterbridge
-description: "Integrate Somfy TaHoma devices into Gladys Assistant via Matterbridge to control your roller shutters, blinds and openings over Matter."
+title: "Somfy and Matter: control your TaHoma devices in Gladys"
+description: "How to make your Somfy TaHoma, TaHoma Switch and Connexoon devices work with Matter in Gladys Assistant, and control your roller shutters, blinds and openings via Matterbridge."
 sidebar_label: Somfy
+keywords:
+  - somfy matter
+  - tahoma matter
+  - tahoma switch matter
+  - somfy tahoma matter
+  - somfy io matter
 ---
+
+import JsonLd from '@site/src/components/seo/JsonLd';
 
 Somfy is a French industrial group specializing in motorization, automation of home and building openings, as well as in the connected home.
 
@@ -20,6 +28,12 @@ Thanks to the open-source project [Matterbridge](https://github.com/luligu/matte
 This is what we will do for Somfy devices.
 
 This step-by-step guide will explain how to expose and control your Somfy roller shutters, blinds, and other openings.
+
+## Is Somfy compatible with Matter?
+
+Somfy devices (io-homecontrol® and RTS) are **not natively exposed over Matter** to third-party controllers: there is no built-in Matter bridge in the **TaHoma**, **TaHoma Switch** or **Connexoon** boxes today, and control still goes through the Somfy cloud.
+
+The good news is that you don't have to wait for Somfy. Using the open-source [Matterbridge](https://github.com/luligu/matterbridge) project, Gladys turns your Somfy **TaHoma**, **TaHoma Switch** and **Connexoon** devices into Matter devices, so you can control your roller shutters, blinds, awnings and other openings directly from Gladys Assistant. The rest of this guide shows you how, step by step.
 
 ### Prerequisites
 
@@ -130,3 +144,74 @@ Thanks to the **Matter** standard and the **Matterbridge** project which make th
 
 - [Integrating Matter devices in Gladys Assistant](/docs/integrations/matter/)
 - [Matterbridge GitHub Repository](https://github.com/luligu/matterbridge)
+
+## Frequently asked questions
+
+### Is Somfy compatible with Matter?
+
+Somfy boxes don't natively expose your io-homecontrol® and RTS devices over Matter to third-party controllers. There is no built-in Matter bridge in the TaHoma, TaHoma Switch or Connexoon. However, you can make them Matter-compatible with the open-source Matterbridge project and control them in Gladys Assistant.
+
+### Is the Somfy TaHoma Switch compatible with Matter?
+
+The TaHoma Switch doesn't act as a native Matter bridge for your io and RTS devices. Using Matterbridge and the `matterbridge-somfy-tahoma` plugin, Gladys can still expose your TaHoma Switch devices over Matter and control them.
+
+### Do I need the Somfy cloud and an internet connection?
+
+Yes, for now. The Matterbridge Somfy/TaHoma plugin communicates with the Somfy cloud, so an active internet connection and a valid Somfy account are required. Support for the Somfy box local API is in development and will eventually allow fully local control.
+
+### Which Somfy devices can I control in Gladys?
+
+Once bridged through Matter, you can control your roller shutters, blinds, awnings and other openings managed by your Somfy box (Connexoon, TaHoma or TaHoma Switch) over the io-homecontrol® and RTS protocols.
+
+### Can I see the position (%) of my shutters?
+
+Matterbridge controls openings autonomously and doesn't query the Somfy servers for the current position when devices are operated from their remote controls or the TaHoma mobile app. Retrieving live positions is being investigated.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Is Somfy compatible with Matter?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Somfy boxes don't natively expose your io-homecontrol and RTS devices over Matter to third-party controllers: there is no built-in Matter bridge in the TaHoma, TaHoma Switch or Connexoon. However, you can make them Matter-compatible with the open-source Matterbridge project and control them in Gladys Assistant.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Is the Somfy TaHoma Switch compatible with Matter?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "The TaHoma Switch doesn't act as a native Matter bridge for your io and RTS devices. Using Matterbridge and the matterbridge-somfy-tahoma plugin, Gladys can still expose your TaHoma Switch devices over Matter and control them.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Do I need the Somfy cloud and an internet connection?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes, for now. The Matterbridge Somfy/TaHoma plugin communicates with the Somfy cloud, so an active internet connection and a valid Somfy account are required. Support for the Somfy box local API is in development and will eventually allow fully local control.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Which Somfy devices can I control in Gladys?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Once bridged through Matter, you can control your roller shutters, blinds, awnings and other openings managed by your Somfy box (Connexoon, TaHoma or TaHoma Switch) over the io-homecontrol and RTS protocols.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I see the position (%) of my Somfy shutters in Gladys?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Matterbridge controls openings autonomously and doesn't query the Somfy servers for the current position when devices are operated from their remote controls or the TaHoma mobile app. Retrieving live positions is being investigated.",
+        },
+      },
+    ],
+  }}
+/>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/somfy-tahoma.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/somfy-tahoma.md
@@ -1,9 +1,17 @@
 ---
 id: somfy-tahoma
-title: Intégrer ses équipements Somfy à Gladys via Matterbridge
-description: "Intégrez vos appareils Somfy TaHoma dans Gladys Assistant via Matterbridge pour piloter vos volets roulants, stores et ouvertures en Matter."
+title: "Somfy et Matter : piloter ses volets TaHoma dans Gladys"
+description: "Comment rendre vos appareils Somfy TaHoma, TaHoma Switch et Connexoon compatibles Matter dans Gladys Assistant, et piloter vos volets roulants, stores et ouvertures via Matterbridge."
 sidebar_label: Somfy
+keywords:
+  - somfy matter
+  - tahoma matter
+  - tahoma switch matter
+  - somfy tahoma matter
+  - somfy io matter
 ---
+
+import JsonLd from '@site/src/components/seo/JsonLd';
 
 Somfy est un groupe industriel français, spécialisé dans la motorisation, l'automatisation des ouvertures de l'habitat et du bâtiment, ainsi que dans la maison connectée.
 
@@ -20,6 +28,12 @@ Grâce au projet open‑source [Matterbridge](https://github.com/luligu/matterbr
 C'est ce que nous allons faire pour les appareils Somfy.
 
 Ce guide pas à pas vous expliquera comment exposer et piloter vos volets roulants, stores, et autres ouvrants Somfy.
+
+## Somfy est-il compatible Matter ?
+
+Les appareils Somfy (io-homecontrol® et RTS) **ne sont pas exposés nativement en Matter** vers des contrôleurs tiers : il n'existe pas de pont Matter intégré dans les box **TaHoma**, **TaHoma Switch** ou **Connexoon** aujourd'hui, et le pilotage passe toujours par le cloud Somfy.
+
+La bonne nouvelle, c'est que vous n'avez pas à attendre Somfy. Grâce au projet open-source [Matterbridge](https://github.com/luligu/matterbridge), Gladys transforme vos appareils Somfy **TaHoma**, **TaHoma Switch** et **Connexoon** en appareils Matter, pour piloter vos volets roulants, stores, bannes et autres ouvrants directement depuis Gladys Assistant. La suite de ce guide vous montre comment, étape par étape.
 
 ### Prérequis
 
@@ -129,3 +143,74 @@ Merci au standard **Matter** et au projet **Matterbridge** qui rendent l’écos
 
 - [Intégrer des appareils Matter dans Gladys Assistant](/fr/docs/integrations/matter/)
 - [Repository GitHub Matterbridge](https://github.com/luligu/matterbridge)
+
+## Questions fréquentes
+
+### Somfy est-il compatible Matter ?
+
+Les box Somfy n'exposent pas nativement vos appareils io-homecontrol® et RTS en Matter vers des contrôleurs tiers. Il n'y a pas de pont Matter intégré dans la TaHoma, la TaHoma Switch ou la Connexoon. Vous pouvez toutefois les rendre compatibles Matter grâce au projet open-source Matterbridge et les piloter dans Gladys Assistant.
+
+### La TaHoma Switch de Somfy est-elle compatible Matter ?
+
+La TaHoma Switch ne joue pas le rôle de pont Matter natif pour vos appareils io et RTS. En utilisant Matterbridge et le plugin `matterbridge-somfy-tahoma`, Gladys peut tout de même exposer vos appareils TaHoma Switch en Matter et les piloter.
+
+### Faut-il le cloud Somfy et une connexion internet ?
+
+Oui, pour l'instant. Le plugin Matterbridge Somfy/TaHoma communique avec le cloud Somfy : une connexion internet active et un compte Somfy valide sont donc nécessaires. Le support de l'API locale de la box Somfy est en cours de développement et permettra à terme un pilotage entièrement local.
+
+### Quels appareils Somfy puis-je piloter dans Gladys ?
+
+Une fois exposés en Matter, vous pouvez piloter vos volets roulants, stores, bannes et autres ouvrants gérés par votre box Somfy (Connexoon, TaHoma ou TaHoma Switch) via les protocoles io-homecontrol® et RTS.
+
+### Puis-je voir la position (%) de mes volets ?
+
+Matterbridge gère les ouvrants de manière autonome et n'interroge pas les serveurs Somfy pour connaître la position actuelle lorsque les appareils sont pilotés depuis leurs télécommandes ou l'application mobile TaHoma. La récupération des positions en temps réel est à l'étude.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Somfy est-il compatible Matter ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Les box Somfy n'exposent pas nativement vos appareils io-homecontrol et RTS en Matter vers des contrôleurs tiers : il n'y a pas de pont Matter intégré dans la TaHoma, la TaHoma Switch ou la Connexoon. Vous pouvez toutefois les rendre compatibles Matter grâce au projet open-source Matterbridge et les piloter dans Gladys Assistant.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "La TaHoma Switch de Somfy est-elle compatible Matter ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "La TaHoma Switch ne joue pas le rôle de pont Matter natif pour vos appareils io et RTS. En utilisant Matterbridge et le plugin matterbridge-somfy-tahoma, Gladys peut tout de même exposer vos appareils TaHoma Switch en Matter et les piloter.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Faut-il le cloud Somfy et une connexion internet ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui, pour l'instant. Le plugin Matterbridge Somfy/TaHoma communique avec le cloud Somfy : une connexion internet active et un compte Somfy valide sont donc nécessaires. Le support de l'API locale de la box Somfy est en cours de développement et permettra à terme un pilotage entièrement local.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Quels appareils Somfy puis-je piloter dans Gladys ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Une fois exposés en Matter, vous pouvez piloter vos volets roulants, stores, bannes et autres ouvrants gérés par votre box Somfy (Connexoon, TaHoma ou TaHoma Switch) via les protocoles io-homecontrol et RTS.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Puis-je voir la position (%) de mes volets Somfy dans Gladys ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Matterbridge gère les ouvrants de manière autonome et n'interroge pas les serveurs Somfy pour connaître la position actuelle lorsque les appareils sont pilotés depuis leurs télécommandes ou l'application mobile TaHoma. La récupération des positions en temps réel est à l'étude.",
+        },
+      },
+    ],
+  }}
+/>


### PR DESCRIPTION
The doc already ranks ~pos 7 for somfy matter / tahoma matter and is the natural target for that intent, so we strengthen it rather than create a competing landing page (which would cannibalize it):

- Retitle + meta to front-load "Somfy and Matter" / "TaHoma Switch"
- Add a "Is Somfy compatible with Matter?" section answering the intent
- Add an FAQ (visible H3s) with FAQPage JSON-LD for rich results
- Keep the honest framing (cloud-based today, local API in progress)

EN + FR, URL unchanged to preserve ranking.