### PR TITLE
SEO/GEO: improve Enedis doc to target "API Enedis / API Linky" queries

### DIFF
--- a/docs/integrations/enedis.md
+++ b/docs/integrations/enedis.md
@@ -1,20 +1,30 @@
 ---
 id: enedis
-title: View your electricity consumption in Gladys with Enedis
-description: "View your electricity consumption in Gladys Assistant with the Enedis integration: connect your Linky meter data via Gladys Plus (France only)."
+title: "Enedis API: track your Linky electricity consumption in Gladys"
+description: "Connect the Enedis Data Connect API to track your Linky meter consumption in Gladys Assistant. Access your electricity data as an individual through Gladys Plus, no company contract required (France only)."
 sidebar_label: Enedis
+keywords:
+  - enedis api
+  - api enedis
+  - api linky
+  - api enedis particulier
+  - enedis data connect
+  - linky consommation
+  - suivre sa consommation électrique
 ---
 
-Enedis is a french electricity provider, and offers an API that allows to retrieve the electricity consumption data from a Linky meter of a household.
+import JsonLd from '@site/src/components/seo/JsonLd';
 
-This API is only proposed to companies, after signing a contract and a certification process.
+Enedis is the company that manages the French electricity distribution network, and the one that installs Linky smart meters in homes. Enedis exposes an API, called Data Connect, that lets you retrieve the electricity consumption data measured by your Linky meter.
 
-For Gladys, we have a legal structure, "Gladys Assistant SAS", which allows us to have access to this API and authorizes us to make it available to individuals.
+The catch: this API is only open to companies, after signing a contract and going through a certification process. As an individual, you cannot request access to the Enedis API directly.
 
-This API is available via [Gladys Plus](/plus).
+This is where Gladys helps. We have a legal entity, "Gladys Assistant SAS", that is certified to access the Enedis Data Connect API and authorized to make it available to individuals. So with Gladys you can track your Linky consumption through the official Enedis API, without running a company yourself.
+
+This integration is available via [Gladys Plus](/plus). Once connected, your daily consumption is retrieved automatically and stored in your own Gladys instance, so you keep your history and can build your own graphs and [scenes](/docs/scenes/intro/) on top of it.
 
 :::note
-This integration is only usable in France as it connects to the french electricity provider API.
+This integration only works in France, as it connects to the Enedis API, which is the French electricity distribution network operator.
 :::
 
 ## Connect to Enedis in Gladys
@@ -49,24 +59,83 @@ Choose "Histogram", and you should see this graph on your dashboard :
 
 ![Enedis Gladys integration, graph](../../static/img/docs/en/configuration/enedis/enedis-graphique.jpg)
 
-## FAQ
+From there, the data behaves like any other Gladys device: you can build automations with it, get alerts when your consumption is unusually high, or cross it with other sensors. It pairs well with the [energy monitoring](/docs/integrations/energy-monitoring/) features.
 
-### I can not make the Enedis consent?
+## Frequently asked questions
+
+### How do I access the Enedis API as an individual?
+
+The Enedis Data Connect API is not open to individuals directly: Enedis only signs API contracts with certified companies. The practical way to access your own Linky data through the official API, without creating a company, is to go through a certified provider. Gladys Assistant SAS is certified, so with [Gladys Plus](/plus) you connect your Enedis account once and Gladys retrieves your consumption for you.
+
+### Is the Enedis API free?
+
+For individuals, the data itself is free: you are simply authorizing access to your own consumption data measured by your Linky meter. The cost is the service that retrieves and stores it. With Gladys, the Enedis integration is included in [Gladys Plus](/plus).
+
+### What data does the Linky meter expose?
+
+Through Data Connect, you can access your daily consumption, and depending on your contract your half-hourly load curve, your maximum power, and your contract details. In Gladys, the daily consumption is retrieved and stored so you can chart it over days, weeks and months.
+
+### Can I store my Linky data locally?
+
+Yes. Once Gladys retrieves your consumption from the Enedis API, the data is stored in your own Gladys instance. You keep your full history even if you later disconnect the integration, and you can build local graphs, scenes and alerts on top of it.
+
+### I can not give the Enedis consent?
 
 The Enedis platform is sometimes offline for updates on the Enedis side. Often the best thing to do is to try again later.
 
 If it still doesn't work, check that your Enedis account is working: are you able to see your electricity consumption data in Enedis? If not, the problem is probably with Enedis.
 
-### I don't have any more data on the previous days ?
+### I don't have any more data on the previous days?
 
 The Enedis API is updated every morning in theory.
 
 However, in practice the data is not always available at the same time, and on some days (public holidays for example), the data is not available.
 
