### PR TITLE
SEO: rewrite Tasmota integration doc (EN + FR)

### DIFF
--- a/docs/integrations/energy-monitoring.md
+++ b/docs/integrations/energy-monitoring.md
@@ -17,7 +17,7 @@ There are several ways to achieve this:
 
 ### 1. **With a Lixee ZLinky TIC via Zigbee (France only)**
 
-:::note For French users
+:::note[For French users]
 This option is specific to France and the Linky smart meter.
 :::
 
@@ -36,7 +36,7 @@ Each color represents an energy price (I'm on Tempo pricing), you can clearly se
 
 ### 2. **Through the Enedis integration on Gladys Plus (France only)**
 
-:::note For French users
+:::note[For French users]
 This option is specific to France and requires a Linky meter with an Enedis account.
 :::
 
@@ -67,7 +67,7 @@ The order of steps in this tutorial is important!
 
 ### Step 1: Configure the Enedis integration (optional, France only)
 
-:::note For French users
+:::note[For French users]
 Skip this step if you're not in France.
 :::
 

--- a/docs/integrations/tasmota.md
+++ b/docs/integrations/tasmota.md
@@ -32,7 +32,7 @@ To connect a Tasmota device to Gladys, there are three steps:
 - **Reuse cheap hardware**: many affordable smart plugs and switches (Sonoff, and other ESP-based devices) can be re-flashed instead of being thrown away.
 - **Reliable and fast**: local commands don't depend on your internet connection, so automations run instantly.
 
-:::tip Tasmota or Zigbee?
+:::tip[Tasmota or Zigbee?]
 Tasmota runs on Wi-Fi devices, so each one connects directly to your router — convenient for a few mains-powered plugs and switches. For battery-powered sensors and large fleets of devices, a low-power [Zigbee](./zigbee2mqtt.md) mesh is usually a better fit. Both are local and both work great in Gladys, and you can mix them. See our [Zigbee dongle buyer's guide](/best-zigbee-dongle/) if you go the Zigbee route.
 :::
 

--- a/docs/integrations/tasmota.md
+++ b/docs/integrations/tasmota.md
@@ -33,7 +33,7 @@ To connect a Tasmota device to Gladys, there are three steps:
 - **Reliable and fast**: local commands don't depend on your internet connection, so automations run instantly.
 
 :::tip[Tasmota or Zigbee?]
-Tasmota runs on Wi-Fi devices, so each one connects directly to your router — convenient for a few mains-powered plugs and switches. For battery-powered sensors and large fleets of devices, a low-power [Zigbee](./zigbee2mqtt.md) mesh is usually a better fit. Both are local and both work great in Gladys, and you can mix them. See our [Zigbee dongle buyer's guide](/best-zigbee-dongle/) if you go the Zigbee route.
+Tasmota runs on Wi-Fi devices, so each one connects directly to your router, which is convenient for a few mains-powered plugs and switches. For battery-powered sensors and large fleets of devices, a low-power [Zigbee](./zigbee2mqtt.md) mesh is usually a better fit. Both are local and both work great in Gladys, and you can mix them. See our [Zigbee dongle buyer's guide](/best-zigbee-dongle/) if you go the Zigbee route.
 :::
 
 ## Flash your device with Tasmota
@@ -80,7 +80,7 @@ Once the device is configured, go back to Gladys:
 4. then click `Save`
 5. and voilà!
 
-Your Tasmota device is now controllable from Gladys, included in your dashboards and usable in your [scenes](/docs/scenes/intro/) — all locally.
+Your Tasmota device is now controllable from Gladys, included in your dashboards and usable in your [scenes](/docs/scenes/intro/), all locally.
 
 ## Frequently asked questions
 

--- a/docs/integrations/tasmota.md
+++ b/docs/integrations/tasmota.md
@@ -1,53 +1,154 @@
 ---
 id: tasmota
-title: Tasmota
-description: "Connect Tasmota devices to Gladys Assistant: flash the open-source firmware on your ESP8266 device, configure MQTT and control it in Gladys."
+title: "Tasmota and Gladys: flash your devices and control them locally over MQTT"
+description: "Connect Tasmota devices to Gladys Assistant: flash the open-source firmware on your ESP8266 or ESP32 device with the web installer, configure MQTT and control everything locally."
 sidebar_label: Tasmota
+keywords:
+  - tasmota
+  - tasmota mqtt
+  - tasmota gladys
+  - tasmota web installer
+  - tasmota esp8266
+  - tasmota esp32
+  - tasmota local
 ---
 
-Tasmota is an open source firmware for ESP8266 devices.
+import JsonLd from '@site/src/components/seo/JsonLd';
 
-To connect them to Gladys:
+[Tasmota](https://tasmota.github.io/docs/) is a free, open-source firmware for ESP8266, ESP8285 and ESP32 based devices. It replaces the manufacturer's cloud firmware on smart plugs, switches, bulbs and sensors so they run **entirely locally**, with no vendor account and no internet dependency, and exposes them over MQTT, HTTP or serial.
 
-- flash your device with Tamosta firmware
-- configure it
-- go to `Integrations / Tasmota` in Gladys
+Because Tasmota talks plain MQTT, it's a perfect match for Gladys Assistant: once flashed, your devices are discovered and controlled locally, on your own network, without going through any third-party cloud.
 
-## Flash with Tasmota firmware
+To connect a Tasmota device to Gladys, there are three steps:
 
-Follow instructions on <a href="https://tasmota.github.io/docs/Getting-Started/" target="_blank">Tasmota installation user guide</a>.
+- flash your device with the Tasmota firmware
+- configure MQTT on the device
+- add it in `Integrations / Tasmota` in Gladys
 
-There are many firmware installation guides online, depending on the device. You will be able to find the right guide for your device by browsing through the search results.
+## Why use Tasmota with Gladys?
 
-## Configure device
+- **Fully local and private**: the device no longer phones home to the manufacturer's servers. It communicates only with your local MQTT broker and Gladys.
+- **No cloud, no subscription**: Tasmota is free and open source, and keeps working even if the original manufacturer shuts down their service.
+- **Reuse cheap hardware**: many affordable smart plugs and switches (Sonoff, and other ESP-based devices) can be re-flashed instead of being thrown away.
+- **Reliable and fast**: local commands don't depend on your internet connection, so automations run instantly.
 
-Once flashed with new firmare, go to the device web page and configure MQTT as describe at <a href="https://tasmota.github.io/docs/MQTT/" target="_blank">Tasmota MQTT configuration</a>.
+:::tip Tasmota or Zigbee?
+Tasmota runs on Wi-Fi devices, so each one connects directly to your router — convenient for a few mains-powered plugs and switches. For battery-powered sensors and large fleets of devices, a low-power [Zigbee](./zigbee2mqtt.md) mesh is usually a better fit. Both are local and both work great in Gladys, and you can mix them. See our [Zigbee dongle buyer's guide](/best-zigbee-dongle/) if you go the Zigbee route.
+:::
 
-Enter your MQTT broken information and fill the <i>Topic</i> field with the expected unique device identifier.
+## Flash your device with Tasmota
 
-Click on `Configuration`.
+The easiest way to install Tasmota is the official **web installer**: [tasmota.github.io/install](https://tasmota.github.io/install/). It flashes your device straight from a Chrome or Edge browser over USB (using the WebSerial API), with no extra software to install.
+
+It supports every Espressif ESP8266, ESP8285, ESP32, ESP32-S and ESP32-C3 based device.
+
+If your device needs a manual flash, follow the [Tasmota installation guide](https://tasmota.github.io/docs/Getting-Started/). There are many device-specific tutorials online; you'll find the right one for your exact model by searching for its name plus "Tasmota".
+
+## Configure MQTT on the device
+
+Once flashed, open the device's web page (its IP address on your network) and configure MQTT as described in the [Tasmota MQTT documentation](https://tasmota.github.io/docs/MQTT/).
+
+Click on the `Configuration` menu.
 
 ![Tasmota menu](../../static/img/docs/en/configuration/tasmota/tasmota-home.png)
 
-Click on `Configure MQTT` menu.
+Click on the `Configure MQTT` menu.
 
 ![Tasmota configuration](../../static/img/docs/en/configuration/tasmota/tasmota-configuration.png)
 
-Then fill configuration form with your information:
+Then fill in the configuration form with your MQTT broker information:
 
-- `Host` : MQTT broker URL
-- `Port` : MQTT broker port
-- `User` : user to connect to MOQTT broker
-- `Password` : password to connect to MQTT broker
+- `Host`: MQTT broker URL
+- `Port`: MQTT broker port
+- `User`: user to connect to the MQTT broker
+- `Password`: password to connect to the MQTT broker
+- `Topic`: a unique identifier for this device
 
 ![Tasmota MQTT](../../static/img/docs/en/configuration/tasmota/tasmota-mqtt.png)
 
+:::note
+Gladys ships with its own MQTT broker. If you haven't set one up yet, install the [MQTT integration](./mqtt.md) in Gladys first, then point your Tasmota devices to it.
+:::
+
 ## Add the device to Gladys
 
-Once saved, go back to Gladys:
+Once the device is configured, go back to Gladys:
 
-1. to `Integration -> Tasmota` page
-2. select `MQTT discover` menu
-3. click on `Scan`button (if device is not already listed)
-4. then `Save`
+1. open the `Integrations -> Tasmota` page
+2. select the `MQTT discover` menu
+3. click the `Scan` button (if the device isn't already listed)
+4. then click `Save`
 5. and voilà!
+
+Your Tasmota device is now controllable from Gladys, included in your dashboards and usable in your [scenes](/docs/scenes/intro/) — all locally.
+
+## Frequently asked questions
+
+### Is Tasmota compatible with Gladys Assistant?
+
+Yes. Tasmota communicates over MQTT, and Gladys has a native Tasmota integration that discovers and controls Tasmota devices on your local network. You just flash the firmware, configure MQTT on the device, and scan for it in `Integrations / Tasmota`.
+
+### Does Tasmota work without the cloud or internet?
+
+Yes. That's the whole point of Tasmota: it replaces the manufacturer's cloud firmware with local control over MQTT and HTTP. Once flashed and paired with Gladys, your device works entirely on your local network, even with no internet connection.
+
+### Which devices can run Tasmota?
+
+Any device based on an Espressif ESP8266, ESP8285, ESP32, ESP32-S or ESP32-C3 chip can be flashed with Tasmota. This includes many smart plugs, switches, relays, bulbs and sensors (such as a number of Sonoff devices).
+
+### How do I flash Tasmota?
+
+The easiest method is the official web installer at tasmota.github.io/install, which flashes your device directly from a Chrome or Edge browser over USB, with no software to install. Manual flashing is also possible following the Tasmota installation guide.
+
+### Do I need a separate MQTT broker for Tasmota?
+
+You need an MQTT broker, but Gladys ships with one. Install the MQTT integration in Gladys, then point your Tasmota devices' MQTT settings to that broker. Gladys will then discover them automatically.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Is Tasmota compatible with Gladys Assistant?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Tasmota communicates over MQTT, and Gladys has a native Tasmota integration that discovers and controls Tasmota devices on your local network. You flash the firmware, configure MQTT on the device, then scan for it in Integrations / Tasmota.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Does Tasmota work without the cloud or internet?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Tasmota replaces the manufacturer's cloud firmware with local control over MQTT and HTTP. Once flashed and paired with Gladys, your device works entirely on your local network, even with no internet connection.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Which devices can run Tasmota?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Any device based on an Espressif ESP8266, ESP8285, ESP32, ESP32-S or ESP32-C3 chip can be flashed with Tasmota. This includes many smart plugs, switches, relays, bulbs and sensors, such as a number of Sonoff devices.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I flash Tasmota?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "The easiest method is the official web installer at tasmota.github.io/install, which flashes your device directly from a Chrome or Edge browser over USB, with no software to install. Manual flashing is also possible by following the Tasmota installation guide.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Do I need a separate MQTT broker for Tasmota?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "You need an MQTT broker, but Gladys ships with one. Install the MQTT integration in Gladys, then point your Tasmota devices' MQTT settings to that broker, and Gladys will discover them automatically.",
+        },
+      },
+    ],
+  }}
+/>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tasmota.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tasmota.md
@@ -33,7 +33,7 @@ Pour connecter un appareil Tasmota à Gladys, trois étapes :
 - **Réutilisez du matériel bon marché** : de nombreuses prises et interrupteurs connectés abordables (Sonoff et autres appareils à base d'ESP) peuvent être reflashés plutôt que jetés.
 - **Fiable et rapide** : les commandes locales ne dépendent pas de votre connexion Internet, vos automatisations s'exécutent instantanément.
 
-:::tip Tasmota ou Zigbee ?
+:::tip[Tasmota ou Zigbee ?]
 Tasmota fonctionne sur des appareils Wi-Fi, chacun se connectant directement à votre box — pratique pour quelques prises et interrupteurs sur secteur. Pour des capteurs sur batterie et de grands parcs d'appareils, un maillage [Zigbee](./zigbee2mqtt.md) basse consommation est souvent préférable. Les deux sont locaux et fonctionnent très bien dans Gladys, et vous pouvez les mélanger. Consultez notre [guide d'achat des clés Zigbee](/fr/best-zigbee-dongle/) si vous partez sur le Zigbee.
 :::
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tasmota.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tasmota.md
@@ -34,7 +34,7 @@ Pour connecter un appareil Tasmota à Gladys, trois étapes :
 - **Fiable et rapide** : les commandes locales ne dépendent pas de votre connexion Internet, vos automatisations s'exécutent instantanément.
 
 :::tip[Tasmota ou Zigbee ?]
-Tasmota fonctionne sur des appareils Wi-Fi, chacun se connectant directement à votre box — pratique pour quelques prises et interrupteurs sur secteur. Pour des capteurs sur batterie et de grands parcs d'appareils, un maillage [Zigbee](./zigbee2mqtt.md) basse consommation est souvent préférable. Les deux sont locaux et fonctionnent très bien dans Gladys, et vous pouvez les mélanger. Consultez notre [guide d'achat des clés Zigbee](/fr/best-zigbee-dongle/) si vous partez sur le Zigbee.
+Tasmota fonctionne sur des appareils Wi-Fi, chacun se connectant directement à votre box, ce qui est pratique pour quelques prises et interrupteurs sur secteur. Pour des capteurs sur batterie et de grands parcs d'appareils, un maillage [Zigbee](./zigbee2mqtt.md) basse consommation est souvent préférable. Les deux sont locaux et fonctionnent très bien dans Gladys, et vous pouvez les mélanger. Consultez notre [guide d'achat des clés Zigbee](/fr/best-zigbee-dongle/) si vous partez sur le Zigbee.
 :::
 
 ## Flashez votre appareil avec Tasmota
@@ -81,7 +81,7 @@ Une fois l'appareil configuré, il ne reste qu'à :
 4. enfin, cliquer sur `Sauvegarder`
 5. et voilà !
 
-Votre appareil Tasmota est désormais pilotable depuis Gladys, intégré à vos dashboards et utilisable dans vos [scènes](/fr/docs/scenes/intro/) — le tout en local.
+Votre appareil Tasmota est désormais pilotable depuis Gladys, intégré à vos dashboards et utilisable dans vos [scènes](/fr/docs/scenes/intro/), le tout en local.
 
 ## Questions fréquentes
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tasmota.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/tasmota.md
@@ -1,29 +1,53 @@
 ---
 id: tasmota
-title: Tasmota
-description: "Connectez vos appareils Tasmota à Gladys Assistant : flashez le firmware open-source sur votre ESP8266, configurez MQTT et pilotez-les dans Gladys."
+title: "Tasmota et Gladys : flashez vos appareils et pilotez-les en local via MQTT"
+description: "Connectez vos appareils Tasmota à Gladys Assistant : flashez le firmware open-source sur votre ESP8266 ou ESP32 avec le web installer, configurez MQTT et pilotez tout en local."
 sidebar_label: Tasmota
+keywords:
+  - tasmota
+  - tasmota mqtt
+  - tasmota français
+  - tasmota gladys
+  - tasmota web installer
+  - tasmota esp8266
+  - tasmota esp32
+  - tasmota local
 ---
 
-Tasmota est un firmware OpenSource pour des appareils basé sur des ESP8266.
+import JsonLd from '@site/src/components/seo/JsonLd';
 
-Pour connecter vos appareils :
+[Tasmota](https://tasmota.github.io/docs/) est un firmware libre et open source pour les appareils à base d'ESP8266, ESP8285 et ESP32. Il remplace le firmware cloud du fabricant sur les prises connectées, interrupteurs, ampoules et capteurs pour qu'ils fonctionnent **entièrement en local**, sans compte fabricant ni dépendance à Internet, et les expose en MQTT, HTTP ou série.
 
-- installez Tasmota sur votre appareil
-- configurez votre appareil
-- allez dans `Intégrations / Tasmota` dans Gladys
+Comme Tasmota communique en MQTT standard, il s'accorde parfaitement avec Gladys Assistant : une fois flashés, vos appareils sont découverts et pilotés en local, sur votre propre réseau, sans passer par aucun cloud tiers.
 
-## Installation du firmware Tasmota
+Pour connecter un appareil Tasmota à Gladys, trois étapes :
 
-Merci de suivre les instructions sur <a href="https://tasmota.github.io/docs/Getting-Started/" target="_blank">le guide d'installation de Tasmota</a>.
+- flashez votre appareil avec le firmware Tasmota
+- configurez le MQTT sur l'appareil
+- ajoutez-le dans `Intégrations / Tasmota` dans Gladys
 
-Il existe des multiples guides d'installation du firmware sur Internet, l'installation est spécifique à chaque appareil.
+## Pourquoi utiliser Tasmota avec Gladys ?
 
-## Configuration du périphérique
+- **100 % local et privé** : l'appareil ne communique plus avec les serveurs du fabricant. Il dialogue uniquement avec votre broker MQTT local et Gladys.
+- **Sans cloud, sans abonnement** : Tasmota est gratuit et open source, et continue de fonctionner même si le fabricant d'origine ferme son service.
+- **Réutilisez du matériel bon marché** : de nombreuses prises et interrupteurs connectés abordables (Sonoff et autres appareils à base d'ESP) peuvent être reflashés plutôt que jetés.
+- **Fiable et rapide** : les commandes locales ne dépendent pas de votre connexion Internet, vos automatisations s'exécutent instantanément.
 
-Une fois que le firmware Tasmota est correctement installé, rendez-vous sur la page web du périphérique et configurez le protocole MQTT comme indiqué sur <a href="https://tasmota.github.io/docs/MQTT/" target="_blank">la page de configuration de MQTT pour Tasmota</a>.
+:::tip Tasmota ou Zigbee ?
+Tasmota fonctionne sur des appareils Wi-Fi, chacun se connectant directement à votre box — pratique pour quelques prises et interrupteurs sur secteur. Pour des capteurs sur batterie et de grands parcs d'appareils, un maillage [Zigbee](./zigbee2mqtt.md) basse consommation est souvent préférable. Les deux sont locaux et fonctionnent très bien dans Gladys, et vous pouvez les mélanger. Consultez notre [guide d'achat des clés Zigbee](/fr/best-zigbee-dongle/) si vous partez sur le Zigbee.
+:::
 
-Remplissez les informations selon votre agent (broker) MQTT, et saisissez l'identifiant unique du périphérique dans le champ <i>Topic</i>.
+## Flashez votre appareil avec Tasmota
+
+Le moyen le plus simple d'installer Tasmota est le **web installer** officiel : [tasmota.github.io/install](https://tasmota.github.io/install/). Il flashe votre appareil directement depuis un navigateur Chrome ou Edge via USB (grâce à l'API WebSerial), sans aucun logiciel à installer.
+
+Il prend en charge tous les appareils à base d'Espressif ESP8266, ESP8285, ESP32, ESP32-S et ESP32-C3.
+
+Si votre appareil nécessite un flash manuel, suivez le [guide d'installation de Tasmota](https://tasmota.github.io/docs/Getting-Started/). Il existe de nombreux tutoriels spécifiques à chaque appareil ; vous trouverez le bon en cherchant le nom de votre modèle suivi de « Tasmota ».
+
+## Configurez le MQTT sur l'appareil
+
+Une fois le firmware installé, ouvrez la page web de l'appareil (son adresse IP sur votre réseau) et configurez le MQTT comme indiqué sur la [documentation MQTT de Tasmota](https://tasmota.github.io/docs/MQTT/).
 
 Cliquez sur le menu `Configuration`.
 
@@ -33,14 +57,19 @@ Cliquez sur le menu `Configuration MQTT`.
 
 ![Tasmota configuration](../../../../../static/img/docs/fr/configuration/tasmota/tasmota-configuration.png)
 
-Puis remplissez le formulaire avec vos informations :
+Puis remplissez le formulaire avec les informations de votre broker MQTT :
 
 - `Host` : l'adresse du broker MQTT
 - `Port` : le port du broker
 - `User` : l'identifiant pour se connecter au broker
 - `Password` : le mot de passe pour se connecter au broker
+- `Topic` : un identifiant unique pour cet appareil
 
 ![Tasmota MQTT](../../../../../static/img/docs/fr/configuration/tasmota/tamosta-mqtt.png)
+
+:::note
+Gladys embarque son propre broker MQTT. Si vous n'en avez pas encore configuré, installez d'abord l'[intégration MQTT](./mqtt.md) dans Gladys, puis faites pointer vos appareils Tasmota dessus.
+:::
 
 ## Ajouter un appareil dans Gladys
 
@@ -51,3 +80,76 @@ Une fois l'appareil configuré, il ne reste qu'à :
 3. cliquer sur le bouton `Scanner` en haut à droite (si le périphérique n'est pas déjà dans la liste)
 4. enfin, cliquer sur `Sauvegarder`
 5. et voilà !
+
+Votre appareil Tasmota est désormais pilotable depuis Gladys, intégré à vos dashboards et utilisable dans vos [scènes](/fr/docs/scenes/intro/) — le tout en local.
+
+## Questions fréquentes
+
+### Tasmota est-il compatible avec Gladys Assistant ?
+
+Oui. Tasmota communique en MQTT, et Gladys dispose d'une intégration Tasmota native qui découvre et pilote les appareils Tasmota sur votre réseau local. Il suffit de flasher le firmware, de configurer le MQTT sur l'appareil, puis de le scanner dans `Intégrations / Tasmota`.
+
+### Tasmota fonctionne-t-il sans cloud ni Internet ?
+
+Oui. C'est tout l'intérêt de Tasmota : il remplace le firmware cloud du fabricant par un contrôle local en MQTT et HTTP. Une fois flashé et associé à Gladys, votre appareil fonctionne entièrement sur votre réseau local, même sans connexion Internet.
+
+### Quels appareils peuvent fonctionner avec Tasmota ?
+
+Tout appareil basé sur une puce Espressif ESP8266, ESP8285, ESP32, ESP32-S ou ESP32-C3 peut être flashé avec Tasmota. Cela concerne de nombreuses prises, interrupteurs, relais, ampoules et capteurs connectés (comme plusieurs appareils Sonoff).
+
+### Comment flasher Tasmota ?
+
+Le plus simple est le web installer officiel sur tasmota.github.io/install, qui flashe votre appareil directement depuis un navigateur Chrome ou Edge via USB, sans logiciel à installer. Le flash manuel est également possible en suivant le guide d'installation de Tasmota.
+
+### Faut-il un broker MQTT séparé pour Tasmota ?
+
+Il faut un broker MQTT, mais Gladys en embarque un. Installez l'intégration MQTT dans Gladys, puis faites pointer la configuration MQTT de vos appareils Tasmota vers ce broker : Gladys les découvrira automatiquement.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Tasmota est-il compatible avec Gladys Assistant ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui. Tasmota communique en MQTT, et Gladys dispose d'une intégration Tasmota native qui découvre et pilote les appareils Tasmota sur votre réseau local. Il suffit de flasher le firmware, de configurer le MQTT sur l'appareil, puis de le scanner dans Intégrations / Tasmota.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Tasmota fonctionne-t-il sans cloud ni Internet ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui. Tasmota remplace le firmware cloud du fabricant par un contrôle local en MQTT et HTTP. Une fois flashé et associé à Gladys, votre appareil fonctionne entièrement sur votre réseau local, même sans connexion Internet.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Quels appareils peuvent fonctionner avec Tasmota ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Tout appareil basé sur une puce Espressif ESP8266, ESP8285, ESP32, ESP32-S ou ESP32-C3 peut être flashé avec Tasmota. Cela concerne de nombreuses prises, interrupteurs, relais, ampoules et capteurs connectés, comme plusieurs appareils Sonoff.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Comment flasher Tasmota ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Le plus simple est le web installer officiel sur tasmota.github.io/install, qui flashe votre appareil directement depuis un navigateur Chrome ou Edge via USB, sans logiciel à installer. Le flash manuel est également possible en suivant le guide d'installation de Tasmota.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Faut-il un broker MQTT séparé pour Tasmota ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Il faut un broker MQTT, mais Gladys en embarque un. Installez l'intégration MQTT dans Gladys, puis faites pointer la configuration MQTT de vos appareils Tasmota vers ce broker : Gladys les découvrira automatiquement.",
+        },
+      },
+    ],
+  }}
+/>


### PR DESCRIPTION
Targets the large, near-zero-CTR Tasmota search cluster (tasmota, tasmota mqtt, tasmota web installer, tasmota français…) sitting at position 7-9.

- Fix typos in the existing doc (Tamosta, MOQTT, "MQTT broken", firmare)
- Modernize: ESP32/ESP32-S/ESP32-C3 support, official browser web installer (tasmota.github.io/install), fully-local control over MQTT framing
- Add SEO/intent title + keywords frontmatter (URL unchanged)
- Add "Why use Tasmota with Gladys?" (local/privacy) and a Tasmota-vs-Zigbee tip linking to the Zigbee dongle guide
- Add a Frequently asked questions section + FAQPage JSON-LD (5 Q&A)
- Internal links to MQTT integration, zigbee2mqtt and scenes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Tasmota integration guide in English and French with clearer setup steps, modernized wording, and improved navigation.
  * Expanded device compatibility details to cover more ESP-based hardware and web-based flashing options.
  * Added a new FAQ section addressing offline use, flashing, supported devices, and MQTT setup.
  * Improved discoverability with updated page metadata and structured FAQ information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->