### PR TITLE
SEO/GEO: improve CalDAV doc to capture "caldav" informational + servi…

### DIFF
--- a/docs/integrations/caldav.md
+++ b/docs/integrations/caldav.md
@@ -1,11 +1,24 @@
 ---
 id: caldav
-title: CalDAV
-description: "Sync your Gladys Assistant calendar with iCloud, Google Calendar, Synology or Nextcloud via CalDAV to trigger scenes from your events."
+title: "CalDAV in Gladys: sync iCloud, Google Calendar, Synology and Nextcloud"
+description: "Connect your calendar to Gladys Assistant over CalDAV. Step by step setup for iCloud, Google Calendar, Synology and Nextcloud, including the app password, to trigger scenes from your events."
 sidebar_label: CalDAV
+keywords:
+  - caldav
+  - caldav google calendar
+  - caldav icloud
+  - caldav nextcloud
+  - caldav synology
+  - caldav app password
 ---
 
-Use CalDav to synchronise your Gladys calendar with external services (Google Calendar, iCloud, Nextcloud...).
+import JsonLd from '@site/src/components/seo/JsonLd';
+
+CalDAV is an open standard that lets applications read and sync calendar events from a calendar server. Most calendar services support it, including iCloud, Google Calendar, Synology Calendar and Nextcloud, which is why it is a convenient, vendor neutral way to bring your existing calendar into another app.
+
+In Gladys, you use CalDAV to synchronise your calendar with these external services. Once your events are in Gladys, you can use them to trigger [scenes](/docs/scenes/intro/): turn the heating on before a meeting, send a reminder when an event starts, or change your house mode when you are on holiday.
+
+Most services require an app specific password rather than your main account password. The steps below show how to generate it and where to paste it for each service.
 
 ## Available services (tested & others)
 
@@ -142,3 +155,74 @@ For all others services
 3. Then enter your password (if applicable)
 
 ![Others services](../../static/img/docs/en/configuration/caldav/other_config.png)
+
+## Frequently asked questions
+
+### What is CalDAV?
+
+CalDAV is an open standard, built on top of WebDAV, that lets applications access and synchronise calendar data from a calendar server. It is supported by most calendar providers, so an app like Gladys can read your events from iCloud, Google Calendar, Synology or Nextcloud without a service specific integration.
+
+### Do I need my account password or an app password?
+
+For most services you need an app specific password, not your main account password. iCloud, Google and Nextcloud all let you generate a dedicated password for Gladys from their security settings, which you can revoke at any time without changing your main password. The setup steps above show where to generate it for each service.
+
+### How do I connect Google Calendar with CalDAV?
+
+Sign in to your Google account, open the security settings and create an app password for "Calendar". Then in Gladys go to the CalDAV config page, choose "Google Calendar", keep the default URL, enter your Google email and paste the generated app password. Gladys will sync your events.
+
+### How do I connect my iCloud calendar?
+
+Sign in at appleid.apple.com and generate an app specific password. In Gladys, open the CalDAV config page, choose "iCloud Calendar", keep the default URL, enter your Apple ID email and paste the password. If the password does not work, make sure you generated an app specific password and not your normal Apple ID password.
+
+### Can I use CalDAV with any other calendar service?
+
+Yes. If your service supports CalDAV, choose "Other" in Gladys, then enter its CalDAV URL, your username or email and your password. This covers self hosted servers like Baïkal or Radicale, and most providers that expose a CalDAV endpoint.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "What is CalDAV?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "CalDAV is an open standard, built on top of WebDAV, that lets applications access and synchronise calendar data from a calendar server. It is supported by most calendar providers, so an app like Gladys can read your events from iCloud, Google Calendar, Synology or Nextcloud without a service specific integration.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Do I need my account password or an app password for CalDAV?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "For most services you need an app specific password, not your main account password. iCloud, Google and Nextcloud all let you generate a dedicated password for Gladys from their security settings, which you can revoke at any time without changing your main password.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I connect Google Calendar with CalDAV?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Sign in to your Google account, open the security settings and create an app password for Calendar. Then in Gladys go to the CalDAV config page, choose Google Calendar, keep the default URL, enter your Google email and paste the generated app password. Gladys will sync your events.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "How do I connect my iCloud calendar with CalDAV?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Sign in at appleid.apple.com and generate an app specific password. In Gladys, open the CalDAV config page, choose iCloud Calendar, keep the default URL, enter your Apple ID email and paste the password. If it does not work, make sure you generated an app specific password and not your normal Apple ID password.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I use CalDAV with any other calendar service?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. If your service supports CalDAV, choose Other in Gladys, then enter its CalDAV URL, your username or email and your password. This covers self hosted servers like Baikal or Radicale, and most providers that expose a CalDAV endpoint.",
+        },
+      },
+    ],
+  }}
+/>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/caldav.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/caldav.md
@@ -1,11 +1,24 @@
 ---
 id: caldav