-If however, you observe holes on your dashboard, which persist over time, please post a message on [the forum](https://community.gladysassistant.com/).
+If however you observe holes on your dashboard, which persist over time, please post a message on [the forum](https://community.gladysassistant.com/).
 
 ### Synchronization is not done anymore?
 
 Your consent is valid for 2 years, and must be renewed if you want Gladys to continue retrieving your data.
 
 If your account does not synchronize anymore, in case of doubt I advise you to renew your consent by clicking on the blue button "I access my Enedis customer space".
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "How do I access the Enedis API as an individual?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "The Enedis Data Connect API is not open to individuals directly: Enedis only signs API contracts with certified companies. To access your own Linky data through the official API without creating a company, you go through a certified provider. Gladys Assistant SAS is certified, so with Gladys Plus you connect your Enedis account once and Gladys retrieves your consumption for you.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Is the Enedis API free?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "For individuals the data itself is free: you authorize access to your own consumption measured by your Linky meter. The cost is the service that retrieves and stores it. With Gladys, the Enedis integration is included in Gladys Plus.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "What data does the Linky meter expose?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Through Data Connect you can access your daily consumption, and depending on your contract your half-hourly load curve, your maximum power and your contract details. In Gladys, the daily consumption is retrieved and stored so you can chart it over days, weeks and months.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I store my Linky data locally?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Once Gladys retrieves your consumption from the Enedis API, the data is stored in your own Gladys instance. You keep your full history even if you later disconnect the integration, and you can build local graphs, scenes and alerts on top of it.",
+        },
+      },
+    ],
+  }}
+/>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/enedis.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/enedis.md
@@ -1,17 +1,27 @@
 ---
 id: enedis
-title: Visualiser sa consommation électrique dans Gladys avec Enedis
-description: "Visualisez votre consommation électrique dans Gladys Assistant avec l'intégration Enedis : récupérez les données de votre compteur Linky via Gladys Plus (France)."
+title: "API Enedis : suivez la consommation de votre Linky dans Gladys"
+description: "Connectez l'API Enedis Data Connect pour suivre la consommation de votre compteur Linky dans Gladys Assistant. Accédez à vos données électriques en tant que particulier via Gladys Plus, sans contrat entreprise (France)."
 sidebar_label: Enedis
+keywords:
+  - api enedis
+  - enedis api
+  - api linky
+  - api enedis particulier
+  - enedis data connect
+  - linky consommation
+  - suivre sa consommation électrique
 ---
 
-Enedis propose une API qui permet de récupérer les données de consommation électrique venant d'un compteur Linky d'un foyer.
+import JsonLd from '@site/src/components/seo/JsonLd';
 
-Cette API est uniquement proposée aux entreprises après signature d'un contrat et d'un processus de certification.
+Enedis est le gestionnaire du réseau de distribution d'électricité français, et c'est aussi l'entreprise qui installe les compteurs communicants Linky dans les foyers. Enedis expose une API, appelée Data Connect, qui permet de récupérer les données de consommation électrique mesurées par votre compteur Linky.
 
-Côté Gladys, nous avons une structure juridique, "Gladys Assistant SAS", qui nous permet d'avoir accès à cette API et nous autorise à la mettre à disposition des particuliers.
+Le souci : cette API est uniquement proposée aux entreprises, après signature d'un contrat et un processus de certification. En tant que particulier, vous ne pouvez pas demander un accès direct à l'API Enedis.
 
-Cette API est mise à disposition via [Gladys Plus](/fr/plus).
+C'est là que Gladys intervient. Nous avons une structure juridique, "Gladys Assistant SAS", qui est certifiée pour accéder à l'API Enedis Data Connect et autorisée à la mettre à disposition des particuliers. Avec Gladys, vous pouvez donc suivre la consommation de votre Linky via l'API officielle Enedis, sans monter votre propre entreprise.
+
+Cette intégration est disponible via [Gladys Plus](/fr/plus). Une fois connectée, votre consommation quotidienne est récupérée automatiquement et stockée dans votre propre instance Gladys : vous gardez votre historique et pouvez construire vos propres graphiques et [scènes](/fr/docs/scenes/intro/) par-dessus.
 
 :::note
 Cette intégration est uniquement utilisable en France, Enedis étant le gestionnaire du réseau de distribution d'électricité français.
@@ -49,7 +59,25 @@ Choisissez "Histogramme", vous devriez voir ce graphique sur votre tableau de bo
 
 ![Intégration Enedis Gladys, graphique](../../../../../static/img/docs/fr/configuration/enedis/enedis-graphique.jpg)
 
