### PR TITLE
SEO/GEO: add live EDF Tempo "colour of the day" page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -175,6 +175,10 @@ module.exports = function createConfig() {
               to: "home-energy-monitoring/",
             },
             {
+              label: "EDF Tempo colour of the day",
+              to: "edf-tempo/",
+            },
+            {
               label: "DIY home alarm system",
               to: "diy-home-alarm-system/",
             },
@@ -336,6 +340,7 @@ module.exports = function createConfig() {
                   path === "/local-smart-home/" ||
                   path === "/open-source-home-automation/" ||
                   path === "/best-zigbee-dongle/" ||
+                  path === "/edf-tempo/" ||
                   path === "/blog/"
                 ) {
                   return { ...item, priority: 0.8 };

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -163,6 +163,10 @@
     "message": "Réduire sa facture d'électricité",
     "description": "The label of footer link with label=Reduce your electricity bill linking to home-energy-monitoring/"
   },
+  "link.item.label.EDF Tempo colour of the day": {
+    "message": "Tempo EDF : couleur du jour",
+    "description": "The label of footer link with label=EDF Tempo colour of the day linking to edf-tempo/"
+  },
   "link.item.label.DIY home alarm system": {
     "message": "Alarme maison DIY",
     "description": "The label of footer link with label=DIY home alarm system linking to diy-home-alarm-system/"

--- a/src/data/edfTempoData.js
+++ b/src/data/edfTempoData.js
@@ -1,0 +1,292 @@
+// Content for the EDF Tempo "couleur du jour" landing page.
+// Targets the very high-volume French cluster "couleur du jour tempo / tempo
+// couleur du jour / edf tempo couleur du jour / jour tempo" (Search Console:
+// 12k+ impressions at position 33-60 with ~0 clicks, only docs ranking).
+// The page combines a live widget (today's & tomorrow's Tempo colour, fetched
+// from our API) with evergreen explanatory content for SEO, and ties back to
+// Gladys' Tempo automation.
+
+export const TEMPO_API_URL =
+  "https://edf-tempo-api.gladysassistant.workers.dev/";
+
+const edfTempoContent = {
+  en: {
+    meta: {
+      title: "EDF Tempo: today's colour (and tomorrow's) — live",
+      description:
+        "Is today an EDF Tempo blue, white or red day? See the live Tempo colour of the day and tomorrow's colour, learn what each colour costs, and how to automate Tempo at home with Gladys.",
+    },
+    hero: {
+      title: "EDF Tempo: what's the colour of the day?",
+      subtitle:
+        "The live Tempo colour for today and tomorrow, plus what each colour means for your electricity bill.",
+    },
+    widget: {
+      todayLabel: "Today",
+      tomorrowLabel: "Tomorrow",
+      live: "Live",
+      loading: "Loading…",
+      error: "Tempo data is momentarily unavailable. Please try again later.",
+      tomorrowUnknownHint: "Published around 11am",
+      source: "Source: EDF, updated automatically",
+      colors: {
+        blue: { name: "Blue", hint: "Cheapest rate" },
+        white: { name: "White", hint: "Intermediate rate" },
+        red: { name: "Red", hint: "Most expensive rate" },
+        unknown: { name: "Coming soon", hint: "Not published yet" },
+      },
+    },
+    whatIs: {
+      title: "What is the EDF Tempo option?",
+      paragraphs: [
+        "Tempo is a regulated EDF electricity pricing option built around coloured days. Each calendar day is blue, white or red, and the price of your kWh depends on the colour, with cheaper off-peak hours every night (10pm to 6am).",
+        "The idea is simple: electricity is much cheaper on the many blue days and more expensive on the rare red days, when the grid is under strain. If you can shift or reduce your usage on white and red days, Tempo can cut your bill significantly, which is exactly where home automation helps.",
+      ],
+    },
+    colorsLegend: {
+      title: "The three Tempo colours",
+      intro: "Over a year, EDF spreads the days across three colours:",
+      cards: [
+        {
+          key: "blue",
+          name: "Blue days",
+          days: "~300 days / year",
+          text: "The cheapest rate, and the vast majority of the year. Most of your consumption happens on blue days.",
+        },
+        {
+          key: "white",
+          name: "White days",
+          days: "~43 days / year",
+          text: "An intermediate rate. More expensive than blue, but still moderate. Worth easing off on heavy appliances.",
+        },
+        {
+          key: "red",
+          name: "Red days",
+          days: "~22 days / year",
+          text: "The most expensive rate by far, only between 1 November and 31 March, on weekdays. During peak hours (6am-10pm) the kWh can cost several times the blue rate.",
+        },
+      ],
+    },
+    redDays: {
+      title: "When are the red days?",
+      intro:
+        "Red days are the ones to anticipate. The rules are fixed:",
+      points: [
+        "There are a maximum of 22 red days per year.",
+        "They can only fall between 1 November and 31 March.",
+        "They are weekdays only (never Saturdays, Sundays or public holidays).",
+        "Tomorrow's colour is published by EDF around 11am the day before, so you always know a red day is coming in advance.",
+      ],
+      outro:
+        "On a red day, the smart move is to pre-heat earlier, avoid running heavy appliances during peak hours, and lean on any battery or water tank you've already heated on cheaper days.",
+    },
+    gladys: {
+      title: "Automate Tempo with Gladys Assistant",
+      paragraphs: [
+        "Knowing the colour is one thing; acting on it automatically is where you actually save. Gladys Assistant retrieves the Tempo colour and lets you build scenes around it: lower the heating on red days, delay the water heater and the washing machine to off-peak hours, or get a notification the evening before a red day.",
+        "It all runs locally on your own hardware, alongside your other devices. Combined with Enedis consumption tracking, you get a complete, private picture of what you spend and when.",
+      ],
+      links: [
+        { label: "Tempo in Gladys scenes →", href: "/docs/scenes/edf-tempo/" },
+        { label: "The Tempo dashboard widget →", href: "/docs/dashboard/edf-tempo/" },
+      ],
+    },
+    related: {
+      title: "Go further",
+      intro: "Cutting your electricity bill is a whole project:",
+      links: [
+        {
+          label: "Reduce your electricity bill",
+          href: "/home-energy-monitoring/",
+          text: "Track your consumption with Enedis and act on the data, locally and privately.",
+        },
+        {
+          label: "Build a local smart home",
+          href: "/local-smart-home/",
+          text: "Why local-first matters and how to build a home that runs without the cloud.",
+        },
+        {
+          label: "Open-source home automation",
+          href: "/open-source-home-automation/",
+          text: "Run your smart home on free, self-hosted software you can trust and keep.",
+        },
+      ],
+    },
+    faqTitle: "Frequently asked questions",
+    cta: {
+      title: "Turn the Tempo colour into automatic savings",
+      text: "Gladys is free, open-source, and installs in a single Docker command. Automate your home around Tempo, locally and privately.",
+      primary: { label: "Get started", href: "/docs/" },
+      secondary: { label: "Reduce your electricity bill", href: "/home-energy-monitoring/" },
+    },
+  },
+
+  fr: {
+    meta: {
+      title: "Tempo EDF : la couleur du jour (et de demain) en direct",
+      description:
+        "Aujourd'hui, jour Tempo bleu, blanc ou rouge ? Découvrez la couleur du jour EDF Tempo et celle de demain en direct, ce que coûte chaque couleur, et comment automatiser Tempo chez vous avec Gladys.",
+    },
+    hero: {
+      title: "Tempo EDF : quelle est la couleur du jour ?",
+      subtitle:
+        "La couleur Tempo du jour et de demain en direct, et ce que chaque couleur change sur votre facture d'électricité.",
+    },
+    widget: {
+      todayLabel: "Aujourd'hui",
+      tomorrowLabel: "Demain",
+      live: "En direct",
+      loading: "Chargement…",
+      error: "Les données Tempo sont momentanément indisponibles. Réessayez plus tard.",
+      tomorrowUnknownHint: "Publiée vers 11h",
+      source: "Source : EDF, mis à jour automatiquement",
+      colors: {
+        blue: { name: "Bleu", hint: "Tarif le plus bas" },
+        white: { name: "Blanc", hint: "Tarif intermédiaire" },
+        red: { name: "Rouge", hint: "Tarif le plus élevé" },
+        unknown: { name: "Bientôt connue", hint: "Pas encore publiée" },
+      },
+    },
+    whatIs: {
+      title: "C'est quoi l'option Tempo d'EDF ?",
+      paragraphs: [
+        "Tempo est une option tarifaire réglementée d'EDF organisée autour de jours de couleur. Chaque jour du calendrier est bleu, blanc ou rouge, et le prix de votre kWh dépend de la couleur, avec en plus des heures creuses moins chères chaque nuit (de 22h à 6h).",
+        "Le principe est simple : l'électricité est bien moins chère les nombreux jours bleus, et plus chère les rares jours rouges, quand le réseau est sous tension. Si vous pouvez décaler ou réduire votre consommation les jours blancs et rouges, Tempo peut réduire fortement votre facture, et c'est précisément là que la domotique aide.",
+      ],
+    },
+    colorsLegend: {
+      title: "Les trois couleurs Tempo",
+      intro: "Sur une année, EDF répartit les jours en trois couleurs :",
+      cards: [
+        {
+          key: "blue",
+          name: "Jours bleus",
+          days: "~300 jours / an",
+          text: "Le tarif le plus bas, et la grande majorité de l'année. L'essentiel de votre consommation tombe les jours bleus.",
+        },
+        {
+          key: "white",
+          name: "Jours blancs",
+          days: "~43 jours / an",
+          text: "Un tarif intermédiaire. Plus cher que le bleu, mais raisonnable. Il vaut le coup de lever le pied sur les gros appareils.",
+        },
+        {
+          key: "red",
+          name: "Jours rouges",
+          days: "~22 jours / an",
+          text: "Le tarif de loin le plus élevé, uniquement du 1er novembre au 31 mars, en jours ouvrés. En heures pleines (6h-22h), le kWh peut coûter plusieurs fois le tarif bleu.",
+        },
+      ],
+    },
+    redDays: {
+      title: "Quand tombent les jours rouges ?",
+      intro:
+        "Les jours rouges sont ceux à anticiper. Les règles sont fixes :",
+      points: [
+        "Il y a au maximum 22 jours rouges par an.",
+        "Ils ne peuvent tomber qu'entre le 1er novembre et le 31 mars.",
+        "Ce sont uniquement des jours ouvrés (jamais les samedis, dimanches ni jours fériés).",
+        "La couleur du lendemain est publiée par EDF vers 11h la veille : vous savez donc toujours à l'avance qu'un jour rouge arrive.",
+      ],
+      outro:
+        "Un jour rouge, le bon réflexe est de préchauffer plus tôt, d'éviter les gros appareils en heures pleines, et de profiter d'un ballon d'eau chaude ou d'une batterie déjà chargés les jours moins chers.",
+    },
+    gladys: {
+      title: "Automatiser Tempo avec Gladys Assistant",
+      paragraphs: [
+        "Connaître la couleur, c'est une chose ; agir dessus automatiquement, c'est là qu'on économise vraiment. Gladys Assistant récupère la couleur Tempo et vous laisse créer des scènes autour : baisser le chauffage les jours rouges, décaler le chauffe-eau et le lave-linge en heures creuses, ou recevoir une notification la veille d'un jour rouge.",
+        "Tout tourne en local, sur votre propre matériel, à côté de vos autres appareils. Combiné au suivi de consommation Enedis, vous obtenez une vision complète et privée de ce que vous dépensez, et quand.",
+      ],
+      links: [
+        { label: "Tempo dans les scènes Gladys →", href: "/fr/docs/scenes/edf-tempo/" },
+        { label: "Le widget Tempo du tableau de bord →", href: "/fr/docs/dashboard/edf-tempo/" },
+      ],
+    },
+    related: {
+      title: "Aller plus loin",
+      intro: "Réduire sa facture d'électricité, c'est tout un projet :",
+      links: [
+        {
+          label: "Réduire sa facture d'électricité",
+          href: "/home-energy-monitoring/",
+          text: "Suivez votre consommation avec Enedis et agissez sur les données, en local et en privé.",
+        },
+        {
+          label: "Créer une maison connectée locale",
+          href: "/local-smart-home/",
+          text: "Pourquoi le local d'abord est important et comment bâtir une maison sans le cloud.",
+        },
+        {
+          label: "La domotique open source",
+          href: "/open-source-home-automation/",
+          text: "Piloter sa maison avec un logiciel libre et auto-hébergé que vous gardez.",
+        },
+      ],
+    },
+    faqTitle: "Questions fréquentes",
+    cta: {
+      title: "Transformez la couleur Tempo en économies automatiques",
+      text: "Gladys est gratuite, open source, et s'installe en une seule commande Docker. Automatisez votre maison autour de Tempo, en local et en privé.",
+      primary: { label: "Commencer", href: "/fr/docs/" },
+      secondary: { label: "Réduire sa facture d'électricité", href: "/home-energy-monitoring/" },
+    },
+  },
+};
+
+export const edfTempoFaqEn = [
+  {
+    question: "What is the EDF Tempo colour of the day?",
+    answer:
+      "Each day under the EDF Tempo option is blue, white or red, and the colour sets the price of your electricity that day. Blue is the cheapest (about 300 days a year), white is intermediate (about 43 days), and red is the most expensive (about 22 days, only in winter). Today's and tomorrow's colours are shown live at the top of this page.",
+  },
+  {
+    question: "What colour is tomorrow on Tempo?",
+    answer:
+      "Tomorrow's Tempo colour is published by EDF around 11am the day before. Before that, it isn't known yet. The widget at the top of this page shows tomorrow's colour as soon as it's available.",
+  },
+  {
+    question: "When are EDF Tempo red days?",
+    answer:
+      "There are at most 22 red days per year, and they can only fall between 1 November and 31 March, on weekdays (never weekends or public holidays). On a red day, peak-hour electricity (6am to 10pm) is far more expensive than usual.",
+  },
+  {
+    question: "How many blue, white and red days are there per year?",
+    answer:
+      "An EDF Tempo year has about 300 blue days, 43 white days and 22 red days, for a total of 365. The vast majority of the year is therefore at the cheapest blue rate.",
+  },
+  {
+    question: "How can I automate EDF Tempo at home?",
+    answer:
+      "With a home automation platform like Gladys Assistant, you can retrieve the Tempo colour and build automations around it: reduce the heating on red days, shift the water heater and washing machine to off-peak hours, or get notified the evening before a red day. Gladys runs locally and is free and open-source.",
+  },
+];
+
+export const edfTempoFaqFr = [
+  {
+    question: "Quelle est la couleur du jour EDF Tempo ?",
+    answer:
+      "Chaque jour de l'option EDF Tempo est bleu, blanc ou rouge, et la couleur fixe le prix de votre électricité ce jour-là. Le bleu est le moins cher (environ 300 jours par an), le blanc est intermédiaire (environ 43 jours) et le rouge est le plus cher (environ 22 jours, uniquement en hiver). La couleur du jour et de demain est affichée en direct en haut de cette page.",
+  },
+  {
+    question: "Quelle couleur Tempo demain ?",
+    answer:
+      "La couleur Tempo du lendemain est publiée par EDF vers 11h la veille. Avant cela, elle n'est pas encore connue. Le widget en haut de cette page affiche la couleur de demain dès qu'elle est disponible.",
+  },
+  {
+    question: "Quand sont les jours rouges EDF Tempo ?",
+    answer:
+      "Il y a au maximum 22 jours rouges par an, et ils ne peuvent tomber qu'entre le 1er novembre et le 31 mars, en jours ouvrés (jamais le week-end ni les jours fériés). Un jour rouge, l'électricité en heures pleines (6h à 22h) est bien plus chère que d'habitude.",
+  },
+  {
+    question: "Combien de jours bleus, blancs et rouges par an ?",
+    answer:
+      "Une année EDF Tempo compte environ 300 jours bleus, 43 jours blancs et 22 jours rouges, soit 365 au total. La grande majorité de l'année est donc au tarif bleu, le moins cher.",
+  },
+  {
+    question: "Comment automatiser EDF Tempo chez soi ?",
+    answer:
+      "Avec une plateforme domotique comme Gladys Assistant, vous pouvez récupérer la couleur Tempo et créer des automatisations autour : baisser le chauffage les jours rouges, décaler le chauffe-eau et le lave-linge en heures creuses, ou être notifié la veille d'un jour rouge. Gladys tourne en local et est gratuite et open source.",
+  },
+];
+
+export default edfTempoContent;

--- a/src/data/structuredData.js
+++ b/src/data/structuredData.js
@@ -29,6 +29,7 @@ import {
   bestZigbeeDongleFaqEn,
   bestZigbeeDongleFaqFr,
 } from "./bestZigbeeDongleData";
+import { edfTempoFaqEn, edfTempoFaqFr } from "./edfTempoData";
 import { protocolsFaqEn, protocolsFaqFr } from "./protocolsComparisonData";
 import { energyFaqEn, energyFaqFr } from "./energyMonitoringData";
 import { alarmFaqEn, alarmFaqFr } from "./alarmSystemData";
@@ -549,6 +550,45 @@ export function getLocalSmartHomePageSchema(lang) {
         lang === "fr" ? localSmartHomeFaqFr : localSmartHomeFaqEn,
         pageUrl
       ),
+    ],
+  };
+}
+
+export function getEdfTempoPageSchema(lang) {
+  const prefix = lang === "fr" ? "/fr" : "";
+  const pageUrl = `${SITE_URL}${prefix}/edf-tempo/`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      getOrganizationNode(),
+      getWebSiteNode(lang),
+      {
+        "@type": "Article",
+        "@id": `${pageUrl}#article`,
+        headline:
+          lang === "fr"
+            ? "Tempo EDF : la couleur du jour (et de demain)"
+            : "EDF Tempo: today's colour (and tomorrow's)",
+        description:
+          lang === "fr"
+            ? "La couleur du jour EDF Tempo et celle de demain en direct, ce que coûte chaque couleur, et comment automatiser Tempo chez soi avec Gladys."
+            : "The live EDF Tempo colour for today and tomorrow, what each colour costs, and how to automate Tempo at home with Gladys.",
+        url: pageUrl,
+        inLanguage: lang === "fr" ? "fr" : "en",
+        isPartOf: { "@id": `${SITE_URL}/#website` },
+        author: {
+          "@type": "Person",
+          name: "Pierre-Gilles Leymarie",
+        },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+        about: [
+          { "@type": "Thing", name: "EDF Tempo" },
+          { "@type": "Thing", name: "Tempo colour of the day" },
+          { "@type": "SoftwareApplication", name: "Gladys Assistant" },
+        ],
+      },
+      toFaqPage(lang === "fr" ? edfTempoFaqFr : edfTempoFaqEn, pageUrl),
     ],
   };
 }