-title: CalDAV
-description: "Synchronisez le calendrier de Gladys Assistant avec iCloud, Google Agenda, Synology ou Nextcloud en CalDAV pour déclencher des scènes selon vos événements."
+title: "CalDAV dans Gladys : synchroniser iCloud, Google Agenda, Synology et Nextcloud"
+description: "Connectez votre agenda à Gladys Assistant en CalDAV. Configuration pas à pas pour iCloud, Google Agenda, Synology et Nextcloud, mot de passe d'application inclus, pour déclencher des scènes selon vos événements."
 sidebar_label: CalDAV
+keywords:
+  - caldav
+  - caldav google agenda
+  - caldav icloud
+  - caldav nextcloud
+  - caldav synology
+  - mot de passe caldav
 ---
 
-Pour synchroniser votre calendrier Gladys avec les serveurs compatibles (Google Agenda, iCloud, Nextcloud...)
+import JsonLd from '@site/src/components/seo/JsonLd';
+
+CalDAV est un standard ouvert qui permet à des applications de lire et de synchroniser les événements d'un agenda hébergé sur un serveur de calendrier. La plupart des services le prennent en charge, dont iCloud, Google Agenda, le calendrier Synology et Nextcloud : c'est donc un moyen pratique et universel de récupérer votre agenda existant dans une autre application.
+
+Dans Gladys, vous utilisez CalDAV pour synchroniser votre agenda avec ces services externes. Une fois vos événements dans Gladys, vous pouvez vous en servir pour déclencher des [scènes](/fr/docs/scenes/intro/) : allumer le chauffage avant une réunion, envoyer un rappel au début d'un événement, ou changer le mode de la maison quand vous êtes en vacances.
+
+La plupart des services demandent un mot de passe d'application dédié, et non le mot de passe principal de votre compte. Les étapes ci-dessous montrent comment le générer et où le coller pour chaque service.
 
 ## Services disponibles (testés & autres)
 
@@ -136,3 +149,74 @@ Pour tout autre service
 3. Entrez le mot de passe de votre compte
 
 ![Autre service](../../../../../static/img/docs/fr/configuration/caldav/other_config.png)
