### PR TITLE
chore: remove em/en dashes from all site content

### DIFF
--- a/blog/2024-11-01-proactive-ai.md
+++ b/blog/2024-11-01-proactive-ai.md
@@ -20,7 +20,7 @@ That was a good start, but I want to take it further! What if AI could be proact
 
 {/* truncate */}
 
-Imagine a car pulls up in front of your house. A dedicated security guard would watch, recognize your car—its shape, color, license plate—and know immediately that it’s you. But hiring a 24/7 guard isn’t within reach for everyone!
+Imagine a car pulls up in front of your house. A dedicated security guard would watch, recognize your car, its shape, color, license plate, and know immediately that it’s you. But hiring a 24/7 guard isn’t within reach for everyone!
 
 What if AI could play that role?
 
@@ -53,7 +53,7 @@ For instance, you could send a CO2 sensor value and request an action if the lev
 
 ![Analyzing Co2 Level Gladys](../static/img/articles/en/gladys-4-48/ask-ai-sensor.png)
 
-No need to look up recommended CO2 levels in a room—the AI draws on its extensive knowledge (essentially all of the internet!) to assess the situation and act intelligently.
+No need to look up recommended CO2 levels in a room, the AI draws on its extensive knowledge (essentially all of the internet!) to assess the situation and act intelligently.
 
 It’s even possible to inject values retrieved from other APIs to:
 

--- a/blog/2025-01-17-2024-yearly-review.md
+++ b/blog/2025-01-17-2024-yearly-review.md
@@ -41,7 +41,7 @@ The start of 2024 saw a significant increase in new installations compared to 20
 
 ![Installations 2024 Gladys Assistant](../static/img/articles/fr/year-in-review-2024/installations.jpg)
 
-The end of the year was quieter, and it’s hard to say whether this decrease in activity is due to my own slower pace — I was traveling in September/October and then on Christmas holidays at the end of the year — or if it was simply a period when everyone was generally less available. In any case, these variations are normal: there are always ups and downs 😄
+The end of the year was quieter, and it’s hard to say whether this decrease in activity is due to my own slower pace, I was traveling in September/October and then on Christmas holidays at the end of the year, or if it was simply a period when everyone was generally less available. In any case, these variations are normal: there are always ups and downs 😄
 
 ### Revenue
 

--- a/blog/2026-02-08-official-starter-kit-back-in-stock.md
+++ b/blog/2026-02-08-official-starter-kit-back-in-stock.md
@@ -14,11 +14,11 @@ Quick news: I just came back from holidays, and the **official starter kit is ba
 
 It's available to ship in two versions:
 
-- **Beelink S12** — 8 GB RAM / Intel N95 CPU / 256 GB SSD
-- **Beelink S13** — 16 GB RAM / Intel N150 CPU / 500 GB SSD
+- **Beelink S12**: 8 GB RAM / Intel N95 CPU / 256 GB SSD
+- **Beelink S13**: 16 GB RAM / Intel N150 CPU / 500 GB SSD
 
 👉 [Discover the official starter kit](/starter-kit/)
 
 The starter kit is the easiest way to run Gladys: a small, silent, low-power mini-PC, pre-configured and ready to go, with no command line or Docker setup required.
 
-And if you're looking for a different model, anything is possible — I do custom builds as long as the mini-PC you want is available on Amazon. Just reach out 😉
+And if you're looking for a different model, anything is possible, I do custom builds as long as the mini-PC you want is available on Amazon. Just reach out 😉