--- a/src/pages/edf-tempo.js
+++ b/src/pages/edf-tempo.js
@@ -1,0 +1,264 @@
+import React, { useEffect, useState } from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+import JsonLd from "../components/seo/JsonLd";
+import { getEdfTempoPageSchema } from "../data/structuredData";
+import edfTempoContent, {
+  edfTempoFaqEn,
+  edfTempoFaqFr,
+  TEMPO_API_URL,
+} from "../data/edfTempoData";
+
+import styles from "./comparison.module.css";
+import t from "./edfTempo.module.css";
+
+const TEMPO_COLORS = ["blue", "white", "red"];
+const normalizeColor = (c) => (TEMPO_COLORS.includes(c) ? c : "unknown");
+
+function DayCard({ label, colorKey, name, hint, loading }) {
+  return (
+    <div
+      className={`${t.dayCard} ${t[colorKey]} ${loading ? t.skeleton : ""}`}
+      aria-live="polite"
+    >
+      <span className={t.dot} aria-hidden="true" />
+      <span className={t.dayLabel}>{label}</span>
+      <span className={t.dayColorName}>{name}</span>
+      {hint ? <span className={t.dayHint}>{hint}</span> : null}
+    </div>
+  );
+}
+
+function TempoWidget({ strings }) {
+  const [state, setState] = useState({ status: "loading" });
+
+  useEffect(() => {
+    let alive = true;
+    fetch(TEMPO_API_URL)
+      .then((r) => r.json())
+      .then((d) => {
+        if (alive) {
+          setState({ status: "ok", today: d.today, tomorrow: d.tomorrow });
+        }
+      })
+      .catch(() => {
+        if (alive) setState({ status: "error" });
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (state.status === "error") {
+    return <div className={t.error}>{strings.error}</div>;
+  }
+
+  const loading = state.status === "loading";
+  const todayKey = loading ? "unknown" : normalizeColor(state.today);
+  const tomorrowKey = loading ? "unknown" : normalizeColor(state.tomorrow);
+
+  const todayName = loading ? strings.loading : strings.colors[todayKey].name;
+  const todayHint = loading ? "" : strings.colors[todayKey].hint;
+
+  const tomorrowName = loading
+    ? strings.loading
+    : strings.colors[tomorrowKey].name;
+  const tomorrowHint = loading
+    ? ""
+    : tomorrowKey === "unknown"
+    ? strings.tomorrowUnknownHint
+    : strings.colors[tomorrowKey].hint;
+
+  return (
+    <>
+      <div className={t.widget}>
+        <DayCard
+          label={strings.todayLabel}
+          colorKey={todayKey}
+          name={todayName}
+          hint={todayHint}
+          loading={loading}
+        />
+        <DayCard
+          label={strings.tomorrowLabel}
+          colorKey={tomorrowKey}
+          name={tomorrowName}
+          hint={tomorrowHint}
+          loading={loading}
+        />
+      </div>
+      {!loading && (
+        <div className={t.liveRow}>
+          <span className={t.liveDot} aria-hidden="true" />
+          {strings.live}
+        </div>
+      )}
+      <p className={t.source}>{strings.source}</p>
+    </>
+  );
+}
+
+function LinkCard({ label, href, text }) {
+  return (
+    <Link to={href} className={styles.card}>
+      <div className={styles.cardTitle}>{label} →</div>
+      <p>{text}</p>
+    </Link>
+  );
+}
+
+const SWATCH_CLASS = {
+  blue: t.legendSwatchBlue,
+  white: t.legendSwatchWhite,
+  red: t.legendSwatchRed,
+};
+
+function TempoPage({ content, faq }) {
+  return (
+    <main className={styles.main}>
+      <div className={`container ${styles.container}`}>
+        {/* HERO + LIVE WIDGET */}
+        <header className={styles.hero}>
+          <h1 className={styles.heroTitle}>{content.hero.title}</h1>
+          <p className={styles.heroSubtitle}>{content.hero.subtitle}</p>
+        </header>
+        <TempoWidget strings={content.widget} />
+
+        {/* WHAT IS TEMPO */}
+        <section className={styles.section} aria-labelledby="whatis-title">
+          <h2 id="whatis-title" className={styles.sectionTitle}>
+            {content.whatIs.title}
+          </h2>
+          <div className={styles.intro}>
+            {content.whatIs.paragraphs.map((p, i) => (
+              <p key={i}>{p}</p>
+            ))}
+          </div>
+        </section>
+
+        {/* THE THREE COLOURS */}
+        <section className={styles.section} aria-labelledby="colors-title">
+          <h2 id="colors-title" className={styles.sectionTitle}>
+            {content.colorsLegend.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.colorsLegend.intro}</p>
+          <div className={t.legendGrid}>
+            {content.colorsLegend.cards.map((card) => (
+              <div key={card.key} className={t.legendCard}>
+                <div className={t.legendHead}>
+                  <span
+                    className={`${t.legendSwatch} ${SWATCH_CLASS[card.key]}`}
+                    aria-hidden="true"
+                  />
+                  <span className={t.legendName}>{card.name}</span>
+                </div>
+                <div className={t.legendDays}>{card.days}</div>
+                <p>{card.text}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* RED DAYS */}
+        <section className={styles.section} aria-labelledby="reddays-title">
+          <h2 id="reddays-title" className={styles.sectionTitle}>
+            {content.redDays.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.redDays.intro}</p>
+          <ul className={styles.bulletList}>
+            {content.redDays.points.map((point, i) => (
+              <li key={i}>{point}</li>
+            ))}
+          </ul>
+          <p className={styles.blockOutro}>{content.redDays.outro}</p>
+        </section>
+
+        {/* AUTOMATE WITH GLADYS */}
+        <section className={styles.section} aria-labelledby="gladys-title">
+          <h2 id="gladys-title" className={styles.sectionTitle}>
+            {content.gladys.title}
+          </h2>
+          <div className={styles.whyNotBoth}>
+            {content.gladys.paragraphs.map((p, i) => (
+              <p key={i}>{p}</p>
+            ))}
+            <p className={styles.compareLink}>
+              {content.gladys.links.map((link, i) => (
+                <React.Fragment key={i}>
+                  <Link to={link.href}>{link.label}</Link>
+                  {i < content.gladys.links.length - 1 ? (
+                    <span aria-hidden="true">{"  ·  "}</span>
+                  ) : null}
+                </React.Fragment>
+              ))}
+            </p>
+          </div>
+        </section>
+
+        {/* RELATED / MESH */}
+        <section className={styles.section} aria-labelledby="related-title">
+          <h2 id="related-title" className={styles.sectionTitle}>
+            {content.related.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.related.intro}</p>
+          <div className={styles.cardGrid}>
+            {content.related.links.map((link, i) => (
+              <LinkCard key={i} {...link} />
+            ))}
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className={styles.section} aria-labelledby="faq-title">
+          <h2 id="faq-title" className={styles.sectionTitle}>
+            {content.faqTitle}
+          </h2>
+          {faq.map((item, i) => (
+            <div key={i} className={styles.faqItem}>
+              <h3 className={styles.faqQuestion}>{item.question}</h3>
+              <p className={styles.faqAnswer}>{item.answer}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* CTA */}
+        <section className={styles.cta} aria-labelledby="cta-title">
+          <h2 id="cta-title" className={styles.ctaTitle}>
+            {content.cta.title}
+          </h2>
+          <p className={styles.ctaText}>{content.cta.text}</p>
+          <div className={styles.ctaButtons}>
+            <Link
+              className="button button--primary button--lg"
+              to={content.cta.primary.href}
+            >
+              {content.cta.primary.label}
+            </Link>
+            <Link
+              className="button button--secondary button--lg"
+              to={content.cta.secondary.href}
+            >
+              {content.cta.secondary.label}
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default function EdfTempoPage() {
+  const { i18n } = useDocusaurusContext();
+  const lang = i18n.currentLocale === "fr" ? "fr" : "en";
+  const content = edfTempoContent[lang];
+  const faq = lang === "fr" ? edfTempoFaqFr : edfTempoFaqEn;
+
+  return (
+    <Layout title={content.meta.title} description={content.meta.description}>
+      <JsonLd data={getEdfTempoPageSchema(lang)} />
+      <TempoPage content={content} faq={faq} />
+    </Layout>
+  );
+}

--- a/src/pages/edfTempo.module.css
+++ b/src/pages/edfTempo.module.css
@@ -1,0 +1,234 @@
+/* Live Tempo colour widget */
+.widget {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+  max-width: 44rem;
+  margin: 2.25rem auto 0.75rem;
+}
+
+@media screen and (max-width: 600px) {
+  .widget {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dayCard {
+  position: relative;
+  border-radius: 20px;
+  padding: 2.25rem 1.5rem;
+  text-align: center;
+  min-height: 210px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 1px solid transparent;
+  box-shadow: 0 14px 38px rgba(0, 0, 0, 0.14);
+  overflow: hidden;
+}
+
+.dayLabel {
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.9;
+}
+
+.dayColorName {
+  font-size: 2.6rem;
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+@media screen and (max-width: 600px) {
+  .dayColorName {
+    font-size: 2.2rem;
+  }
+}
+
+.dayHint {
+  font-size: 0.95rem;
+  opacity: 0.9;
+}
+
+.dot {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  margin-bottom: 0.4rem;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.25);
+}
+
+/* Tempo colours */
+.blue {
+  background: linear-gradient(150deg, #3b8bff 0%, #0a4bb3 100%);
+  color: #ffffff;
+}
+.blue .dot {
+  background: #ffffff;
+}
+
+.white {
+  background: linear-gradient(150deg, #ffffff 0%, #e7eef7 100%);
+  color: #16233d;
+  border-color: #d3dcea;
+}
+.white .dot {
+  background: #16233d;
+  box-shadow: 0 0 0 4px rgba(22, 35, 61, 0.12);
+}
+
+.red {
+  background: linear-gradient(150deg, #f4524f 0%, #b00f0a 100%);
+  color: #ffffff;
+}
+.red .dot {
+  background: #ffffff;
+}
+
+.unknown {
+  background: linear-gradient(150deg, #eef1f5 0%, #dde3ec 100%);
+  color: #4a5567;
+  border-color: #d3dcea;
+}
+.unknown .dot {
+  background: #9aa6b6;
+}
+
+/* Live badge */
+.liveRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  max-width: 44rem;
+  margin: 0 auto;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.liveDot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: #e23b3b;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(0.75);
+  }
+}
+
+.source {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-top: 0.5rem;
+}
+
+.error {
+  max-width: 44rem;
+  margin: 2rem auto 0;
+  text-align: center;
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 1.5rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* Skeleton loading state */
+.skeleton {
+  color: transparent !important;
+  background: linear-gradient(
+    100deg,
+    #e9edf2 30%,
+    #f4f6f9 50%,
+    #e9edf2 70%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.3s ease-in-out infinite;
+  border-color: #e3e8ef;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Colour legend cards */
+.legendGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+@media screen and (max-width: 768px) {
+  .legendGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.legendCard {
+  border-radius: 14px;
+  padding: 1.5rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.legendHead {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.35rem;
+}
+
+.legendSwatch {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 7px;
+  flex: none;
+}
+
+.legendSwatchBlue {
+  background: linear-gradient(150deg, #3b8bff, #0a4bb3);
+}
+.legendSwatchWhite {
+  background: #ffffff;
+  border: 1px solid #d3dcea;
+}
+.legendSwatchRed {
+  background: linear-gradient(150deg, #f4524f, #b00f0a);
+}
+
+.legendName {
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.legendDays {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.75rem;
+}
+
+.legendCard p {
+  margin: 0;
+  line-height: 1.55;
+  font-size: 0.95rem;
+}


### PR DESCRIPTION
Targets the large French cluster "couleur du jour tempo / edf tempo couleur du jour / jour tempo" (Search Console: 12k+ impressions at position 33-60, ~0 clicks, only docs ranking). EN + FR page with a live widget showing today's and tomorrow's Tempo colour (client-side fetch from the Gladys EDF Tempo API), plus evergreen content: what Tempo is, the three colours and their day counts, when red days fall, and how to automate Tempo with Gladys. Article + FAQPage JSON-LD, footer link, sitemap priority 0.8.