-## FAQ
+À partir de là, la donnée se comporte comme n'importe quel autre appareil Gladys : vous pouvez créer des automatisations, recevoir une alerte quand votre consommation est anormalement élevée, ou la croiser avec vos autres capteurs. Elle se marie bien avec les fonctionnalités de [suivi de consommation énergétique](/fr/docs/integrations/energy-monitoring/).
+
+## Foire aux questions
+
+### Comment accéder à l'API Enedis en tant que particulier ?
+
+L'API Enedis Data Connect n'est pas ouverte directement aux particuliers : Enedis ne signe de contrat d'API qu'avec des entreprises certifiées. La façon concrète d'accéder à vos propres données Linky via l'API officielle, sans créer d'entreprise, est de passer par un prestataire certifié. Gladys Assistant SAS est certifiée : avec [Gladys Plus](/fr/plus), vous connectez votre compte Enedis une fois et Gladys récupère votre consommation pour vous.
+
+### L'API Enedis est-elle gratuite ?
+
+Pour un particulier, la donnée elle-même est gratuite : vous autorisez simplement l'accès à votre propre consommation, mesurée par votre compteur Linky. Le coût, c'est le service qui la récupère et la stocke. Avec Gladys, l'intégration Enedis est incluse dans [Gladys Plus](/fr/plus).
+
+### Quelles données le compteur Linky expose-t-il ?
+
+Via Data Connect, vous pouvez accéder à votre consommation quotidienne, et selon votre contrat à votre courbe de charge à la demi-heure, votre puissance maximale et les informations de votre contrat. Dans Gladys, la consommation quotidienne est récupérée et stockée pour que vous puissiez la visualiser sur des jours, des semaines et des mois.
+
+### Puis-je stocker mes données Linky en local ?
+
+Oui. Une fois que Gladys a récupéré votre consommation depuis l'API Enedis, la donnée est stockée dans votre propre instance Gladys. Vous gardez tout votre historique même si vous déconnectez plus tard l'intégration, et vous pouvez construire des graphiques, des scènes et des alertes en local par-dessus.
 
 ### Je n'arrive pas à faire le consentement Enedis ?
 
@@ -70,3 +98,44 @@ Si toutefois, vous observez des trous sur votre tableau de bord qui persiste dan
 Votre consentement est valide 2 ans, et doit être renouvellé si vous voulez que Gladys continue à récupérer vos données.
 
 Si votre compte ne se synchronise plus, en cas de doutes je vous conseille de refaire un consentement en cliquant sur le bouton bleu "J'accède à mon espace client Enedis".
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Comment accéder à l'API Enedis en tant que particulier ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "L'API Enedis Data Connect n'est pas ouverte directement aux particuliers : Enedis ne signe de contrat d'API qu'avec des entreprises certifiées. Pour accéder à vos propres données Linky via l'API officielle sans créer d'entreprise, vous passez par un prestataire certifié. Gladys Assistant SAS est certifiée : avec Gladys Plus, vous connectez votre compte Enedis une fois et Gladys récupère votre consommation pour vous.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "L'API Enedis est-elle gratuite ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Pour un particulier, la donnée elle-même est gratuite : vous autorisez l'accès à votre propre consommation, mesurée par votre compteur Linky. Le coût, c'est le service qui la récupère et la stocke. Avec Gladys, l'intégration Enedis est incluse dans Gladys Plus.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Quelles données le compteur Linky expose-t-il ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Via Data Connect, vous pouvez accéder à votre consommation quotidienne, et selon votre contrat à votre courbe de charge à la demi-heure, votre puissance maximale et les informations de votre contrat. Dans Gladys, la consommation quotidienne est récupérée et stockée pour la visualiser sur des jours, des semaines et des mois.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Puis-je stocker mes données Linky en local ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui. Une fois que Gladys a récupéré votre consommation depuis l'API Enedis, la donnée est stockée dans votre propre instance Gladys. Vous gardez tout votre historique même si vous déconnectez plus tard l'intégration, et vous pouvez construire des graphiques, des scènes et des alertes en local par-dessus.",
+        },
+      },
+    ],
+  }}
+/>


### PR DESCRIPTION
Rewrite the existing Enedis integration doc (EN+FR) to capture the ~5,300 monthly impressions sitting at position 8-9 with near-zero CTR on queries like "api enedis", "enedis api" and "api enedis particulier".

- SEO title + keywords frontmatter (API Enedis / Linky angle)
- Expanded intro: Enedis Data Connect API, the company-only access barrier, and how Gladys (certified) opens it to individuals
- Local-storage framing + link to energy-monitoring and scenes
- Expanded FAQ with intent-matching Q&A (access as an individual, is it free, what Linky exposes, local storage)
- FAQPage JSON-LD for rich results / GEO
- No em dashes