--- a/blog/2026-02-09-ai-built-a-full-integration-claude-opus.md
+++ b/blog/2026-02-09-ai-built-a-full-integration-claude-opus.md
@@ -20,6 +20,6 @@ I show the whole process in my latest YouTube video:
 
 The final pull request is here: [GladysAssistant/Gladys#2430](https://github.com/GladysAssistant/Gladys/pull/2430)
 
-This matters for Gladys: it means we can dramatically lower the barrier to contributing new integrations. If you have comments, drop them under the YouTube video — it really helps the channel, and I'll answer quickly!
+This matters for Gladys: it means we can dramatically lower the barrier to contributing new integrations. If you have comments, drop them under the YouTube video, it really helps the channel, and I'll answer quickly!
 
 Have a great week 🚀

--- a/blog/2026-02-17-gladys-featured-on-igeneration.md
+++ b/blog/2026-02-17-gladys-featured-on-igeneration.md
@@ -14,6 +14,6 @@ Some great news on the press side: Gladys was just featured on **iGeneration (iG
 
 The title says it all: *"Gladys Assistant, the home automation that's more advanced than Apple Home and more accessible than Home Assistant."*
 
-It's always a pleasure to see the project recognized by a media outlet aimed at the general public, and not just by the tech-savvy home automation crowd. It's a sign that the vision behind Gladys — a powerful **yet** approachable, privacy-first, open-source home assistant — resonates beyond our community.
+It's always a pleasure to see the project recognized by a media outlet aimed at the general public, and not just by the tech-savvy home automation crowd. It's a sign that the vision behind Gladys, a powerful **yet** approachable, privacy-first, open-source home assistant, resonates beyond our community.
 
 👉 [Read the article on iGen.fr](https://www.igen.fr/domotique/2026/02/gladys-assistant-la-domotique-plus-avancee-que-maison-et-plus-accessible-que-home-assistant-154785)

--- a/blog/2026-02-23-gladys-4-68-matterbridge.md
+++ b/blog/2026-02-23-gladys-4-68-matterbridge.md
@@ -8,7 +8,7 @@ slug: gladys-4-68-matterbridge
 
 Hey everyone,
 
-A new version of Gladys is out, with several improvements and fixes — including a one-click way to run **Matterbridge** and open the door to many more compatible devices.
+A new version of Gladys is out, with several improvements and fixes, including a one-click way to run **Matterbridge** and open the door to many more compatible devices.
 
 {/* truncate */}
 

--- a/blog/2026-02-27-ai-controls-my-home-openclaw.md
+++ b/blog/2026-02-27-ai-controls-my-home-openclaw.md
@@ -1,6 +1,6 @@
 ---
 title: "I Let the OpenClaw AI Control My Smart Home"
-description: "I connected the OpenClaw AI framework to Gladys to let an autonomous agent control a real smart home. Impressive results — and safety lessons."
+description: "I connected the OpenClaw AI framework to Gladys to let an autonomous agent control a real smart home. Impressive results, and safety lessons."
 authors: pierregilles
 image: /img/presentation/ai-controls-my-home-openclaw-en.jpg
 slug: ai-controls-my-home-openclaw
@@ -8,7 +8,7 @@ slug: ai-controls-my-home-openclaw
 
 Hey everyone!
 
-You've probably heard of **OpenClaw**, the AI framework that blew up on GitHub a few weeks ago and was just acquired by OpenAI. I decided to connect it to Gladys to see what it could do — and honestly, the result is impressive.
+You've probably heard of **OpenClaw**, the AI framework that blew up on GitHub a few weeks ago and was just acquired by OpenAI. I decided to connect it to Gladys to see what it could do, and honestly, the result is impressive.
 
 {/* truncate */}
 
@@ -18,4 +18,4 @@ I plugged OpenClaw into Gladys to test the possibilities of letting an autonomou
 
 **A word of caution:** I don't recommend installing OpenClaw on your Gladys server. It's still very early software, it touches a bit of everything, and it has been criticized for security issues. For this test, I deployed OpenClaw on an isolated cloud VM to keep everything sandboxed 🔐
 
-It's a fascinating glimpse of where AI-driven home automation is heading — but safety and privacy come first.
+It's a fascinating glimpse of where AI-driven home automation is heading, but safety and privacy come first.

--- a/blog/2026-02-27-gladys-4-69-zigbee2mqtt-ember.md
+++ b/blog/2026-02-27-gladys-4-69-zigbee2mqtt-ember.md
@@ -8,7 +8,7 @@ slug: gladys-4-69-zigbee2mqtt-ember
 
 Hey everyone,
 
-A new version of Gladys Assistant is available 🥳 — featuring the new Zigbee2mqtt Ember driver and Tasmota energy tracking.
+A new version of Gladys Assistant is available 🥳, featuring the new Zigbee2mqtt Ember driver and Tasmota energy tracking.
 
 {/* truncate */}
 
@@ -18,11 +18,11 @@ Zigbee2mqtt now offers a new driver, **Ember**, for certain dongles such as the 
 
 If you use EZSP, Zigbee2mqtt won't touch your installation without your action, to avoid breaking your setup. **Stability is a core value of the project**, and this update was designed not to impact your daily use.
 
-If you want to switch to Ember, you can — but you'll probably need to update your Zigbee dongle's firmware first. For example, for the Sonoff Dongle-E, the integration lets you choose between "Ember" (the new default) and the old EZSP driver:
+If you want to switch to Ember, you can, but you'll probably need to update your Zigbee dongle's firmware first. For example, for the Sonoff Dongle-E, the integration lets you choose between "Ember" (the new default) and the old EZSP driver:
 
 ![Selecting the Zigbee driver](../static/img/articles/gladys-4-69-zigbee2mqtt-ember/01.png)
 
-If you test the new driver and your firmware isn't compatible, don't panic — you'll see a clear message:
+If you test the new driver and your firmware isn't compatible, don't panic, you'll see a clear message:
 
 ![Firmware incompatibility message](../static/img/articles/gladys-4-69-zigbee2mqtt-ember/02.png)
 

--- a/blog/2026-03-05-run-local-llm-on-mini-pc.md
+++ b/blog/2026-03-05-run-local-llm-on-mini-pc.md
@@ -16,4 +16,4 @@ Can you really run a capable AI model locally, on a small mini-PC, without sendi
 
 Running AI locally is a topic that's very close to the heart of the Gladys project: privacy first, your data stays at home. In this video I show how I got an AI model running on a mini-PC, what kind of hardware it takes, and what you can realistically expect.
 
-If you have questions, feel free to leave them in the comments on YouTube — it really helps with visibility 😉
+If you have questions, feel free to leave them in the comments on YouTube, it really helps with visibility 😉

--- a/blog/2026-03-06-gladys-4-70-reset-zigbee2mqtt.md
+++ b/blog/2026-03-06-gladys-4-70-reset-zigbee2mqtt.md
@@ -16,7 +16,7 @@ A new version of Gladys is out, focused on UX and stability improvements for the
 
 ### A reset button for Zigbee2mqtt
 
-A new **"Reset"** button appears in the Zigbee2mqtt integration. It lets users with a corrupted integration — or who simply want to switch dongles — completely reset the integration in a single click.
+A new **"Reset"** button appears in the Zigbee2mqtt integration. It lets users with a corrupted integration, or who simply want to switch dongles, completely reset the integration in a single click.
 
 ![Reset button in the Zigbee2mqtt integration](../static/img/articles/gladys-4-70-reset-zigbee2mqtt/01.png)
 

--- a/blog/2026-03-20-gladys-4-71-nuki-matter.md
+++ b/blog/2026-03-20-gladys-4-71-nuki-matter.md
@@ -28,7 +28,7 @@ Thanks [@ProtZ](https://community.gladysassistant.com/) for this thorough work!
 Matter keeps evolving quickly in Gladys:
 
 - **Clearer pairing process:** pairing instructions are now easier to read and more accessible for new users.
-- **New Boolean & Switch clusters:** to support the IKEA BILRESA and the Aqara Door and Window Sensor P2. I developed this compatibility by testing through Matterbridge — feedback on IKEA / Aqara devices is very welcome 🙂
+- **New Boolean & Switch clusters:** to support the IKEA BILRESA and the Aqara Door and Window Sensor P2. I developed this compatibility by testing through Matterbridge, feedback on IKEA / Aqara devices is very welcome 🙂
 - **HEPA filter monitoring:** Matter-compatible air purifiers can now expose their HEPA filter status in Gladys. Thanks **@Nagromdark**!
 
 I'm continuing to invest heavily in Matter, and I'm currently preparing a major update of the `matter-js` library for even more stability and compatibility.
@@ -41,7 +41,7 @@ A message now clearly indicates that this integration only works with Bluetooth 
 
 ## 🛠️ Missing icons for energy production sensors
 
-`ENERGY_PRODUCTION_SENSOR` features had missing icons in some views. This is now fixed — thanks **@Terdious**!
+`ENERGY_PRODUCTION_SENSOR` features had missing icons in some views. This is now fixed, thanks **@Terdious**!
 
 ---
 

--- a/blog/2026-03-26-make-any-washing-machine-smart.md
+++ b/blog/2026-03-26-make-any-washing-machine-smart.md
@@ -14,6 +14,6 @@ Today I want to share a genuinely useful automation I set up at home, using noth
 
 [![How to make any washing machine smart](../static/img/articles/make-any-washing-machine-smart/youtube.jpg)](https://youtu.be/gn-bBBs39G0)
 
-The idea is simple: by measuring the power consumption of the plug, Gladys knows exactly when a laundry cycle starts and when it finishes — and can then send you a notification so you never forget your laundry in the machine again. No special appliance required, just a Zigbee plug with energy monitoring and a Gladys scene.
+The idea is simple: by measuring the power consumption of the plug, Gladys knows exactly when a laundry cycle starts and when it finishes, and can then send you a notification so you never forget your laundry in the machine again. No special appliance required, just a Zigbee plug with energy monitoring and a Gladys scene.
 
 I walk through the whole setup in the video above. If you have questions, drop them in the comments on YouTube 🙏

--- a/blog/2026-04-03-gladys-4-72-faster-ai-stable-homekit.md
+++ b/blog/2026-04-03-gladys-4-72-faster-ai-stable-homekit.md
@@ -8,7 +8,7 @@ slug: gladys-4-72-faster-ai-stable-homekit
 
 Hey everyone!
 
-Gladys Assistant 4.72.0 is available 🎉 — with a faster AI, a more stable HomeKit, and a long list of fixes.
+Gladys Assistant 4.72.0 is available 🎉, with a faster AI, a more stable HomeKit, and a long list of fixes.
 
 {/* truncate */}
 
@@ -17,7 +17,7 @@ Gladys Assistant 4.72.0 is available 🎉 — with a faster AI, a more stable Ho
 - **Zigbee: dual on/off support for the IKEA BILRESA button.** The IKEA BILRESA button is now fully supported via Zigbee2mqtt.
 - **AI: lower latency and cost.** Camera images sent to the AI are now resized before sending, which reduces both the latency and the cost of API calls.
 - **Integration list: tags added.** Integrations are now tagged (local, cloud, Gladys Plus) to make their operating mode clearer.
-- **ZwaveJS UI: out of alpha.** The ZwaveJS UI integration is stable enough — the alpha warning banner has been removed.
+- **ZwaveJS UI: out of alpha.** The ZwaveJS UI integration is stable enough, the alpha warning banner has been removed.
 - **MQTT: renamed to "MQTT Virtual Devices"** to make the integration easier to understand for users coming from Home Assistant.
 - **Node-RED: warning before container deletion.** A message now warns that deleting the Node-RED container also deletes all associated data.
 

--- a/blog/2026-04-03-mistral-vs-elevenlabs-voice-ai.md
+++ b/blog/2026-04-03-mistral-vs-elevenlabs-voice-ai.md
@@ -1,6 +1,6 @@
 ---
 title: "Mistral vs ElevenLabs: Is the Voice AI Revolution French? 🇫🇷"
-description: "Mistral's local Voxtral text-to-speech vs ElevenLabs — plus a move to Mistral Small 3.2 on Scaleway for Gladys Plus, with higher AI quotas."
+description: "Mistral's local Voxtral text-to-speech vs ElevenLabs, plus a move to Mistral Small 3.2 on Scaleway for Gladys Plus, with higher AI quotas."
 authors: pierregilles
 image: /img/presentation/mistral-vs-elevenlabs-voice-ai-en.jpg
 slug: mistral-vs-elevenlabs-voice-ai
@@ -8,7 +8,7 @@ slug: mistral-vs-elevenlabs-voice-ai
 
 Hey everyone,
 
-Last week, Mistral released a new Text-to-Speech model (Voxtral) capable of running 100% locally, without sending any data to the cloud. I wanted to test it head-to-head against ElevenLabs — and honestly, the results are really good!
+Last week, Mistral released a new Text-to-Speech model (Voxtral) capable of running 100% locally, without sending any data to the cloud. I wanted to test it head-to-head against ElevenLabs, and honestly, the results are really good!
 
 {/* truncate */}
 

--- a/blog/2026-04-10-matterbridge-ai-revolution.md
+++ b/blog/2026-04-10-matterbridge-ai-revolution.md
@@ -1,6 +1,6 @@
 ---
 title: "Matterbridge + AI: Make Any Device Work With Gladys, Without Writing Code"
-description: "Combining Matterbridge with AI, we can make almost any device compatible with Gladys — without writing code. Here's the vision."
+description: "Combining Matterbridge with AI, we can make almost any device compatible with Gladys, without writing code. Here's the vision."
 authors: pierregilles
 image: /img/presentation/matterbridge-ai-revolution-en.jpg
 slug: matterbridge-ai-revolution
@@ -8,7 +8,7 @@ slug: matterbridge-ai-revolution
 
 Hey everyone,
 
-I spent a lot of last week tinkering with Matterbridge, and I had a real "aha" moment I wanted to share: we're going to be able to make **any device** Matter-compatible — and therefore Gladys-compatible — without writing a single line of code.
+I spent a lot of last week tinkering with Matterbridge, and I had a real "aha" moment I wanted to share: we're going to be able to make **any device** Matter-compatible, and therefore Gladys-compatible, without writing a single line of code.
 
 {/* truncate */}
 
@@ -28,7 +28,7 @@ In Gladys, I've always taken the approach of building large, tailor-made integra
 
 **What if those integrations could simply be Matterbridge plugins, developed by an AI?**
 
-The Matterbridge plugin system is well-defined, well-documented, and full of examples. And these integrations often already exist elsewhere in open source (Node-RED, Home Assistant): we can simply ask the AI to translate, say, a Node-RED plugin into a Matterbridge plugin. There's nothing to invent — it's just "translating code"!
+The Matterbridge plugin system is well-defined, well-documented, and full of examples. And these integrations often already exist elsewhere in open source (Node-RED, Home Assistant): we can simply ask the AI to translate, say, a Node-RED plugin into a Matterbridge plugin. There's nothing to invent, it's just "translating code"!
 
 ## What I tested
 
@@ -42,6 +42,6 @@ The logical next step: **what if we fully automated the creation of Matterbridge
 
 ![The Matterbridge plugin factory concept](../static/img/articles/matterbridge-ai-revolution/01.jpg)
 
-With a system like that, we could industrialize the development of integrations and close the gap between Gladys and projects like Home Assistant. I genuinely think this is a revolution — and it confirms my decision to invest heavily in Matter this year, because it really is the future of the connected home.
+With a system like that, we could industrialize the development of integrations and close the gap between Gladys and projects like Home Assistant. I genuinely think this is a revolution, and it confirms my decision to invest heavily in Matter this year, because it really is the future of the connected home.
 
 What do you think?

--- a/blog/2026-05-11-gladys-4-73-matter-tuya-mcp.md
+++ b/blog/2026-05-11-gladys-4-73-matter-tuya-mcp.md
@@ -14,7 +14,7 @@ A new version of Gladys Assistant is available: **v4.73.0!** This release brings
 
 ## 🧩 Matter.js updated to 0.16.11
 
-Gladys now ships the latest version of Matter.js (`0.16.11`). This is a big update — we're moving up from 0.13.0 — and it improves the compatibility and stability of Matter devices.
+Gladys now ships the latest version of Matter.js (`0.16.11`). This is a big update, we're moving up from 0.13.0, and it improves the compatibility and stability of Matter devices.
 
 Please check that your Matter devices still work after this update, as there's a Matter.js file migration that was a little tricky for some users.
 

--- a/blog/2026-05-19-recommended-hardware-guide.md
+++ b/blog/2026-05-19-recommended-hardware-guide.md
@@ -16,6 +16,6 @@ I just added a new page to the documentation: **the recommended hardware** to bu
 
 The idea behind this page is to give a clear reference for someone starting from scratch and wondering what to buy. Instead of spending hours comparing dozens of products across forums, you get a curated list of well-rated devices that are compatible with Gladys.
 
-Everything is based on Zigbee — it's what I use at home, and what I show in the [video training course](https://formation.gladysassistant.com/b/T6f3j).
+Everything is based on Zigbee, it's what I use at home, and what I show in the [video training course](https://formation.gladysassistant.com/b/T6f3j).
 
 Feel free to send me your feedback: if you have devices you particularly like and that deserve a spot on the list, I'm all ears!

--- a/blog/2026-05-20-gladys-on-antoineguilbert.md
+++ b/blog/2026-05-20-gladys-on-antoineguilbert.md
@@ -14,7 +14,7 @@ I'm really proud to see Gladys featured on **Antoine Guilbert's blog**, a French
 
 The article is great: well-researched, beautifully written, and it perfectly captures the vision behind Gladys and what we're trying to build with the project.
 
-I really recommend giving it a read — it's a genuinely pleasant one:
+I really recommend giving it a read, it's a genuinely pleasant one:
 
 👉 [Read the article on AntoineGuilbert.fr](https://www.antoineguilbert.fr/gladys-assistant-alternative-home-assistant/)
 

--- a/blog/2026-05-22-matterbridge-ai-plugin-factory.md
+++ b/blog/2026-05-22-matterbridge-ai-plugin-factory.md
@@ -57,7 +57,7 @@ Then enter the plugin name in the **"Plugin Name"** field and click **"Add +"**:
 
 ![Add the plugin](../static/img/articles/matterbridge-ai-plugin-factory/07.jpg)
 
-The plugin is installed — you can test it!
+The plugin is installed, you can test it!
 
 ## Step 3: Give feedback
 
@@ -67,4 +67,4 @@ If the plugin doesn't work as expected, leave a comment on the GitHub ticket. Th
 
 ---
 
-Don't hesitate to open tickets — that's exactly what it's for! And if you have questions about how the factory works, ask away.
+Don't hesitate to open tickets, that's exactly what it's for! And if you have questions about how the factory works, ask away.

--- a/blog/2026-05-28-gladys-becomes-real-ai-agent.md
+++ b/blog/2026-05-28-gladys-becomes-real-ai-agent.md
@@ -28,7 +28,7 @@ From now on, when you ask Gladys a question, it no longer just tries to phrase a
 - Create a scene that every morning at 7am sends me a message with the CO2 level in the living room, the kitchen, and the state of my doors
 - Create a scene that, when there's motion in my garage, sends the AI a photo from my camera and checks whether the car is my red Tesla Model 3. If it is, the AI stays silent; otherwise, it warns me that an unknown car is there.
 
-These are requests that would have required several manual steps before — or simply didn't work at all! This work builds in part on the MCP server developed by [@bertrandda](https://community.gladysassistant.com/), which I integrated into this new architecture. Thanks to him!
+These are requests that would have required several manual steps before, or simply didn't work at all! This work builds in part on the MCP server developed by [@bertrandda](https://community.gladysassistant.com/), which I integrated into this new architecture. Thanks to him!
 
 ## A redesigned, genuinely usable interface
 
@@ -50,8 +50,8 @@ Do you use Gladys on the go via Telegram or Nextcloud Talk? The improved agent i
 
 ### Try it now, for free
 
-First, update Gladys to v4.76.0. Then you'll need Gladys Plus — and I'm offering you [a full one-month trial, no credit card required](/plus/). Each account gets **3,000 requests per month + 500 image-analysis requests.** That's more than enough to explore what the agent can do, and I'm curious to read your feedback on what works, what surprises you, and what you'd like to see next!
+First, update Gladys to v4.76.0. Then you'll need Gladys Plus, and I'm offering you [a full one-month trial, no credit card required](/plus/). Each account gets **3,000 requests per month + 500 image-analysis requests.** That's more than enough to explore what the agent can do, and I'm curious to read your feedback on what works, what surprises you, and what you'd like to see next!
 
-For the AI model, I've reached the limits of Mistral Small 3.2 with this tool, so for now I've switched to Gemma 4 — still on Scaleway, hosted in France, with your data fully private 🔒
+For the AI model, I've reached the limits of Mistral Small 3.2 with this tool, so for now I've switched to Gemma 4, still on Scaleway, hosted in France, with your data fully private 🔒
 
 Of course there may be bugs, and I'm keen to hear your feedback 🙂

--- a/blog/2026-06-01-gladys-4-77-voice-assistant.md
+++ b/blog/2026-06-01-gladys-4-77-voice-assistant.md
@@ -8,7 +8,7 @@ slug: gladys-4-77-voice-assistant
 
 Hey everyone,
 
-A new version of Gladys is available, with several nice improvements — including a brand-new **Voice Assistant** widget you can drop right onto your dashboard 🎙️
+A new version of Gladys is available, with several nice improvements, including a brand-new **Voice Assistant** widget you can drop right onto your dashboard 🎙️
 
 {/* truncate */}
 
@@ -18,7 +18,7 @@ You can now add a **Voice Assistant** widget directly to your dashboard.
 
 [![Voice Assistant widget demo](../static/img/articles/gladys-4-77-voice-assistant/youtube.jpg)](https://youtube.com/shorts/7LBeCTegKsY)
 
-Handy on a wall-mounted tablet or a smartphone. I'd love your feedback — it's first and foremost a proof of concept that could grow into more voice features in Gladys if you find it useful!
+Handy on a wall-mounted tablet or a smartphone. I'd love your feedback, it's first and foremost a proof of concept that could grow into more voice features in Gladys if you find it useful!
 
 ## 📊 Gauge widget: customizable color thresholds
 

--- a/blog/2026-06-05-new-raspberry-pi-image.md
+++ b/blog/2026-06-05-new-raspberry-pi-image.md
@@ -22,7 +22,7 @@ For the occasion, I also rewrote the installation tutorial on the site, with eve
 
 ## My take on the Raspberry Pi
 
-I'll be honest: I still don't think the Raspberry Pi is the best long-term option — a mini-PC remains more powerful and more reliable for a daily setup. I also strongly advise against using a microSD card: in practice, data corruption often happens after a few months. If you go with a Pi, plan for an NVMe SSD instead.
+I'll be honest: I still don't think the Raspberry Pi is the best long-term option, a mini-PC remains more powerful and more reliable for a daily setup. I also strongly advise against using a microSD card: in practice, data corruption often happens after a few months. If you go with a Pi, plan for an NVMe SSD instead.
 
 But for people who already have a Pi on hand, it's an excellent way to discover Gladys without dealing with Docker or the command line 🙂
 

--- a/blog/2026-06-08-gladys-4-78-ai-weekly-home-report.md
+++ b/blog/2026-06-08-gladys-4-78-ai-weekly-home-report.md
@@ -8,7 +8,7 @@ slug: gladys-4-78-ai-weekly-home-report
 
 Hey everyone 🙂
 
-I just released Gladys Assistant 4.78! Here's what's new — starting with the headline feature: an **AI-powered weekly report** of your home.
+I just released Gladys Assistant 4.78! Here's what's new, starting with the headline feature: an **AI-powered weekly report** of your home.
 
 {/* truncate */}
 
@@ -34,7 +34,7 @@ Of course, we can make this report evolve if you have ideas!
 
 You can now add a Link widget to your dashboard to access an external interface in one click: Zigbee2mqtt, Tasmota, your router's interface, a NAS, a camera, etc.
 
-Each link is customizable — title, URL, and icon (website, server, NAS, Wi-Fi, web interface…):
+Each link is customizable, title, URL, and icon (website, server, NAS, Wi-Fi, web interface…):
 
 ![Link widget configuration](../static/img/articles/gladys-4-78-ai-weekly-home-report/02.png)
 

--- a/blog/2026-06-15-gladys-4-79-smarter-ai-matter.md
+++ b/blog/2026-06-15-gladys-4-79-smarter-ai-matter.md
@@ -8,7 +8,7 @@ slug: gladys-4-79-smarter-ai-matter
 
 Hey everyone,
 
-Gladys v4.79 is out 🙂 — with a smarter AI agent, a better voice assistant, and support for more Matter devices.
+Gladys v4.79 is out 🙂, with a smarter AI agent, a better voice assistant, and support for more Matter devices.
 
 {/* truncate */}
 
@@ -26,7 +26,7 @@ This version brings several improvements to the AI agent:
   - **Web Request:** the agent can query APIs or web pages. It's a personal need I implemented, and it's incredibly handy!
   - **Compare Times:** compares times of day.
 
-These new tools unlock very powerful things — for example, fetching a store's opening hours and telling you whether it's currently open! Super useful in scenes via the "Ask the AI" action. The possibilities are endless.
+These new tools unlock very powerful things, for example, fetching a store's opening hours and telling you whether it's currently open! Super useful in scenes via the "Ask the AI" action. The possibilities are endless.
 
 ## 🎙️ Voice assistant
 

--- a/blog/2026-06-22-gladys-4-80-matter-netatmo-tuya-ai.md
+++ b/blog/2026-06-22-gladys-4-80-matter-netatmo-tuya-ai.md
@@ -36,7 +36,7 @@ This version further improves Matter compatibility:
 Matter.js was also updated to version [0.17.3](https://github.com/matter-js/matter.js/blob/main/CHANGELOG.md#0170-2026-05-20), a major step forward bringing notably:
 
 - Support for the **Matter 1.5 / 1.5.1** specification, improving compatibility with the newest devices.
-- A **20–50% reduction in memory usage**, letting Gladys run even more smoothly.
+- A **20-50% reduction in memory usage**, letting Gladys run even more smoothly.
 
 ## 📡 Integrations
 

--- a/docs/installation/0_1_recommended-hardware.md
+++ b/docs/installation/0_1_recommended-hardware.md
@@ -33,7 +33,7 @@ The Zigbee coordinator is **the most important device** of your installation: it
     </div>
     <span class="product-card__badge">Ethernet alternative</span>
     <h4 class="product-card__title">SMLight SLZB-06</h4>
-    <p class="product-card__description">Ethernet/PoE Zigbee coordinator. Useful if you want to move the dongle away from your server (e.g. in a tech closet) to get better Zigbee mesh coverage. <strong>⚠️ With this model, you'll have to install and run Zigbee2MQTT yourself</strong> (Docker, dedicated machine…) — Gladys' Zigbee2MQTT integration won't start it automatically, unlike with the USB dongle.</p>
+    <p class="product-card__description">Ethernet/PoE Zigbee coordinator. Useful if you want to move the dongle away from your server (e.g. in a tech closet) to get better Zigbee mesh coverage. <strong>⚠️ With this model, you'll have to install and run Zigbee2MQTT yourself</strong> (Docker, dedicated machine…), Gladys' Zigbee2MQTT integration won't start it automatically, unlike with the USB dongle.</p>
     <a class="product-card__cta" href="https://www.amazon.com/s?k=SMLight+SLZB-06&tag=gladproj-21" target="_blank" rel="noopener">View on Amazon</a>
   </div>
 </div>
@@ -122,7 +122,7 @@ The Zigbee coordinator is **the most important device** of your installation: it
       <img src="https://www.zigbee2mqtt.io/images/devices/E2.jpg" alt="Nous E2 Zigbee Door & Window Sensor" loading="lazy" />
     </div>
     <span class="product-card__badge">Recommended</span>
-    <h4 class="product-card__title">Nous E2 — Zigbee 3.0 Door & Window Sensor</h4>
+    <h4 class="product-card__title">Nous E2: Zigbee 3.0 Door & Window Sensor</h4>
     <p class="product-card__description">Fully local Zigbee 3.0 door/window sensor. Compact form factor, long battery life, excellent value, and great Zigbee2MQTT support.</p>
     <a class="product-card__cta" href="https://www.amazon.com/s?k=Nous+E2+Zigbee+door+sensor&tag=gladproj-21" target="_blank" rel="noopener">View on Amazon</a>
   </div>
@@ -146,7 +146,7 @@ The Zigbee coordinator is **the most important device** of your installation: it
     </div>
     <span class="product-card__badge">Recommended</span>
     <h4 class="product-card__title">Aqara Wireless Mini Switch</h4>
-    <p class="product-card__description">Tiny wireless button with single press / double press / long press detection. Three actions on a single button — perfect for custom automations.</p>
+    <p class="product-card__description">Tiny wireless button with single press / double press / long press detection. Three actions on a single button, perfect for custom automations.</p>
     <a class="product-card__cta" href="https://www.amazon.com/s?k=Aqara+Wireless+Mini+Switch+WXKG11LM&tag=gladproj-21" target="_blank" rel="noopener">View on Amazon</a>
   </div>
   <div class="product-card">
@@ -177,7 +177,7 @@ The Zigbee coordinator is **the most important device** of your installation: it
       <img src="https://www.zigbee2mqtt.io/images/devices/MINI-ZBRBS.png" alt="SONOFF MINI-ZBRBS Zigbee Roller Shutter Module" loading="lazy" />
     </div>
     <span class="product-card__badge">Alternative</span>
-    <h4 class="product-card__title">SONOFF MINI-ZBRBS — Zigbee Roller Shutter Module</h4>
+    <h4 class="product-card__title">SONOFF MINI-ZBRBS: Zigbee Roller Shutter Module</h4>
     <p class="product-card__description">Compact in-wall Zigbee 3.0 roller shutter module from SONOFF. A great alternative to the Sunricher, from a brand very well supported by Zigbee2MQTT.</p>
     <a class="product-card__cta" href="https://www.amazon.com/s?k=SONOFF+MINI-ZBRBS+roller+shutter&tag=gladproj-21" target="_blank" rel="noopener">View on Amazon</a>
   </div>
@@ -230,7 +230,7 @@ These switches **replace your existing wall switches** and let you control a lig
       <img src="https://www.zigbee2mqtt.io/images/devices/SNZB-05P.png" alt="SONOFF SNZB-05P Zigbee Water Leak Sensor" loading="lazy" />
     </div>
     <span class="product-card__badge">Recommended</span>
-    <h4 class="product-card__title">SONOFF SNZB-05P — Zigbee Water Leak Sensor (IP67)</h4>
+    <h4 class="product-card__title">SONOFF SNZB-05P: Zigbee Water Leak Sensor (IP67)</h4>
     <p class="product-card__description">IP67-rated Zigbee water leak sensor with an extendable remote probe. Perfect to place under the sink, behind the washing machine or near the water heater.</p>
     <a class="product-card__cta" href="https://www.amazon.com/s?k=SONOFF+SNZB-05P&tag=gladproj-21" target="_blank" rel="noopener">View on Amazon</a>
   </div>
@@ -244,7 +244,7 @@ These switches **replace your existing wall switches** and let you control a lig
       <img src="https://www.zigbee2mqtt.io/images/devices/SMSZB-120.jpg" alt="Frient Intelligent Smoke Alarm SMSZB-120" loading="lazy" />
     </div>
     <span class="product-card__badge">Recommended</span>
-    <h4 class="product-card__title">Frient — Intelligent Smoke Alarm Zigbee 3.0 (SMSZB-120)</h4>
+    <h4 class="product-card__title">Frient: Intelligent Smoke Alarm Zigbee 3.0 (SMSZB-120)</h4>
     <p class="product-card__description">EN 14604 certified, professional-grade Zigbee smoke detector. Very well rated in the Zigbee2MQTT community, long-life battery included.</p>
     <a class="product-card__cta" href="https://www.amazon.com/s?k=Frient+Smoke+Alarm+SMSZB-120&tag=gladproj-21" target="_blank" rel="noopener">View on Amazon</a>
   </div>

--- a/docs/integrations/homekit.md
+++ b/docs/integrations/homekit.md
@@ -43,4 +43,4 @@ If you add a new device in Gladys after you’ve already linked to HomeKit:
 - If the device is **compatible**, it will be automatically added to HomeKit in a **default room**. You can then move it to the correct room manually.
 - If the new device **doesn’t appear**, try restarting the HomeKit integration by clicking the `Restart` button, then wait a few seconds for the bridge to reload.
 
-🛠️ Need help? Join us on the [Gladys community forum](https://community.gladysassistant.com/) — we’re here to support you!
+🛠️ Need help? Join us on the [Gladys community forum](https://community.gladysassistant.com/), we’re here to support you!

--- a/docs/integrations/matter.md
+++ b/docs/integrations/matter.md
@@ -33,7 +33,7 @@ In short, Matter focuses on the “what” and the “how” of smart device int
 
 Thread, on the other hand, is a **low-level mesh network protocol**, designed for communication between low-power wireless devices. It acts as an alternative to Zigbee or Wi-Fi, but unlike them, it is based on IP standards (IPv6), making it natively Internet-compatible.
 
-Thread handles the “how it travels” part — that is, transporting messages over a reliable, fast, and secure wireless network.
+Thread handles the “how it travels” part, that is, transporting messages over a reliable, fast, and secure wireless network.
 
 Some Matter devices use Thread as their network protocol, but not all! Matter devices can also use Wi-Fi, Ethernet, or even Bluetooth.
 

--- a/docs/integrations/zwavejs-ui.md
+++ b/docs/integrations/zwavejs-ui.md
@@ -39,20 +39,20 @@ You can then add them to Gladys with a single click!
 
 ## Supported Features
 
-- **Door/Window Sensors** – Detect open/close status, such as the [Fibaro Door Opening Sensor](https://www.amazon.com/Fibaro-FGDW-002-1-Window-Temperature-Sensor/dp/B074FCG1PF?crid=AMCFKK427FRN&keywords=Fibaro+door+sensor+2&qid=1704977401&sprefix=fibaro+door+sensor+2%2Caps%2C164&sr=8-1&linkCode=ll1&tag=gladproj-20&linkId=3e61bb12444e6d8265e7440bd0174456&language=en_US&ref_=as_li_ss_tl).
-- **Binary Switches** – Control lights or power outlets (on/off). Supported devices include:
+- **Door/Window Sensors**: Detect open/close status, such as the [Fibaro Door Opening Sensor](https://www.amazon.com/Fibaro-FGDW-002-1-Window-Temperature-Sensor/dp/B074FCG1PF?crid=AMCFKK427FRN&keywords=Fibaro+door+sensor+2&qid=1704977401&sprefix=fibaro+door+sensor+2%2Caps%2C164&sr=8-1&linkCode=ll1&tag=gladproj-20&linkId=3e61bb12444e6d8265e7440bd0174456&language=en_US&ref_=as_li_ss_tl).
+- **Binary Switches**: Control lights or power outlets (on/off). Supported devices include:
   - [Fibaro Wall Plug](https://www.fibaro.com/en/products/wall-plug/)
   - [Fibaro Switches](https://www.fibaro.com/en/products/switches/)
-- **Air Temperature Sensors** – Monitor room temperature.
-- **Power Metering** – Track energy consumption analytics.
-- **Curtain/Shutter Control** – Open, close, and check curtain position. Supported devices include:
+- **Air Temperature Sensors**: Monitor room temperature.
+- **Power Metering**: Track energy consumption analytics.
+- **Curtain/Shutter Control**: Open, close, and check curtain position. Supported devices include:
   - [Fibaro Walli Roller Shutter](https://manuals.fibaro.com/fr/walli-roller-shutter/)
   - [Qubino Flush Shutter](https://qubino.com/products/flush-shutter/)
-- **Dimmers** – Adjust brightness or control voltage-based devices. Supported devices include:
+- **Dimmers**: Adjust brightness or control voltage-based devices. Supported devices include:
   - [Fibaro Walli Dimmer](https://manuals.fibaro.com/fr/walli-dimmer/)
   - [Fibaro Dimmer 2](https://manuals.fibaro.com/fr/dimmer-2/)
-- **Luminosity Sensors** – Measure ambient light levels.
-- **Alarm Sensors** – Detect security threats.
-- **Binary Sensors** – Support various on/off detection scenarios.
+- **Luminosity Sensors**: Measure ambient light levels.
+- **Alarm Sensors**: Detect security threats.
+- **Binary Sensors**: Support various on/off detection scenarios.
 
 If your device is not currently supported, let us know on the forum!

--- a/docs/scenes/user-presence.md
+++ b/docs/scenes/user-presence.md
@@ -13,7 +13,7 @@ On the dashboard, Gladys allows you to display which users are present or absent
 
 You can use scenes to define a user's presence or absence.
 
-- This can be done manually, by launching the scene when you leave or arrive home (useful, but perhaps a bit restrictive – automation is preferred!).
+- This can be done manually, by launching the scene when you leave or arrive home (useful, but perhaps a bit restrictive, automation is preferred!).
 - Or, automate presence detection: This could be a button at the entrance, motion detection if you're home alone, a Tasker app that sends an MQTT message when you're connected to home Wi-Fi, or a Nut tracker. The choice is yours!
 
 We have tutorials for [Bluetooth detection](/docs/integrations/bluetooth/) and [network scan](/docs/integrations/lan-manager/).

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -352,7 +352,7 @@
     "description": "Integration improve integration list here"
   },
   "home.metaDescription": {
-    "message": "Gladys Assistant est une plateforme de domotique open-source et respectueuse de la vie privée. Auto-hébergée, sans cloud — une alternative simple à Home Assistant.",
+    "message": "Gladys Assistant est une plateforme de domotique open-source et respectueuse de la vie privée. Auto-hébergée, sans cloud, une alternative simple à Home Assistant.",
     "description": "home page meta description"
   },
   "openPage.title": {

--- a/i18n/fr/docusaurus-plugin-content-blog/2024-11-01-proactive-ai.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2024-11-01-proactive-ai.md
@@ -20,7 +20,7 @@ C’était un bon début, mais je veux aller encore plus loin ! Et si l’IA pou
 
 ## Imaginez les possibilités
 
-Imaginez qu’une voiture arrive devant chez vous. Un agent de sécurité dévoué surveillerait, reconnaîtrait votre voiture – sa forme, sa couleur, sa plaque – et saurait immédiatement que c’est bien vous. Mais embaucher un agent 24/24, ce n’est pas à la portée de tous !
+Imaginez qu’une voiture arrive devant chez vous. Un agent de sécurité dévoué surveillerait, reconnaîtrait votre voiture, sa forme, sa couleur, sa plaque, et saurait immédiatement que c’est bien vous. Mais embaucher un agent 24/24, ce n’est pas à la portée de tous !
 
 Et si l’IA pouvait remplir ce rôle ?
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2025-01-17-2024-yearly-review.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2025-01-17-2024-yearly-review.md
@@ -50,7 +50,7 @@ Le début de l'année 2024 a connu une forte hausse des nouvelles installations 
 
 ![Installations 2024 Gladys Assistant](../../../static/img/articles/fr/year-in-review-2024/installations.jpg)
 
-La fin de l’année a été plus calme, et il est difficile de dire si cette baisse d’activité est liée à ma propre réduction de rythme — j'étais en voyage en septembre/octobre, puis en congés de Noël en fin d'année — ou si c’est simplement une période où tout le monde était globalement moins disponible. Quoi qu’il en soit, ces variations sont normales : il y a toujours des hauts et des bas 😄
+La fin de l’année a été plus calme, et il est difficile de dire si cette baisse d’activité est liée à ma propre réduction de rythme, j'étais en voyage en septembre/octobre, puis en congés de Noël en fin d'année, ou si c’est simplement une période où tout le monde était globalement moins disponible. Quoi qu’il en soit, ces variations sont normales : il y a toujours des hauts et des bas 😄
 
 ## Chiffre d'affaires
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-02-08-official-starter-kit-back-in-stock.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-02-08-official-starter-kit-back-in-stock.md
@@ -14,8 +14,8 @@ Petite news : je viens de rentrer de congés, et j'ai remis **le kit de démarra
 
 Il est disponible à la livraison en deux versions :
 
-- **Beelink S12** — 8 Go de RAM / CPU Intel N95 / 256 Go SSD
-- **Beelink S13** — 16 Go de RAM / CPU Intel N150 / 500 Go SSD
+- **Beelink S12** : 8 Go de RAM / CPU Intel N95 / 256 Go SSD
+- **Beelink S13** : 16 Go de RAM / CPU Intel N150 / 500 Go SSD
 
 👉 [Découvrir le kit de démarrage officiel](/fr/starter-kit/)
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-02-17-gladys-featured-on-igeneration.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-02-17-gladys-featured-on-igeneration.md
@@ -14,6 +14,6 @@ Une excellente nouvelle côté presse : Gladys vient d'être mis en avant sur **
 
 Le titre dit tout : *« Gladys Assistant, la domotique plus avancée que Maison et plus accessible que Home Assistant ».*
 
-Ça fait toujours plaisir de voir le projet reconnu par un média qui s'adresse au grand public, et pas seulement à la communauté domotique avertie. C'est le signe que la vision derrière Gladys — un assistant domotique puissant **mais** accessible, respectueux de la vie privée et open-source — résonne au-delà de notre communauté.
+Ça fait toujours plaisir de voir le projet reconnu par un média qui s'adresse au grand public, et pas seulement à la communauté domotique avertie. C'est le signe que la vision derrière Gladys, un assistant domotique puissant **mais** accessible, respectueux de la vie privée et open-source, résonne au-delà de notre communauté.
 
 👉 [Lire l'article sur iGen.fr](https://www.igen.fr/domotique/2026/02/gladys-assistant-la-domotique-plus-avancee-que-maison-et-plus-accessible-que-home-assistant-154785)

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-02-23-gladys-4-68-matterbridge.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-02-23-gladys-4-68-matterbridge.md
@@ -8,7 +8,7 @@ slug: gladys-4-68-matterbridge
 
 Salut à tous,
 
-Une nouvelle version de Gladys est disponible, avec plusieurs améliorations et corrections — dont la possibilité de lancer **Matterbridge** en un clic, ouvrant la porte à encore plus d'appareils compatibles.
+Une nouvelle version de Gladys est disponible, avec plusieurs améliorations et corrections, dont la possibilité de lancer **Matterbridge** en un clic, ouvrant la porte à encore plus d'appareils compatibles.
 
 {/* truncate */}
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-02-27-ai-controls-my-home-openclaw.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-02-27-ai-controls-my-home-openclaw.md
@@ -8,7 +8,7 @@ slug: ai-controls-my-home-openclaw
 
 Salut à tous !
 
-Vous avez sûrement entendu parler d'**OpenClaw**, le framework IA qui a explosé sur GitHub il y a quelques semaines, et qui vient d'être racheté par OpenAI. J'ai fait le test de le connecter à Gladys pour voir ce qu'il avait dans le ventre — et honnêtement, c'est vraiment bluffant.
+Vous avez sûrement entendu parler d'**OpenClaw**, le framework IA qui a explosé sur GitHub il y a quelques semaines, et qui vient d'être racheté par OpenAI. J'ai fait le test de le connecter à Gladys pour voir ce qu'il avait dans le ventre, et honnêtement, c'est vraiment bluffant.
 
 {/* truncate */}
 
@@ -18,4 +18,4 @@ J'ai branché OpenClaw sur Gladys pour tester les possibilités de laisser un ag
 
 **Une mise en garde :** je vous déconseille d'installer OpenClaw sur votre serveur Gladys. C'est un logiciel encore en début de vie, qui touche un peu à tout, et qui a été pas mal décrié pour ses failles de sécurité. Pour ce test, j'ai déployé OpenClaw sur une VM isolée dans le Cloud pour rester dans un environnement cloisonné 🔐
 
-C'est un aperçu fascinant de là où va la domotique pilotée par IA — mais la sécurité et la vie privée passent avant tout.
+C'est un aperçu fascinant de là où va la domotique pilotée par IA, mais la sécurité et la vie privée passent avant tout.

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-02-27-gladys-4-69-zigbee2mqtt-ember.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-02-27-gladys-4-69-zigbee2mqtt-ember.md
@@ -8,7 +8,7 @@ slug: gladys-4-69-zigbee2mqtt-ember
 
 Salut à tous,
 
-Une nouvelle version de Gladys Assistant est disponible 🥳 — avec le nouveau driver Ember de Zigbee2mqtt et le suivi énergétique Tasmota.
+Une nouvelle version de Gladys Assistant est disponible 🥳, avec le nouveau driver Ember de Zigbee2mqtt et le suivi énergétique Tasmota.
 
 {/* truncate */}
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-03-06-gladys-4-70-reset-zigbee2mqtt.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-03-06-gladys-4-70-reset-zigbee2mqtt.md
@@ -16,7 +16,7 @@ Je viens de sortir une nouvelle version de Gladys, avec des améliorations d'UX 
 
 ### Un bouton de réinitialisation pour Zigbee2mqtt
 
-Un nouveau bouton **« Réinitialiser »** fait son apparition dans l'intégration Zigbee2mqtt. Il permet aux utilisateurs qui ont une intégration corrompue — ou qui souhaitent changer de dongle — de réinitialiser totalement l'intégration en un clic.
+Un nouveau bouton **« Réinitialiser »** fait son apparition dans l'intégration Zigbee2mqtt. Il permet aux utilisateurs qui ont une intégration corrompue, ou qui souhaitent changer de dongle, de réinitialiser totalement l'intégration en un clic.
 
 ![Bouton de réinitialisation dans l'intégration Zigbee2mqtt](../../../static/img/articles/gladys-4-70-reset-zigbee2mqtt/01.png)
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-03-26-make-any-washing-machine-smart.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-03-26-make-any-washing-machine-smart.md
@@ -14,6 +14,6 @@ Je vous présente aujourd'hui une automatisation bien pratique que j'ai mise en 
 
 [![Comment rendre n'importe quel lave-linge intelligent](../../../static/img/articles/make-any-washing-machine-smart/youtube.jpg)](https://youtu.be/gn-bBBs39G0)
 
-L'idée est simple : en mesurant la consommation électrique de la prise, Gladys sait exactement quand un cycle de lavage démarre et quand il se termine — et peut ensuite vous envoyer une notification pour ne plus jamais oublier votre linge dans la machine. Aucun appareil spécial requis, juste une prise Zigbee avec mesure de consommation et une scène Gladys.
+L'idée est simple : en mesurant la consommation électrique de la prise, Gladys sait exactement quand un cycle de lavage démarre et quand il se termine, et peut ensuite vous envoyer une notification pour ne plus jamais oublier votre linge dans la machine. Aucun appareil spécial requis, juste une prise Zigbee avec mesure de consommation et une scène Gladys.
 
 Je vous montre toute la mise en place dans la vidéo ci-dessus. Si vous avez des questions, n'hésitez pas à les mettre en commentaire de la vidéo 🙏

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-04-03-gladys-4-72-faster-ai-stable-homekit.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-04-03-gladys-4-72-faster-ai-stable-homekit.md
@@ -8,7 +8,7 @@ slug: gladys-4-72-faster-ai-stable-homekit
 
 Salut à tous !
 
-Gladys Assistant 4.72.0 est disponible 🎉 — avec une IA plus rapide, un HomeKit plus stable, et une longue liste de correctifs.
+Gladys Assistant 4.72.0 est disponible 🎉, avec une IA plus rapide, un HomeKit plus stable, et une longue liste de correctifs.
 
 {/* truncate */}
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-04-03-mistral-vs-elevenlabs-voice-ai.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-04-03-mistral-vs-elevenlabs-voice-ai.md
@@ -1,6 +1,6 @@
 ---
 title: "Mistral vs ElevenLabs : la révolution vocale est-elle française ? 🇫🇷"
-description: "Le text-to-speech local Voxtral de Mistral face à ElevenLabs — et le passage de Gladys Plus à Mistral Small 3.2 chez Scaleway, avec des quotas IA augmentés."
+description: "Le text-to-speech local Voxtral de Mistral face à ElevenLabs, et le passage de Gladys Plus à Mistral Small 3.2 chez Scaleway, avec des quotas IA augmentés."
 authors: pierregilles
 image: /img/presentation/mistral-vs-elevenlabs-voice-ai-fr.jpg
 slug: mistral-vs-elevenlabs-voice-ai
@@ -8,7 +8,7 @@ slug: mistral-vs-elevenlabs-voice-ai
 
 Salut à tous,
 
-La semaine dernière, Mistral a sorti un nouveau modèle de Text-to-Speech (Voxtral) capable de tourner 100 % en local, sans envoyer la moindre donnée dans le cloud. J'ai voulu le tester face à ElevenLabs pour voir ce que ça valait vraiment — et honnêtement, les résultats sont vraiment bons !
+La semaine dernière, Mistral a sorti un nouveau modèle de Text-to-Speech (Voxtral) capable de tourner 100 % en local, sans envoyer la moindre donnée dans le cloud. J'ai voulu le tester face à ElevenLabs pour voir ce que ça valait vraiment, et honnêtement, les résultats sont vraiment bons !
 
 {/* truncate */}
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-04-10-matterbridge-ai-revolution.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-04-10-matterbridge-ai-revolution.md
@@ -8,7 +8,7 @@ slug: matterbridge-ai-revolution
 
 Salut à tous,
 
-J'ai pas mal bidouillé la semaine dernière autour de Matterbridge, et j'ai eu une vraie révélation que je voulais vous partager : on va pouvoir rendre **n'importe quel appareil** compatible Matter — et donc compatible Gladys — sans écrire une seule ligne de code.
+J'ai pas mal bidouillé la semaine dernière autour de Matterbridge, et j'ai eu une vraie révélation que je voulais vous partager : on va pouvoir rendre **n'importe quel appareil** compatible Matter, et donc compatible Gladys, sans écrire une seule ligne de code.
 
 {/* truncate */}
 
@@ -42,6 +42,6 @@ La suite logique : **et si on automatisait complètement la création de plugins
 
 ![Le concept d'usine à plugins Matterbridge](../../../static/img/articles/matterbridge-ai-revolution/01.jpg)
 
-Avec un système pareil, on pourrait industrialiser le développement d'intégrations et réduire l'écart entre Gladys et des projets comme Home Assistant. Je pense que c'est une vraie révolution — et ça me conforte dans mon choix d'investir beaucoup de ressources sur Matter cette année, car c'est vraiment l'avenir de la maison connectée.
+Avec un système pareil, on pourrait industrialiser le développement d'intégrations et réduire l'écart entre Gladys et des projets comme Home Assistant. Je pense que c'est une vraie révolution, et ça me conforte dans mon choix d'investir beaucoup de ressources sur Matter cette année, car c'est vraiment l'avenir de la maison connectée.
 
 Qu'en pensez-vous ?

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-05-11-gladys-4-73-matter-tuya-mcp.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-05-11-gladys-4-73-matter-tuya-mcp.md
@@ -14,7 +14,7 @@ Une nouvelle version de Gladys Assistant est disponible : **v4.73.0 !** Cette re
 
 ## 🧩 Mise à jour de Matter.js en 0.16.11
 
-Gladys embarque désormais la dernière version de Matter.js (`0.16.11`). C'est une grosse mise à jour — nous montons depuis la 0.13.0 — qui améliore la compatibilité et la stabilité des appareils Matter.
+Gladys embarque désormais la dernière version de Matter.js (`0.16.11`). C'est une grosse mise à jour, nous montons depuis la 0.13.0, qui améliore la compatibilité et la stabilité des appareils Matter.
 
 Pensez à vérifier que vos appareils Matter fonctionnent toujours après cette version, car il y a une migration de fichier de Matter.js qui a pu être capricieuse chez certains utilisateurs.
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-05-28-gladys-becomes-real-ai-agent.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-05-28-gladys-becomes-real-ai-agent.md
@@ -50,7 +50,7 @@ Vous utilisez Gladys en mobilité via Telegram ou Nextcloud Talk ? L'agent amél
 
 ### Essayez maintenant, c'est gratuit
 
-Tout d'abord, mettez à jour Gladys en v4.76.0. Ensuite, il vous faut Gladys Plus — et je vous offre [1 mois d'essai complet, sans carte bancaire](/fr/plus/). Chaque compte dispose de **3 000 requêtes par mois + 500 requêtes d'analyse d'images.** C'est largement suffisant pour explorer ce que l'agent sait faire, et je suis curieux de lire vos retours sur ce qui marche, ce qui surprend, et ce que vous aimeriez voir ensuite !
+Tout d'abord, mettez à jour Gladys en v4.76.0. Ensuite, il vous faut Gladys Plus, et je vous offre [1 mois d'essai complet, sans carte bancaire](/fr/plus/). Chaque compte dispose de **3 000 requêtes par mois + 500 requêtes d'analyse d'images.** C'est largement suffisant pour explorer ce que l'agent sait faire, et je suis curieux de lire vos retours sur ce qui marche, ce qui surprend, et ce que vous aimeriez voir ensuite !
 
 Pour le modèle d'IA, j'ai atteint avec cet outil les limites de Mistral Small 3.2, et pour l'instant je suis passé à Gemma 4, toujours chez Scaleway, hébergé en France, avec vos données entièrement privées 🔒
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-06-01-gladys-4-77-voice-assistant.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-06-01-gladys-4-77-voice-assistant.md
@@ -8,7 +8,7 @@ slug: gladys-4-77-voice-assistant
 
 Salut à tous,
 
-Une nouvelle version de Gladys est disponible, avec plusieurs améliorations sympas — dont un tout nouveau widget **Assistant Vocal** à poser directement sur votre tableau de bord 🎙️
+Une nouvelle version de Gladys est disponible, avec plusieurs améliorations sympas, dont un tout nouveau widget **Assistant Vocal** à poser directement sur votre tableau de bord 🎙️
 
 {/* truncate */}
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-06-05-new-raspberry-pi-image.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-06-05-new-raspberry-pi-image.md
@@ -22,7 +22,7 @@ Pour l'occasion, j'ai aussi réécrit le tutoriel d'installation sur le site, av
 
 ## Mon avis sur le Raspberry Pi
 
-Je le dis franchement : je ne pense toujours pas que le Raspberry Pi soit la meilleure option sur le long terme — un mini-PC reste plus performant et plus fiable pour une installation quotidienne. Je déconseille aussi fortement l'utilisation d'une carte micro-SD : en pratique, la corruption des données arrive souvent au bout de quelques mois. Si vous partez sur un Pi, prévoyez plutôt un SSD NVMe.
+Je le dis franchement : je ne pense toujours pas que le Raspberry Pi soit la meilleure option sur le long terme, un mini-PC reste plus performant et plus fiable pour une installation quotidienne. Je déconseille aussi fortement l'utilisation d'une carte micro-SD : en pratique, la corruption des données arrive souvent au bout de quelques mois. Si vous partez sur un Pi, prévoyez plutôt un SSD NVMe.
 
 Mais pour des utilisateurs qui ont déjà un Pi sous la main, c'est une excellente façon de découvrir Gladys sans se prendre la tête avec Docker ou la ligne de commande 🙂
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-06-08-gladys-4-78-ai-weekly-home-report.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-06-08-gladys-4-78-ai-weekly-home-report.md
@@ -8,7 +8,7 @@ slug: gladys-4-78-ai-weekly-home-report
 
 Salut à tous 🙂
 
-Je viens de publier Gladys Assistant 4.78 ! Voilà les nouveautés — en commençant par la fonctionnalité phare : un **bilan hebdomadaire de votre maison généré par l'IA**.
+Je viens de publier Gladys Assistant 4.78 ! Voilà les nouveautés, en commençant par la fonctionnalité phare : un **bilan hebdomadaire de votre maison généré par l'IA**.
 
 {/* truncate */}
 
@@ -34,7 +34,7 @@ Bien sûr, on peut faire évoluer ce bilan si vous avez des idées !
 
 Vous pouvez maintenant ajouter un widget Lien sur votre tableau de bord pour accéder en un clic à une interface externe : Zigbee2mqtt, Tasmota, l'interface de votre box, un NAS, une caméra, etc.
 
-Chaque lien est personnalisable — titre, URL et icône (site web, serveur, NAS, Wi-Fi, interface web…) :
+Chaque lien est personnalisable, titre, URL et icône (site web, serveur, NAS, Wi-Fi, interface web…) :
 
 ![Configuration du widget Lien](../../../static/img/articles/gladys-4-78-ai-weekly-home-report/02.png)
 

--- a/i18n/fr/docusaurus-plugin-content-blog/2026-06-15-gladys-4-79-smarter-ai-matter.md
+++ b/i18n/fr/docusaurus-plugin-content-blog/2026-06-15-gladys-4-79-smarter-ai-matter.md
@@ -8,7 +8,7 @@ slug: gladys-4-79-smarter-ai-matter
 
 Salut à tous,
 
-La version v4.79 de Gladys est sortie 🙂 — avec un agent IA plus malin, un assistant vocal amélioré, et le support de plus d'appareils Matter.
+La version v4.79 de Gladys est sortie 🙂, avec un agent IA plus malin, un assistant vocal amélioré, et le support de plus d'appareils Matter.
 
 {/* truncate */}
 
@@ -26,7 +26,7 @@ Cette version apporte plusieurs améliorations à l'agent IA :
   - **Web Request :** l'agent peut interroger des APIs ou des pages web. C'est un besoin personnel que j'ai implémenté, et c'est ultra pratique !
   - **Compare Times :** comparaison d'horaires.
 
-Ces nouveaux outils permettent de faire des choses très puissantes — par exemple aller chercher les horaires d'ouverture d'un commerce et vous dire s'il est actuellement ouvert ! Super pratique dans les scènes via l'action « Demander à l'IA ». Les possibilités sont infinies.
+Ces nouveaux outils permettent de faire des choses très puissantes, par exemple aller chercher les horaires d'ouverture d'un commerce et vous dire s'il est actuellement ouvert ! Super pratique dans les scènes via l'action « Demander à l'IA ». Les possibilités sont infinies.
 
 ## 🎙️ Assistant vocal
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/0_1_recommended-hardware.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/0_1_recommended-hardware.md
@@ -122,7 +122,7 @@ Le coordinateur Zigbee est **l'appareil le plus important** de votre installatio
       <img src="https://www.zigbee2mqtt.io/images/devices/E3.png" alt="Nous E2 détecteur d'ouverture Zigbee" loading="lazy" />
     </div>
     <span class="product-card__badge">Recommandé</span>
-    <h4 class="product-card__title">Nous E3 — Détecteur d'ouverture Zigbee 3.0</h4>
+    <h4 class="product-card__title">Nous E3 : Détecteur d'ouverture Zigbee 3.0</h4>
     <p class="product-card__description">Détecteur d'ouverture porte/fenêtre Zigbee 3.0 100 % local. Format compact, longue autonomie sur pile, très bon rapport qualité/prix. Excellent support Zigbee2MQTT.</p>
     <a class="product-card__cta" href="https://www.domadoo.fr/fr/peripheriques/6193-nous-detecteur-d-ouverture-de-porte-ou-fenetre-zigbee-30-5907772033876.html?domid=17" target="_blank" rel="noopener">Voir le produit sur Domadoo</a>
   </div>
@@ -177,7 +177,7 @@ Le coordinateur Zigbee est **l'appareil le plus important** de votre installatio
       <img src="https://www.zigbee2mqtt.io/images/devices/MINI-ZBRBS.png" alt="SONOFF Module Volet Roulant Zigbee MINI-ZBRBS" loading="lazy" />
     </div>
     <span class="product-card__badge">Alternative</span>
-    <h4 class="product-card__title">SONOFF MINI-ZBRBS — Module Volet Roulant Zigbee</h4>
+    <h4 class="product-card__title">SONOFF MINI-ZBRBS : Module Volet Roulant Zigbee</h4>
     <p class="product-card__description">Micromodule volet roulant Zigbee 3.0 de SONOFF, format compact pour boîte d'encastrement. Bonne alternative au Sunricher, signé d'une marque très bien supportée par Zigbee2MQTT.</p>
     <a class="product-card__cta" href="https://www.domadoo.fr/fr/produits-de-domotique/8384-sonoff-module-volet-roulant-zigbee-mini-zbrbs.html?domid=17" target="_blank" rel="noopener">Voir le produit sur Domadoo</a>
   </div>
@@ -230,7 +230,7 @@ Ces interrupteurs **remplacent vos interrupteurs muraux existants** et permetten
       <img src="https://www.zigbee2mqtt.io/images/devices/SNZB-05P.png" alt="SONOFF SNZB-05P détecteur d'inondation Zigbee" loading="lazy" />
     </div>
     <span class="product-card__badge">Recommandé</span>
-    <h4 class="product-card__title">SONOFF SNZB-05P — Détecteur d'inondation Zigbee IP67</h4>
+    <h4 class="product-card__title">SONOFF SNZB-05P : Détecteur d'inondation Zigbee IP67</h4>
     <p class="product-card__description">Détecteur de fuite d'eau Zigbee certifié IP67, avec sonde déportée extensible (jusqu'à plusieurs mètres). Parfait à placer sous l'évier, derrière la machine à laver ou près du ballon d'eau chaude.</p>
     <a class="product-card__cta" href="https://www.domadoo.fr/fr/produits-de-domotique/7183-sonoff-detecteur-d-inondation-zigbee-ip67-extensible-snzb-05p-6920075741810.html?domid=17" target="_blank" rel="noopener">Voir le produit sur Domadoo</a>
   </div>
@@ -244,7 +244,7 @@ Ces interrupteurs **remplacent vos interrupteurs muraux existants** et permetten
       <img src="https://www.zigbee2mqtt.io/images/devices/SMSZB-120.jpg" alt="Frient Détecteur de fumée intelligent Zigbee SMSZB-120" loading="lazy" />
     </div>
     <span class="product-card__badge">Recommandé</span>
-    <h4 class="product-card__title">Frient — Détecteur de fumée intelligent Zigbee 3.0 (SMSZB-120)</h4>
+    <h4 class="product-card__title">Frient : Détecteur de fumée intelligent Zigbee 3.0 (SMSZB-120)</h4>
     <p class="product-card__description">Détecteur de fumée Zigbee certifié EN 14604, qualité professionnelle, conforme aux normes des DAAF français. Très bien noté dans la communauté Zigbee2MQTT, pile longue durée incluse.</p>
     <a class="product-card__cta" href="https://www.domadoo.fr/fr/peripheriques/5409-frient-detecteur-de-fumee-intelligent-zigbee-30-smszb-120-5713594002330.html?domid=17" target="_blank" rel="noopener">Voir le produit sur Domadoo</a>
   </div>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/zwavejs-ui.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/zwavejs-ui.md
@@ -39,20 +39,20 @@ Vous pouvez ensuite les ajouter à Gladys d'un seul clic!
 
 ## Fonctionnalités supportées
 
-- **Capteurs de porte/fenêtre** – Détectent l'état ouvert/fermé, comme le [Fibaro Door Opening Sensor](https://www.domadoo.fr/fr/peripheriques/4105-fibaro-detecteur-d-ouverture-z-wave-doorwindow-sensor-2-blanc-5902701700348.html?domid=17).
-- **Interrupteurs binaires** – Permettent d'allumer/éteindre les lumières ou de couper l'alimentation des prises électriques. Appareils compatibles :
+- **Capteurs de porte/fenêtre** : Détectent l'état ouvert/fermé, comme le [Fibaro Door Opening Sensor](https://www.domadoo.fr/fr/peripheriques/4105-fibaro-detecteur-d-ouverture-z-wave-doorwindow-sensor-2-blanc-5902701700348.html?domid=17).
+- **Interrupteurs binaires** : Permettent d'allumer/éteindre les lumières ou de couper l'alimentation des prises électriques. Appareils compatibles :
   - [Fibaro Wall Plug](https://www.fibaro.com/fr/products/wall-plug/)
   - [Interrupteurs Fibaro](https://www.fibaro.com/fr/products/switches/)
-- **Capteurs de température** – Surveillent la température ambiante.
-- **Suivi de la consommation électrique** – Analyse de la consommation d'énergie.
-- **Contrôle des rideaux/volets** – Ouvrir, fermer et connaître la position des rideaux. Appareils compatibles :
+- **Capteurs de température** : Surveillent la température ambiante.
+- **Suivi de la consommation électrique** : Analyse de la consommation d'énergie.
+- **Contrôle des rideaux/volets** : Ouvrir, fermer et connaître la position des rideaux. Appareils compatibles :
   - [Fibaro Walli Roller Shutter](https://manuals.fibaro.com/fr/walli-roller-shutter/)
   - [Qubino Flush Shutter](https://qubino.com/products/flush-shutter/)
-- **Variateurs de lumière (Dimmers)** – Ajustent la luminosité ou contrôlent des appareils à tension variable. Appareils compatibles :
+- **Variateurs de lumière (Dimmers)** : Ajustent la luminosité ou contrôlent des appareils à tension variable. Appareils compatibles :
   - [Fibaro Walli Dimmer](https://manuals.fibaro.com/fr/walli-dimmer/)
   - [Fibaro Dimmer 2](https://manuals.fibaro.com/fr/dimmer-2/)
-- **Capteurs de luminosité** – Mesurent l'intensité lumineuse ambiante.
-- **Capteurs d'alarme** – Détectent les menaces de sécurité.
-- **Capteurs binaires** – Permettent divers scénarios de détection ON/OFF.
+- **Capteurs de luminosité** : Mesurent l'intensité lumineuse ambiante.
+- **Capteurs d'alarme** : Détectent les menaces de sécurité.
+- **Capteurs binaires** : Permettent divers scénarios de détection ON/OFF.
 
 Si vous avez un appareil qui n'est pas encore géré, n'hésitez pas à nous contacter sur le forum.

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -539,7 +539,7 @@ function Home({ integrations, lang }) {
                   id="home.coolFeatures.dashboardDescrition"
                   description="Cool features dashboard title on the homepage"
                 >
-                  Temperature, security cameras, presence—monitor everything
+                  Temperature, security cameras, presence: monitor everything
                   from one beautiful dashboard.
                 </Translate>
               </p>
@@ -583,7 +583,7 @@ function Home({ integrations, lang }) {
                   id="home.coolFeatures.sceneDescription"
                   description="Cool features scene title on the homepage"
                 >
-                  Coffee brewing, lights turning on, music playing—all
+                  Coffee brewing, lights turning on, music playing: all
                   automatic. No coding required.
                 </Translate>
               </p>

--- a/src/components/plus/NabuCasaCompare.js
+++ b/src/components/plus/NabuCasaCompare.js
@@ -25,7 +25,7 @@ function NabuCasaCompare() {
         <Translate id="gladysPlusPage.v2.compare.subtitle">
           Nabu Casa is the official Home Assistant Cloud, made by the team
           driving Home Assistant. It's a great product. Here's how Gladys Plus
-          compares — without cherry-picking.
+          compares, without cherry-picking.
         </Translate>
       </p>
 
@@ -301,7 +301,7 @@ function NabuCasaCompare() {
             French integrations like Enedis,
             and
             direct contact with the maker (in French if you want). It's an indie
-            project funded by you alone — no investors, no foundation.
+            project funded by you alone, with no investors and no foundation.
           </Translate>
         </p>
       </div>

--- a/src/data/edfTempoData.js
+++ b/src/data/edfTempoData.js
@@ -12,7 +12,7 @@ export const TEMPO_API_URL =
 const edfTempoContent = {
   en: {
     meta: {
-      title: "EDF Tempo: today's colour (and tomorrow's) — live",
+      title: "EDF Tempo: today's colour (and tomorrow's), live",
       description:
         "Is today an EDF Tempo blue, white or red day? See the live Tempo colour of the day and tomorrow's colour, learn what each colour costs, and how to automate Tempo at home with Gladys.",
     },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -23,7 +23,7 @@ function HomePage() {
         id: "home.metaDescription",
         description: "home page meta description",
         message:
-          "Gladys Assistant is a privacy-first, open-source home automation platform. Self-hosted, no cloud required — a simpler alternative to Home Assistant.",
+          "Gladys Assistant is a privacy-first, open-source home automation platform. Self-hosted, no cloud required, a simpler alternative to Home Assistant.",
       })}
     >
       <JsonLd data={getHomepageSchema(i18n.currentLocale)} />

--- a/src/pages/starter-kit.js
+++ b/src/pages/starter-kit.js
@@ -1143,7 +1143,7 @@ function Plus() {
                 </li>
               </ul>
               <p>
-                <b>Hébergé en Europe 🇪🇺</b> — L'infrastructure Gladys Plus et
+                <b>Hébergé en Europe 🇪🇺</b> : L'infrastructure Gladys Plus et
                 l'inférence IA tournent dans des data centers européens. Tes
                 données restent chiffrées de bout en bout.
               </p>


### PR DESCRIPTION
Em dashes read as AI-generated. This sweeps the whole repo (landing pages, docs, blog, FR + EN) and replaces them with natural punctuation:

- prose parentheticals/breaks -> comma
- definition-list and product-card labels -> colon (French ":" spacing)
- number ranges -> hyphen (e.g. 20–50% -> 20-50%)

The only remaining "—" is the "No" indicator glyph in the Nabu Casa comparison table (a UI element with aria-label="No", not prose).