+
+## Foire aux questions
+
+### Qu'est-ce que le CalDAV ?
+
+CalDAV est un standard ouvert, construit au-dessus de WebDAV, qui permet à des applications d'accéder aux données d'un agenda et de les synchroniser depuis un serveur de calendrier. Il est pris en charge par la plupart des fournisseurs d'agenda, ce qui permet à une application comme Gladys de lire vos événements depuis iCloud, Google Agenda, Synology ou Nextcloud sans intégration spécifique à chaque service.
+
+### Faut-il le mot de passe de mon compte ou un mot de passe d'application ?
+
+Pour la plupart des services, il faut un mot de passe d'application dédié, et non le mot de passe principal de votre compte. iCloud, Google et Nextcloud permettent tous de générer un mot de passe spécifique pour Gladys depuis leurs paramètres de sécurité, que vous pouvez révoquer à tout moment sans changer votre mot de passe principal. Les étapes ci-dessus montrent où le générer pour chaque service.
+
+### Comment connecter Google Agenda en CalDAV ?
+
+Connectez-vous à votre compte Google, ouvrez les paramètres de sécurité et créez un mot de passe d'application pour "Agenda". Ensuite, dans Gladys, allez sur la page de configuration CalDAV, choisissez "Google Agenda", laissez l'URL par défaut, entrez votre email Google et collez le mot de passe d'application généré. Gladys synchronisera vos événements.
+
+### Comment connecter mon agenda iCloud ?
+
+Connectez-vous sur appleid.apple.com et générez un mot de passe d'application. Dans Gladys, ouvrez la page de configuration CalDAV, choisissez "Calendrier iCloud", laissez l'URL par défaut, entrez l'email de votre Apple ID et collez le mot de passe. Si cela ne fonctionne pas, vérifiez bien que vous avez généré un mot de passe d'application et non votre mot de passe Apple ID habituel.
+
+### Puis-je utiliser CalDAV avec n'importe quel autre service d'agenda ?
+
+Oui. Si votre service prend en charge CalDAV, choisissez "Autre" dans Gladys, puis entrez son URL CalDAV, votre nom d'utilisateur ou email et votre mot de passe. Cela couvre les serveurs auto-hébergés comme Baïkal ou Radicale, et la plupart des fournisseurs qui exposent un point d'accès CalDAV.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Qu'est-ce que le CalDAV ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "CalDAV est un standard ouvert, construit au-dessus de WebDAV, qui permet à des applications d'accéder aux données d'un agenda et de les synchroniser depuis un serveur de calendrier. Il est pris en charge par la plupart des fournisseurs d'agenda, ce qui permet à une application comme Gladys de lire vos événements depuis iCloud, Google Agenda, Synology ou Nextcloud sans intégration spécifique à chaque service.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Faut-il le mot de passe de mon compte ou un mot de passe d'application pour CalDAV ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Pour la plupart des services, il faut un mot de passe d'application dédié, et non le mot de passe principal de votre compte. iCloud, Google et Nextcloud permettent tous de générer un mot de passe spécifique pour Gladys depuis leurs paramètres de sécurité, que vous pouvez révoquer à tout moment sans changer votre mot de passe principal.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Comment connecter Google Agenda en CalDAV ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Connectez-vous à votre compte Google, ouvrez les paramètres de sécurité et créez un mot de passe d'application pour Agenda. Ensuite, dans Gladys, allez sur la page de configuration CalDAV, choisissez Google Agenda, laissez l'URL par défaut, entrez votre email Google et collez le mot de passe d'application généré. Gladys synchronisera vos événements.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Comment connecter mon agenda iCloud en CalDAV ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Connectez-vous sur appleid.apple.com et générez un mot de passe d'application. Dans Gladys, ouvrez la page de configuration CalDAV, choisissez Calendrier iCloud, laissez l'URL par défaut, entrez l'email de votre Apple ID et collez le mot de passe. Si cela ne fonctionne pas, vérifiez que vous avez généré un mot de passe d'application et non votre mot de passe Apple ID habituel.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Puis-je utiliser CalDAV avec n'importe quel autre service d'agenda ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui. Si votre service prend en charge CalDAV, choisissez Autre dans Gladys, puis entrez son URL CalDAV, votre nom d'utilisateur ou email et votre mot de passe. Cela couvre les serveurs auto-hébergés comme Baikal ou Radicale, et la plupart des fournisseurs qui exposent un point d'accès CalDAV.",
+        },
+      },
+    ],
+  }}
+/>


### PR DESCRIPTION
…ce queries

Rewrite the existing CalDAV integration doc (EN+FR) to capture the ~5,000 monthly impressions at position 5-9 with near-zero CTR on "caldav", "caldav google agenda", "caldav icloud", "mot de passe caldav iphone" and related queries. Setup steps left untouched.

- SEO title + keywords frontmatter (CalDAV + iCloud/Google/Synology/Nextcloud)
- Intro explaining what CalDAV is (captures informational intent) and what you do with it in Gladys (trigger scenes from events)
- Note on the app-specific password requirement (top sub-query)
- FAQ: what is CalDAV, app password vs account password, Google Calendar setup, iCloud setup, other services
- FAQPage JSON-LD for rich results / GEO
- No em dashes