### PR TITLE
open: reframe /open page around trust, community and longevity

### DIFF
--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -423,7 +423,7 @@
     "description": "Chart title"
   },
   "openPage.lastYearReviews": {
-    "message": "Bilan des années précédentes",
+    "message": "Historique du projet",
     "description": "Last year reviews"
   },
   "openPage.nbOfForumUsers": {
@@ -1458,5 +1458,9 @@
   },
   "gladysPlusPage.v2.finalCta.secondary": {
     "message": "Voir le kit de démarrage"
+  },
+  "openPage.latestReleases": {
+    "message": "Dernières actus & versions →",
+    "description": "Open page latest releases link"
   }
 }

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -1462,5 +1462,17 @@
   "openPage.latestReleases": {
     "message": "Dernières actus & versions →",
     "description": "Open page latest releases link"
+  },
+  "openPage.chart.activeInstances": {
+    "message": "Instances actives",
+    "description": "Instance chart active instances series label"
+  },
+  "openPage.chart.trend": {
+    "message": "Tendance long terme",
+    "description": "Instance chart trend line label"
+  },
+  "openPage.chart.spikeNote": {
+    "message": "Le pic de février 2026 vient d'une vidéo virale « Home Assistant vs Gladys » qui a amené une vague de curieux. La base qui est restée est toujours bien au-dessus de notre point de départ, et la tendance de fond reste à la hausse.",
+    "description": "Open page instance chart spike explanation"
   }
 }

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -363,12 +363,52 @@
     "description": "gladys open page meta description"
   },
   "openPage.description": {
-    "message": "Gladys Assistant est un projet 100% transparent : découvre en temps réel le nombre d'utilisateurs, le revenu mensuel, et toutes les métriques du projet.",
+    "message": "Gladys Assistant est radicalement transparent. Voici nos vrais chiffres, en direct : combien de foyers utilisent Gladys, notre communauté, et comment le projet est financé. Pas d'investisseurs, pas de publicité, pas de revente de données, juste un projet financé par les gens qui l'utilisent.",
     "description": "Open page description"
   },
+  "openPage.lockin.title": {
+    "message": "Ta maison ne dépend jamais de nous",
+    "description": "Open page no lock-in title"
+  },
+  "openPage.lockin.body": {
+    "message": "Gladys est open-source (Apache 2.0) et tourne 100% en local sur ton propre matériel. Même si Gladys Plus disparaissait demain, tes automatisations continuent de fonctionner et tes données restent chez toi. Gladys Plus est un confort, jamais un verrou, et c'est précisément ce qui nous permet d'être aussi transparents.",
+    "description": "Open page no lock-in body"
+  },
   "openPage.homeRunningGladys": {
-    "message": "Nombre d'instances Gladys",
+    "message": "Foyers utilisant Gladys",
     "description": "Open Page home running Gladys"
+  },
+  "openPage.communityMembers": {
+    "message": "Membres de la communauté",
+    "description": "Open Page community members"
+  },
+  "openPage.onlineSince": {
+    "message": "En ligne depuis",
+    "description": "Open Page online since"
+  },
+  "openPage.onlineSinceSubtitle": {
+    "message": "quasi zéro interruption",
+    "description": "Open Page online since subtitle"
+  },
+  "openPage.funding.title": {
+    "message": "Comment le projet est financé",
+    "description": "Open Page funding title"
+  },
+  "openPage.funding.intro": {
+    "message": "Gladys Plus est la seule chose qui finance Gladys, et il vit entièrement de ses abonnés. Aucun argent extérieur.",
+    "description": "Open Page funding intro"
+  },
+  "openPage.funding.supporters": {
+    "message": "Soutiens Gladys Plus",
+    "description": "Open Page supporters"
+  },
+  "openPage.funding.mrr": {
+    "message": "Revenu mensuel récurrent",
+    "description": "Open Page MRR label"
+  },
+  "openPage.funding.note": {
+    "message": "C'est tout : {count} personnes qui maintiennent en vie un projet indépendant et respectueux de la vie privée. Chaque abonnement finance les serveurs, l'infrastructure et le développement, rien d'autre. Pas d'investisseurs à satisfaire, pas de croissance à tout prix.",
+    "description": "Open Page funding note"
   },
   "openPage.gladysPlusUsers": {
     "message": "Utilisateurs Gladys Plus",

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -363,7 +363,7 @@
     "description": "gladys open page meta description"
   },
   "openPage.description": {
-    "message": "Gladys Assistant est radicalement transparent. Voici nos vrais chiffres, en direct : combien de foyers utilisent Gladys, notre communauté, et comment le projet est financé. Pas d'investisseurs, pas de publicité, pas de revente de données, juste un projet financé par les gens qui l'utilisent.",
+    "message": "Pas d'investisseurs, pas de publicité, pas de revente de données. Gladys est construit au grand jour depuis 2013 et tourne entièrement sur ton propre matériel. Voici les vrais chiffres du projet, en direct.",
     "description": "Open page description"
   },
   "openPage.lockin.title": {
@@ -371,7 +371,7 @@
     "description": "Open page no lock-in title"
   },
   "openPage.lockin.body": {
-    "message": "Gladys est open-source (Apache 2.0) et tourne 100% en local sur ton propre matériel. Même si Gladys Plus disparaissait demain, tes automatisations continuent de fonctionner et tes données restent chez toi. Gladys Plus est un confort, jamais un verrou, et c'est précisément ce qui nous permet d'être aussi transparents.",
+    "message": "Gladys est open-source (Apache 2.0) et tourne 100% en local sur ton propre matériel. Si Gladys Plus disparaissait demain, tes automatisations continueraient de fonctionner et tes données resteraient chez toi. Gladys Plus est un confort, jamais un verrou, et c'est précisément ce qui nous permet d'être aussi transparents.",
     "description": "Open page no lock-in body"
   },
   "openPage.homeRunningGladys": {
@@ -382,20 +382,12 @@
     "message": "Membres de la communauté",
     "description": "Open Page community members"
   },
-  "openPage.onlineSince": {
-    "message": "En ligne depuis",
-    "description": "Open Page online since"
-  },
-  "openPage.onlineSinceSubtitle": {
-    "message": "quasi zéro interruption",
-    "description": "Open Page online since subtitle"
-  },
   "openPage.funding.title": {
     "message": "Comment le projet est financé",
     "description": "Open Page funding title"
   },
   "openPage.funding.intro": {
-    "message": "Gladys Plus est la seule chose qui finance Gladys, et il vit entièrement de ses abonnés. Aucun argent extérieur.",
+    "message": "Gladys Plus est la seule chose qui finance Gladys, et il vit entièrement de ses abonnés. Aucun argent extérieur, aucune contrepartie.",
     "description": "Open Page funding intro"
   },
   "openPage.funding.supporters": {
@@ -419,28 +411,20 @@
     "description": "Open Page MRR"
   },
   "openPage.numberOfHomeRunningGladys": {
-    "message": "Nombre d'instances Gladys",
+    "message": "Foyers utilisant Gladys au fil du temps",
     "description": "Chart title"
   },
-  "openPage.lastYearReviews": {
-    "message": "Historique du projet",
-    "description": "Last year reviews"
-  },
   "openPage.nbOfForumUsers": {
-    "message": "Nb d'utilisateurs du forum",
+    "message": "Membres du forum",
     "description": "Gladys open page number of forum users"
   },
   "openPage.forumPageViews": {
-    "message": "Nb de page vues du forum",
+    "message": "Pages vues du forum",
     "description": "Gladys open forum page views"
   },
   "openPage.lastWeek": {
     "message": "(Dernière semaine)",
     "description": "Gladys Open page last week"
-  },
-  "openPage.yearlyReview": {
-    "message": "Bilan de l'année {year}",
-    "description": "Yearly reviews"
   },
   "contact.submit": {
     "message": "Envoyer",
@@ -1459,10 +1443,6 @@
   "gladysPlusPage.v2.finalCta.secondary": {
     "message": "Voir le kit de démarrage"
   },
-  "openPage.latestReleases": {
-    "message": "Dernières actus & versions →",
-    "description": "Open page latest releases link"
-  },
   "openPage.chart.activeInstances": {
     "message": "Instances actives",
     "description": "Instance chart active instances series label"
@@ -1472,7 +1452,51 @@
     "description": "Instance chart trend line label"
   },
   "openPage.chart.spikeNote": {
-    "message": "Le pic de février 2026 vient d'une vidéo virale « Home Assistant vs Gladys » qui a amené une vague de curieux. La base qui est restée est toujours bien au-dessus de notre point de départ, et la tendance de fond reste à la hausse.",
+    "message": "Le pic de février 2026 vient d'une vidéo virale « Home Assistant vs Gladys » qui a amené une vague de curieux. La base qui est restée est toujours bien au-dessus de notre point de départ, et la tendance de fond reste à la hausse. Le dernier point, en pointillés, correspond au mois en cours, encore en cours de comptage.",
     "description": "Open page instance chart spike explanation"
+  },
+  "openPage.eyebrow": {
+    "message": "Chiffres en direct, mis à jour automatiquement",
+    "description": "Open page live eyebrow"
+  },
+  "openPage.h1": {
+    "message": "Tout sur Gladys, à livre ouvert",
+    "description": "Gladys open page H1"
+  },
+  "openPage.metric.homesSub": {
+    "message": "En direct, déclaré par les instances",
+    "description": "Open page homes metric subtitle"
+  },
+  "openPage.metric.communitySub": {
+    "message": "Sur le forum et au-delà",
+    "description": "Open page community metric subtitle"
+  },
+  "openPage.metric.yearsLabel": {
+    "message": "Années à livre ouvert",
+    "description": "Open page years metric label"
+  },
+  "openPage.metric.yearsSub": {
+    "message": "Depuis 2013, toujours indépendant",
+    "description": "Open page years metric subtitle"
+  },
+  "openPage.metric.supportersSub": {
+    "message": "Financent tout le projet",
+    "description": "Open page supporters metric subtitle"
+  },
+  "openPage.chart.currentMonthShort": {
+    "message": "en cours",
+    "description": "Instance chart current month short tag"
+  },
+  "openPage.chart.currentMonthTooltip": {
+    "message": "Mois en cours, encore incomplet",
+    "description": "Instance chart current month tooltip"
+  },
+  "openPage.chart.yAxis": {
+    "message": "Nombre d'instances",
+    "description": "Instance chart y axis title"
+  },
+  "openPage.community.title": {
+    "message": "Une communauté bien vivante",
+    "description": "Open page community section title"
   }
 }

--- a/src/pages/open.js
+++ b/src/pages/open.js
@@ -244,8 +244,8 @@ function Open() {
                 </p>
               </div>
             </div>
-            <div className="row">
-              <div className="col col--10 col--offset-1">
+            <div className={"row " + styles.openPageChartRow}>
+              <div className="col col--12">
                 <div className="alert alert--info" role="note">
                   <h2 style={{ marginTop: 0 }}>
                     <Translate
@@ -369,7 +369,7 @@ function Open() {
                     </div>
                   </div>
                 </div>
-                <div class={"row " + styles.openPageChartRow}>
+                <div className={"row " + styles.openPageChartRow}>
                   <div className={"col col--12 " + styles.openPageCard}>
                     <div className="card">
                       <div className="card__body">
@@ -456,19 +456,29 @@ function Open() {
                     </div>
                   </div>
                 </div>
-                <div class={"row " + styles.openPageChartRow}>
+                <div className={"row " + styles.openPageChartRow}>
                   <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card" style={{ height: "270px" }}>
+                    <div className="card">
                       <div className="card__body">
                         <h2 className="text--center">
                           <Translate
                             id="openPage.lastYearReviews"
                             description="Last year reviews"
                           >
-                            Last years reviews
+                            Project history
                           </Translate>
                         </h2>
                         <ul>
+                          <li className={styles.openPageList}>
+                            <a href={`${urlPrefix}/blog`}>
+                              <Translate
+                                id="openPage.latestReleases"
+                                description="Open page latest releases link"
+                              >
+                                Latest news & releases →
+                              </Translate>
+                            </a>
+                          </li>
                           <li className={styles.openPageList}>
                             <a href={`${urlPrefix}/blog/2024-year-in-review`}>
                               <Translate
@@ -531,7 +541,7 @@ function Open() {
                     </div>
                   </div>
                   <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card" style={{ height: "270px" }}>
+                    <div className="card">
                       <div className="card__body">
                         <h2 className="text--center">
                           <Translate
@@ -554,7 +564,7 @@ function Open() {
                     </div>
                   </div>
                   <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card" style={{ height: "270px" }}>
+                    <div className="card">
                       <div className="card__header">
                         <h2
                           className="text--center"

--- a/src/pages/open.js
+++ b/src/pages/open.js
@@ -87,6 +87,11 @@ function Open() {
     ? Math.round(usageChartData.chartmogul_data.current / 100)
     : null;
 
+  const communityMembers = usageChartData
+    ? usageChartData.forum_users.find((user) => user.user_type === "total")
+        ?.count
+    : null;
+
   async function fetchData() {
     const data = await getUsage();
     setUsageChartData(data);
@@ -231,10 +236,39 @@ function Open() {
                     id="openPage.description"
                     description="Open page description"
                   >
-                    Gladys Assistant is completely transparent: how much people
-                    are using Gladys? What's the current revenue of the project?
+                    Gladys Assistant is radically transparent. Here are our real
+                    numbers, live: how many homes run Gladys, our community, and
+                    how the project is funded. No investors, no ads, no data
+                    resale, just a project funded by the people who use it.
                   </Translate>
                 </p>
+              </div>
+            </div>
+            <div className="row">
+              <div className="col col--10 col--offset-1">
+                <div className="alert alert--info" role="note">
+                  <h2 style={{ marginTop: 0 }}>
+                    <Translate
+                      id="openPage.lockin.title"
+                      description="Open page no lock-in title"
+                    >
+                      Your home never depends on us
+                    </Translate>
+                  </h2>
+                  <p style={{ marginBottom: 0 }}>
+                    <Translate
+                      id="openPage.lockin.body"
+                      description="Open page no lock-in body"
+                    >
+                      Gladys is open-source (Apache 2.0) and runs 100% locally on
+                      your own hardware. Even if Gladys Plus disappeared
+                      tomorrow, your automations keep running and your data stays
+                      in your home. Gladys Plus is a convenience, never a
+                      lock-in, and that is exactly why we can afford to be this
+                      transparent.
+                    </Translate>
+                  </p>
+                </div>
               </div>
             </div>
             {loading && (
@@ -274,7 +308,7 @@ function Open() {
                             id="openPage.homeRunningGladys"
                             description="Open Page home running Gladys"
                           >
-                            Home running Gladys
+                            Homes running Gladys
                           </Translate>
                         </div>
                         <h3
@@ -291,17 +325,17 @@ function Open() {
                       <div className="card__body">
                         <div className="text--center">
                           <Translate
-                            id="openPage.gladysPlusUsers"
-                            description="Open Page gladys plus users Gladys"
+                            id="openPage.communityMembers"
+                            description="Open Page community members"
                           >
-                            Gladys Plus users
+                            Community members
                           </Translate>
                         </div>
                         <h3
                           className="text--center"
                           style={{ fontSize: "4rem" }}
                         >
-                          {numberOfGladysPlusUsers}
+                          {communityMembers}
                         </h3>
                       </div>
                     </div>
@@ -311,18 +345,26 @@ function Open() {
                       <div className="card__body">
                         <div className="text--center">
                           <Translate
-                            id="openPage.mrr"
-                            description="Open Page MRR"
+                            id="openPage.onlineSince"
+                            description="Open Page online since"
                           >
-                            MRR
+                            Online since
                           </Translate>
                         </div>
                         <h3
                           className="text--center"
                           style={{ fontSize: "4rem" }}
                         >
-                          {mrr} €
+                          2019
                         </h3>
+                        <div className="text--center text--secondary">
+                          <Translate
+                            id="openPage.onlineSinceSubtitle"
+                            description="Open Page online since subtitle"
+                          >
+                            with near-zero downtime
+                          </Translate>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -342,6 +384,74 @@ function Open() {
                         <div style={{ height: "400px" }}>
                           <canvas ref={usageChartRef}></canvas>
                         </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className={"row " + styles.openPageChartRow}>
+                  <div className={"col col--12 " + styles.openPageCard}>
+                    <div className="card">
+                      <div className="card__body">
+                        <h2 className="text--center">
+                          <Translate
+                            id="openPage.funding.title"
+                            description="Open Page funding title"
+                          >
+                            How the project is funded
+                          </Translate>
+                        </h2>
+                        <p className="text--center">
+                          <Translate
+                            id="openPage.funding.intro"
+                            description="Open Page funding intro"
+                          >
+                            Gladys Plus is the only thing funding Gladys, and it
+                            is powered entirely by its subscribers. No outside
+                            money.
+                          </Translate>
+                        </p>
+                        <div className="row">
+                          <div className="col col--6 text--center">
+                            <div>
+                              <Translate
+                                id="openPage.funding.supporters"
+                                description="Open Page supporters"
+                              >
+                                Gladys Plus supporters
+                              </Translate>
+                            </div>
+                            <h3 style={{ fontSize: "3.5rem", marginBottom: 0 }}>
+                              {numberOfGladysPlusUsers}
+                            </h3>
+                          </div>
+                          <div className="col col--6 text--center">
+                            <div>
+                              <Translate
+                                id="openPage.funding.mrr"
+                                description="Open Page MRR label"
+                              >
+                                Monthly recurring revenue
+                              </Translate>
+                            </div>
+                            <h3 style={{ fontSize: "3.5rem", marginBottom: 0 }}>
+                              {mrr} €
+                            </h3>
+                          </div>
+                        </div>
+                        <p
+                          className="text--center"
+                          style={{ marginTop: "1.5rem", marginBottom: 0 }}
+                        >
+                          <Translate
+                            id="openPage.funding.note"
+                            description="Open Page funding note"
+                            values={{ count: numberOfGladysPlusUsers }}
+                          >
+                            {
+                              "That's it: {count} people keeping an independent, privacy-first project alive. Every subscription funds servers, infrastructure and development, nothing else. No investors to please, no growth at all costs."
+                            }
+                          </Translate>
+                        </p>
                       </div>
                     </div>
                   </div>

--- a/src/pages/open.js
+++ b/src/pages/open.js
@@ -65,6 +65,29 @@ async function getUsage() {
   };
 }
 
+// Returns a straight line (one value per point) fitted to the data with a
+// least-squares linear regression. Overlaying it on the instance chart shows
+// the long-term direction, so a one-off spike (the viral Feb 2026 video) and
+// the churn that follows it don't read as the project declining.
+function computeTrendLine(points) {
+  const n = points.length;
+  const ys = points.map((p) => Number(p));
+  if (n < 2) {
+    return ys;
+  }
+  const meanX = (n - 1) / 2;
+  const meanY = ys.reduce((sum, y) => sum + y, 0) / n;
+  let sxy = 0;
+  let sxx = 0;
+  for (let i = 0; i < n; i += 1) {
+    sxy += (i - meanX) * (ys[i] - meanY);
+    sxx += (i - meanX) ** 2;
+  }
+  const slope = sxx === 0 ? 0 : sxy / sxx;
+  const intercept = meanY - slope * meanX;
+  return ys.map((_, i) => Math.round(intercept + slope * i));
+}
+
 function Open() {
   const context = useDocusaurusContext();
   const [usageChartCanva, setUsageChartCanva] = useState(null);
@@ -112,9 +135,26 @@ function Open() {
         labels: usageChartData.labels,
         datasets: [
           {
-            label: "Number of Gladys instances",
+            label: translate({
+              id: "openPage.chart.activeInstances",
+              description: "Instance chart active instances series label",
+              message: "Active instances",
+            }),
             borderColor: "#74b9ff",
             data: usageChartData.points,
+            fill: false,
+          },
+          {
+            label: translate({
+              id: "openPage.chart.trend",
+              description: "Instance chart trend line label",
+              message: "Long-term trend",
+            }),
+            borderColor: "#00b894",
+            borderDash: [6, 6],
+            borderWidth: 2,
+            pointRadius: 0,
+            data: computeTrendLine(usageChartData.points),
             fill: false,
           },
         ],
@@ -384,6 +424,21 @@ function Open() {
                         <div style={{ height: "400px" }}>
                           <canvas ref={usageChartRef}></canvas>
                         </div>
+                        <p
+                          className="text--center text--secondary"
+                          style={{ marginTop: "1rem", marginBottom: 0 }}
+                        >
+                          <Translate
+                            id="openPage.chart.spikeNote"
+                            description="Open page instance chart spike explanation"
+                          >
+                            The February 2026 peak came from a viral "Home
+                            Assistant vs Gladys" video that brought a wave of
+                            curious users. The base that stayed is still well
+                            above where we started, and the long-term trend
+                            keeps pointing up.
+                          </Translate>
+                        </p>
                       </div>
                     </div>
                   </div>

--- a/src/pages/open.js
+++ b/src/pages/open.js
@@ -28,11 +28,12 @@ async function getUsage() {
   const labels = [];
   const points = [];
 
-  data.gladys_4_instances.forEach((elem, index) => {
-    if (index < data.gladys_4_instances.length - 1) {
-      labels.push(elem.month);
-      points.push(elem.nb_instances);
-    }
+  // Keep every month, including the current (still-running) one. The last
+  // point is flagged as "in progress" in the chart instead of being dropped,
+  // so the most recent recovery stays visible.
+  data.gladys_4_instances.forEach((elem) => {
+    labels.push(elem.month);
+    points.push(elem.nb_instances);
   });
 
   const forumPageViewsLabels = [];
@@ -63,6 +64,16 @@ async function getUsage() {
     nb_gladys_plus_users: data.nb_gladys_plus_users,
     chartmogul_data: data.chartmogul_data,
   };
+}
+
+// "2026-06" -> "Jun 2026" (localized short month + year).
+function formatMonthLabel(month, locale) {
+  const [year, monthIndex] = month.split("-").map(Number);
+  const date = new Date(year, monthIndex - 1, 1);
+  return date.toLocaleDateString(locale === "fr" ? "fr-FR" : "en-US", {
+    month: "short",
+    year: "numeric",
+  });
 }
 
 // Returns a straight line (one value per point) fitted to the data with a
@@ -96,7 +107,6 @@ function Open() {
   const [usageChartData, setUsageChartData] = useState(null);
   const { i18n } = context;
   const language = i18n.currentLocale;
-  const urlPrefix = language === "fr" ? "/fr" : "";
 
   const numberOfInstances = usageChartData
     ? usageChartData.points[usageChartData.points.length - 1]
@@ -115,6 +125,10 @@ function Open() {
         ?.count
     : null;
 
+  // Gladys has been developed in the open since 2013. Compute the count of
+  // years live so the longevity stat never goes stale.
+  const yearsInTheOpen = new Date().getFullYear() - 2013;
+
   async function fetchData() {
     const data = await getUsage();
     setUsageChartData(data);
@@ -129,10 +143,25 @@ function Open() {
     if (!usageChartData) {
       return;
     }
+    const lastIndex = usageChartData.points.length - 1;
+    const currentTag = translate({
+      id: "openPage.chart.currentMonthShort",
+      description: "Instance chart current month short tag",
+      message: "current",
+    });
+    const currentMonthTooltip = translate({
+      id: "openPage.chart.currentMonthTooltip",
+      description: "Instance chart current month tooltip",
+      message: "Current month, still in progress",
+    });
+    const displayLabels = usageChartData.labels.map((month, index) => {
+      const base = formatMonthLabel(month, language);
+      return index === lastIndex ? `${base} (${currentTag})` : base;
+    });
     const config = {
       type: "line",
       data: {
-        labels: usageChartData.labels,
+        labels: displayLabels,
         datasets: [
           {
             label: translate({
@@ -141,8 +170,21 @@ function Open() {
               message: "Active instances",
             }),
             borderColor: "#74b9ff",
+            backgroundColor: "#74b9ff",
             data: usageChartData.points,
             fill: false,
+            tension: 0.3,
+            // Dash the very last segment and highlight the last point so the
+            // still-running current month reads as provisional, not final.
+            segment: {
+              borderDash: (ctx) =>
+                ctx.p1DataIndex === lastIndex ? [6, 6] : undefined,
+            },
+            pointRadius: (ctx) => (ctx.dataIndex === lastIndex ? 6 : 3),
+            pointBackgroundColor: (ctx) =>
+              ctx.dataIndex === lastIndex ? "#e17055" : "#74b9ff",
+            pointBorderColor: (ctx) =>
+              ctx.dataIndex === lastIndex ? "#e17055" : "#74b9ff",
           },
           {
             label: translate({
@@ -169,6 +211,12 @@ function Open() {
         plugins: {
           tooltip: {
             position: "nearest",
+            callbacks: {
+              afterLabel: (ctx) =>
+                ctx.dataIndex === lastIndex && ctx.datasetIndex === 0
+                  ? currentMonthTooltip
+                  : undefined,
+            },
           },
         },
         indexAxis: "x",
@@ -179,7 +227,11 @@ function Open() {
           y: {
             title: {
               display: true,
-              text: "Number of instances",
+              text: translate({
+                id: "openPage.chart.yAxis",
+                description: "Instance chart y axis title",
+                message: "Number of instances",
+              }),
             },
             beginAtZero: true,
           },
@@ -256,81 +308,77 @@ function Open() {
       <main>
         <div style={{ paddingTop: "2rem", paddingBottom: "2rem" }}>
           <div className="container">
-            <div className="row">
-              <div className="col col--12">
-                <h1
-                  className="text--center"
-                  style={{
-                    fontSize: "50px",
-                  }}
+            <div className={styles.openHero}>
+              <span className={styles.openEyebrow}>
+                <span className={styles.liveDot} aria-hidden="true"></span>
+                <Translate
+                  id="openPage.eyebrow"
+                  description="Open page live eyebrow"
                 >
+                  Live numbers, updated automatically
+                </Translate>
+              </span>
+              <h1 className={styles.openTitle}>
+                <Translate id="openPage.h1" description="Gladys open page H1">
+                  Everything about Gladys, in the open
+                </Translate>
+              </h1>
+              <p className={styles.openLead}>
+                <Translate
+                  id="openPage.description"
+                  description="Open page description"
+                >
+                  No investors, no ads, no data resale. Gladys has been built in
+                  the open since 2013 and runs entirely on your own hardware.
+                  These are the real numbers behind the project, live.
+                </Translate>
+              </p>
+            </div>
+            <div className={styles.lockinCallout}>
+              <div className={styles.lockinIcon} aria-hidden="true">
+                🔒
+              </div>
+              <div>
+                <h2 className={styles.lockinTitle}>
                   <Translate
-                    id="openPage.title"
-                    description="Gladys open page title"
+                    id="openPage.lockin.title"
+                    description="Open page no lock-in title"
                   >
-                    Open metrics
+                    Your home never depends on us
                   </Translate>
-                </h1>
-                <p className="text--center">
+                </h2>
+                <p className={styles.lockinBody}>
                   <Translate
-                    id="openPage.description"
-                    description="Open page description"
+                    id="openPage.lockin.body"
+                    description="Open page no lock-in body"
                   >
-                    Gladys Assistant is radically transparent. Here are our real
-                    numbers, live: how many homes run Gladys, our community, and
-                    how the project is funded. No investors, no ads, no data
-                    resale, just a project funded by the people who use it.
+                    Gladys is open-source (Apache 2.0) and runs 100% locally on
+                    your own hardware. If Gladys Plus disappeared tomorrow, your
+                    automations would keep running and your data would stay in
+                    your home. Gladys Plus is a convenience, never a lock-in, and
+                    that is exactly why we can afford to be this transparent.
                   </Translate>
                 </p>
               </div>
             </div>
-            <div className={"row " + styles.openPageChartRow}>
-              <div className="col col--12">
-                <div className="alert alert--info" role="note">
-                  <h2 style={{ marginTop: 0 }}>
-                    <Translate
-                      id="openPage.lockin.title"
-                      description="Open page no lock-in title"
-                    >
-                      Your home never depends on us
-                    </Translate>
-                  </h2>
-                  <p style={{ marginBottom: 0 }}>
-                    <Translate
-                      id="openPage.lockin.body"
-                      description="Open page no lock-in body"
-                    >
-                      Gladys is open-source (Apache 2.0) and runs 100% locally on
-                      your own hardware. Even if Gladys Plus disappeared
-                      tomorrow, your automations keep running and your data stays
-                      in your home. Gladys Plus is a convenience, never a
-                      lock-in, and that is exactly why we can afford to be this
-                      transparent.
-                    </Translate>
-                  </p>
-                </div>
-              </div>
-            </div>
             {loading && (
               <div className={styles.loadingContainer}>
-                <div className="row">
-                  <div className="col col--4">
-                    <div className={styles.skeletonCard}>
-                      <div className={styles.skeletonTitle}></div>
-                      <div className={styles.skeletonNumber}></div>
-                    </div>
+                <div className={styles.metricsGrid}>
+                  <div className={styles.skeletonCard}>
+                    <div className={styles.skeletonTitle}></div>
+                    <div className={styles.skeletonNumber}></div>
                   </div>
-                  <div className="col col--4">
-                    <div className={styles.skeletonCard}>
-                      <div className={styles.skeletonTitle}></div>
-                      <div className={styles.skeletonNumber}></div>
-                    </div>
+                  <div className={styles.skeletonCard}>
+                    <div className={styles.skeletonTitle}></div>
+                    <div className={styles.skeletonNumber}></div>
                   </div>
-                  <div className="col col--4">
-                    <div className={styles.skeletonCard}>
-                      <div className={styles.skeletonTitle}></div>
-                      <div className={styles.skeletonNumber}></div>
-                    </div>
+                  <div className={styles.skeletonCard}>
+                    <div className={styles.skeletonTitle}></div>
+                    <div className={styles.skeletonNumber}></div>
+                  </div>
+                  <div className={styles.skeletonCard}>
+                    <div className={styles.skeletonTitle}></div>
+                    <div className={styles.skeletonNumber}></div>
                   </div>
                 </div>
                 <div className={styles.skeletonChart}></div>
@@ -339,321 +387,245 @@ function Open() {
             )}
             {loading === false && (
               <div>
-                <div className="row">
-                  <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card">
-                      <div className="card__body">
-                        <div className="text--center">
-                          <Translate
-                            id="openPage.homeRunningGladys"
-                            description="Open Page home running Gladys"
-                          >
-                            Homes running Gladys
-                          </Translate>
-                        </div>
-                        <h3
-                          className="text--center"
-                          style={{ fontSize: "4rem" }}
-                        >
-                          {numberOfInstances}
-                        </h3>
-                      </div>
+                <div className={styles.metricsGrid}>
+                  <div className={styles.metricCard}>
+                    <div className={styles.metricIcon} aria-hidden="true">
+                      🏠
+                    </div>
+                    <div className={styles.metricValue}>{numberOfInstances}</div>
+                    <div className={styles.metricLabel}>
+                      <Translate
+                        id="openPage.homeRunningGladys"
+                        description="Open Page home running Gladys"
+                      >
+                        Homes running Gladys
+                      </Translate>
+                    </div>
+                    <div className={styles.metricSub}>
+                      <Translate
+                        id="openPage.metric.homesSub"
+                        description="Open page homes metric subtitle"
+                      >
+                        Live, self-reported
+                      </Translate>
                     </div>
                   </div>
-                  <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card">
-                      <div className="card__body">
-                        <div className="text--center">
-                          <Translate
-                            id="openPage.communityMembers"
-                            description="Open Page community members"
-                          >
-                            Community members
-                          </Translate>
-                        </div>
-                        <h3
-                          className="text--center"
-                          style={{ fontSize: "4rem" }}
-                        >
-                          {communityMembers}
-                        </h3>
-                      </div>
+                  <div className={styles.metricCard}>
+                    <div className={styles.metricIcon} aria-hidden="true">
+                      💬
+                    </div>
+                    <div className={styles.metricValue}>{communityMembers}</div>
+                    <div className={styles.metricLabel}>
+                      <Translate
+                        id="openPage.communityMembers"
+                        description="Open Page community members"
+                      >
+                        Community members
+                      </Translate>
+                    </div>
+                    <div className={styles.metricSub}>
+                      <Translate
+                        id="openPage.metric.communitySub"
+                        description="Open page community metric subtitle"
+                      >
+                        On the forum and beyond
+                      </Translate>
                     </div>
                   </div>
-                  <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card">
-                      <div className="card__body">
-                        <div className="text--center">
-                          <Translate
-                            id="openPage.onlineSince"
-                            description="Open Page online since"
-                          >
-                            Online since
-                          </Translate>
-                        </div>
-                        <h3
-                          className="text--center"
-                          style={{ fontSize: "4rem" }}
-                        >
-                          2019
-                        </h3>
-                        <div className="text--center text--secondary">
-                          <Translate
-                            id="openPage.onlineSinceSubtitle"
-                            description="Open Page online since subtitle"
-                          >
-                            with near-zero downtime
-                          </Translate>
-                        </div>
-                      </div>
+                  <div className={styles.metricCard}>
+                    <div className={styles.metricIcon} aria-hidden="true">
+                      🌱
+                    </div>
+                    <div className={styles.metricValue}>{yearsInTheOpen}</div>
+                    <div className={styles.metricLabel}>
+                      <Translate
+                        id="openPage.metric.yearsLabel"
+                        description="Open page years metric label"
+                      >
+                        Years in the open
+                      </Translate>
+                    </div>
+                    <div className={styles.metricSub}>
+                      <Translate
+                        id="openPage.metric.yearsSub"
+                        description="Open page years metric subtitle"
+                      >
+                        Since 2013, still independent
+                      </Translate>
                     </div>
                   </div>
-                </div>
-                <div className={"row " + styles.openPageChartRow}>
-                  <div className={"col col--12 " + styles.openPageCard}>
-                    <div className="card">
-                      <div className="card__body">
-                        <h2 className="text--center">
-                          <Translate
-                            id="openPage.numberOfHomeRunningGladys"
-                            description="Chart title"
-                          >
-                            Number of home running Gladys
-                          </Translate>
-                        </h2>
-                        <div style={{ height: "400px" }}>
-                          <canvas ref={usageChartRef}></canvas>
-                        </div>
-                        <p
-                          className="text--center text--secondary"
-                          style={{ marginTop: "1rem", marginBottom: 0 }}
-                        >
-                          <Translate
-                            id="openPage.chart.spikeNote"
-                            description="Open page instance chart spike explanation"
-                          >
-                            The February 2026 peak came from a viral "Home
-                            Assistant vs Gladys" video that brought a wave of
-                            curious users. The base that stayed is still well
-                            above where we started, and the long-term trend
-                            keeps pointing up.
-                          </Translate>
-                        </p>
-                      </div>
+                  <div className={styles.metricCard}>
+                    <div className={styles.metricIcon} aria-hidden="true">
+                      ❤️
+                    </div>
+                    <div className={styles.metricValue}>
+                      {numberOfGladysPlusUsers}
+                    </div>
+                    <div className={styles.metricLabel}>
+                      <Translate
+                        id="openPage.funding.supporters"
+                        description="Open Page supporters"
+                      >
+                        Gladys Plus supporters
+                      </Translate>
+                    </div>
+                    <div className={styles.metricSub}>
+                      <Translate
+                        id="openPage.metric.supportersSub"
+                        description="Open page supporters metric subtitle"
+                      >
+                        Funding the whole project
+                      </Translate>
                     </div>
                   </div>
                 </div>
-                <div className={"row " + styles.openPageChartRow}>
-                  <div className={"col col--12 " + styles.openPageCard}>
-                    <div className="card">
-                      <div className="card__body">
-                        <h2 className="text--center">
-                          <Translate
-                            id="openPage.funding.title"
-                            description="Open Page funding title"
-                          >
-                            How the project is funded
-                          </Translate>
-                        </h2>
-                        <p className="text--center">
-                          <Translate
-                            id="openPage.funding.intro"
-                            description="Open Page funding intro"
-                          >
-                            Gladys Plus is the only thing funding Gladys, and it
-                            is powered entirely by its subscribers. No outside
-                            money.
-                          </Translate>
-                        </p>
-                        <div className="row">
-                          <div className="col col--6 text--center">
-                            <div>
-                              <Translate
-                                id="openPage.funding.supporters"
-                                description="Open Page supporters"
-                              >
-                                Gladys Plus supporters
-                              </Translate>
-                            </div>
-                            <h3 style={{ fontSize: "3.5rem", marginBottom: 0 }}>
-                              {numberOfGladysPlusUsers}
-                            </h3>
-                          </div>
-                          <div className="col col--6 text--center">
-                            <div>
-                              <Translate
-                                id="openPage.funding.mrr"
-                                description="Open Page MRR label"
-                              >
-                                Monthly recurring revenue
-                              </Translate>
-                            </div>
-                            <h3 style={{ fontSize: "3.5rem", marginBottom: 0 }}>
-                              {mrr} €
-                            </h3>
-                          </div>
+                <section className={styles.openSection}>
+                  <div className={styles.openPanel}>
+                    <h2 className={styles.openPanelTitle}>
+                      <Translate
+                        id="openPage.numberOfHomeRunningGladys"
+                        description="Chart title"
+                      >
+                        Homes running Gladys over time
+                      </Translate>
+                    </h2>
+                    <div style={{ height: "400px" }}>
+                      <canvas ref={usageChartRef}></canvas>
+                    </div>
+                    <p className={styles.chartCaption}>
+                      <Translate
+                        id="openPage.chart.spikeNote"
+                        description="Open page instance chart spike explanation"
+                      >
+                        The February 2026 peak came from a viral "Home Assistant
+                        vs Gladys" video that brought a wave of curious users.
+                        The base that stayed is still well above where we
+                        started, and the long-term trend keeps pointing up. The
+                        last, dotted point is the current month, still in
+                        progress.
+                      </Translate>
+                    </p>
+                  </div>
+                </section>
+                <section className={styles.openSection}>
+                  <div className={styles.fundingPanel}>
+                    <h2 className={styles.openPanelTitle}>
+                      <Translate
+                        id="openPage.funding.title"
+                        description="Open Page funding title"
+                      >
+                        How the project is funded
+                      </Translate>
+                    </h2>
+                    <p className={styles.openPanelIntro}>
+                      <Translate
+                        id="openPage.funding.intro"
+                        description="Open Page funding intro"
+                      >
+                        Gladys Plus is the only thing funding Gladys, and it runs
+                        entirely on its subscribers. No outside money, no strings
+                        attached.
+                      </Translate>
+                    </p>
+                    <div className={styles.fundingStats}>
+                      <div className={styles.fundingStat}>
+                        <div className={styles.fundingStatValue}>
+                          {numberOfGladysPlusUsers}
                         </div>
-                        <p
-                          className="text--center"
-                          style={{ marginTop: "1.5rem", marginBottom: 0 }}
-                        >
+                        <div className={styles.fundingStatLabel}>
                           <Translate
-                            id="openPage.funding.note"
-                            description="Open Page funding note"
-                            values={{ count: numberOfGladysPlusUsers }}
+                            id="openPage.funding.supporters"
+                            description="Open Page supporters"
                           >
-                            {
-                              "That's it: {count} people keeping an independent, privacy-first project alive. Every subscription funds servers, infrastructure and development, nothing else. No investors to please, no growth at all costs."
-                            }
+                            Gladys Plus supporters
                           </Translate>
-                        </p>
+                        </div>
+                      </div>
+                      <div className={styles.fundingStat}>
+                        <div className={styles.fundingStatValue}>{mrr} €</div>
+                        <div className={styles.fundingStatLabel}>
+                          <Translate
+                            id="openPage.funding.mrr"
+                            description="Open Page MRR label"
+                          >
+                            Monthly recurring revenue
+                          </Translate>
+                        </div>
                       </div>
                     </div>
+                    <p className={styles.fundingNote}>
+                      <Translate
+                        id="openPage.funding.note"
+                        description="Open Page funding note"
+                        values={{ count: numberOfGladysPlusUsers }}
+                      >
+                        {
+                          "That's it: {count} people keeping an independent, privacy-first project alive. Every subscription funds servers, infrastructure and development, nothing else. No investors to please, no growth at all costs."
+                        }
+                      </Translate>
+                    </p>
                   </div>
-                </div>
-                <div className={"row " + styles.openPageChartRow}>
-                  <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card">
-                      <div className="card__body">
-                        <h2 className="text--center">
-                          <Translate
-                            id="openPage.lastYearReviews"
-                            description="Last year reviews"
-                          >
-                            Project history
-                          </Translate>
-                        </h2>
-                        <ul>
-                          <li className={styles.openPageList}>
-                            <a href={`${urlPrefix}/blog`}>
-                              <Translate
-                                id="openPage.latestReleases"
-                                description="Open page latest releases link"
-                              >
-                                Latest news & releases →
-                              </Translate>
-                            </a>
-                          </li>
-                          <li className={styles.openPageList}>
-                            <a href={`${urlPrefix}/blog/2024-year-in-review`}>
-                              <Translate
-                                id="openPage.yearlyReview"
-                                description="Yearly reviews"
-                                values={{ year: 2024 }}
-                              >
-                                {"{year} yearly review"}
-                              </Translate>
-                            </a>
-                          </li>
-                          <li className={styles.openPageList}>
-                            <a href={`${urlPrefix}/blog/2023-year-in-review`}>
-                              <Translate
-                                id="openPage.yearlyReview"
-                                description="Yearly reviews"
-                                values={{ year: 2023 }}
-                              >
-                                {"{year} yearly review"}
-                              </Translate>
-                            </a>
-                          </li>
-                          <li className={styles.openPageList}>
-                            <a href={`${urlPrefix}/blog/2022-year-in-review`}>
-                              <Translate
-                                id="openPage.yearlyReview"
-                                description="Yearly reviews"
-                                values={{ year: 2022 }}
-                              >
-                                {"{year} yearly review"}
-                              </Translate>
-                            </a>
-                          </li>
-                          <li className={styles.openPageList}>
-                            <a href={`${urlPrefix}/blog/2021-year-in-review`}>
-                              <Translate
-                                id="openPage.yearlyReview"
-                                description="Yearly reviews"
-                                values={{ year: 2021 }}
-                              >
-                                {"{year} yearly review"}
-                              </Translate>
-                            </a>
-                          </li>
-                          <li className={styles.openPageList}>
-                            <a
-                              href={`${urlPrefix}/blog/bilan-2020-gladys-assistant`}
+                </section>
+                <section className={styles.openSection}>
+                  <h2 className={styles.openSectionHeading}>
+                    <Translate
+                      id="openPage.community.title"
+                      description="Open page community section title"
+                    >
+                      A living community
+                    </Translate>
+                  </h2>
+                  <div className={styles.communityGrid}>
+                    <div className={styles.openPanel}>
+                      <h3 className={styles.openPanelSubtitle}>
+                        <Translate
+                          id="openPage.nbOfForumUsers"
+                          description="Gladys open page number of forum users"
+                        >
+                          Forum members
+                        </Translate>
+                      </h3>
+                      <div className={styles.forumUserList}>
+                        {usageChartData &&
+                          usageChartData.forum_users &&
+                          usageChartData.forum_users.map((user) => (
+                            <div
+                              className={styles.forumUserRow}
+                              key={user.user_type}
                             >
-                              <Translate
-                                id="openPage.yearlyReview"
-                                description="Yearly reviews"
-                                values={{ year: 2020 }}
-                              >
-                                {"{year} yearly review"}
-                              </Translate>
-                            </a>
-                          </li>
-                        </ul>
+                              <span className={styles.forumUserType}>
+                                {user.user_type}
+                              </span>
+                              <span className={styles.forumUserCount}>
+                                {user.count}
+                              </span>
+                            </div>
+                          ))}
                       </div>
                     </div>
-                  </div>
-                  <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card">
-                      <div className="card__body">
-                        <h2 className="text--center">
-                          <Translate
-                            id="openPage.nbOfForumUsers"
-                            description="Gladys open page number of forum users"
-                          >
-                            No. of forum users
-                          </Translate>
-                        </h2>
-                        <ul>
-                          {usageChartData &&
-                            usageChartData.forum_users &&
-                            usageChartData.forum_users.map((user) => (
-                              <li className={styles.openPageList}>
-                                <b>{user.user_type}:</b> {user.count}
-                              </li>
-                            ))}
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-                  <div className={"col col--4 " + styles.openPageCard}>
-                    <div className="card">
-                      <div className="card__header">
-                        <h2
-                          className="text--center"
-                          style={{ marginBottom: 0 }}
+                    <div className={styles.openPanel}>
+                      <h3 className={styles.openPanelSubtitle}>
+                        <Translate
+                          id="openPage.forumPageViews"
+                          description="Gladys open forum page views"
                         >
-                          <Translate
-                            id="openPage.forumPageViews"
-                            description="Gladys open forum page views"
-                          >
-                            Forum page views
-                          </Translate>
-                        </h2>
-                        <div className="text--center">
-                          <Translate
-                            id="openPage.lastWeek"
-                            description="Gladys Open page last week"
-                          >
-                            (Last week)
-                          </Translate>
-                        </div>
-                      </div>
-                      <div className="card__body">
-                        <div
-                          style={{
-                            height: "150px",
-                            width: "100%",
-                          }}
+                          Forum page views
+                        </Translate>
+                      </h3>
+                      <div className={styles.openPanelHint}>
+                        <Translate
+                          id="openPage.lastWeek"
+                          description="Gladys Open page last week"
                         >
-                          <canvas ref={forumChartRef}></canvas>
-                        </div>
+                          (Last week)
+                        </Translate>
+                      </div>
+                      <div style={{ height: "200px", width: "100%" }}>
+                        <canvas ref={forumChartRef}></canvas>
                       </div>
                     </div>
                   </div>
-                </div>
+                </section>
               </div>
             )}
           </div>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -46,6 +46,15 @@
   margin-top: 32px;
 }
 
+/* Make every card stretch to the full height of its column so cards sitting
+   side by side in a row always line up, regardless of content length. */
+.openPageCard {
+  display: flex;
+}
+.openPageCard > .card {
+  width: 100%;
+}
+
 @media screen and (max-width: 996px) {
   .openPageCard {
     margin-bottom: 16px;

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -366,3 +366,330 @@ Black friday
   font-weight: bolder;
   font-size: 25px;
 }
+
+/* =========================================================================
+   /open page redesign
+   ========================================================================= */
+
+.openHero {
+  text-align: center;
+  padding: 3rem 0 1.5rem;
+}
+
+.openEyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ifm-color-primary);
+  background: var(--ifm-color-primary-lightest);
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+}
+
+[data-theme="dark"] .openEyebrow {
+  background: rgba(116, 185, 255, 0.12);
+}
+
+.liveDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #2ecc71;
+  box-shadow: 0 0 0 0 rgba(46, 204, 113, 0.55);
+  animation: liveDotPulse 2s infinite;
+}
+
+@keyframes liveDotPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(46, 204, 113, 0.55);
+  }
+  70% {
+    box-shadow: 0 0 0 8px rgba(46, 204, 113, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(46, 204, 113, 0);
+  }
+}
+
+.openTitle {
+  font-size: 3rem;
+  font-weight: 800;
+  line-height: 1.1;
+  margin: 1.25rem 0 0.85rem;
+}
+
+.openLead {
+  font-size: 1.2rem;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+@media screen and (max-width: 768px) {
+  .openTitle {
+    font-size: 2.1rem;
+  }
+  .openLead {
+    font-size: 1.05rem;
+  }
+}
+
+/* Metric cards ---------------------------------------------------------- */
+
+.metricsGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+@media screen and (max-width: 996px) {
+  .metricsGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .metricsGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.metricCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  text-align: center;
+  padding: 1.75rem 1.25rem;
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 16px;
+  box-shadow: var(--ifm-global-shadow-lw);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.metricCard:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--ifm-global-shadow-md);
+}
+
+.metricIcon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.metricValue {
+  font-size: 2.75rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--ifm-color-primary);
+}
+
+.metricLabel {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.metricSub {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* Lock-in callout ------------------------------------------------------- */
+
+.lockinCallout {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-start;
+  margin-top: 2.5rem;
+  padding: 1.75rem 2rem;
+  border-radius: 16px;
+  border: 1px solid var(--ifm-color-primary-lighter);
+  background: linear-gradient(
+    135deg,
+    var(--ifm-color-primary-lightest),
+    transparent 70%
+  );
+}
+
+[data-theme="dark"] .lockinCallout {
+  background: linear-gradient(
+    135deg,
+    rgba(116, 185, 255, 0.1),
+    transparent 70%
+  );
+  border-color: rgba(116, 185, 255, 0.25);
+}
+
+.lockinIcon {
+  font-size: 2rem;
+  line-height: 1.2;
+}
+
+.lockinTitle {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+.lockinBody {
+  margin: 0;
+  color: var(--ifm-color-emphasis-800);
+  line-height: 1.6;
+}
+
+@media screen and (max-width: 768px) {
+  .lockinCallout {
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.5rem;
+  }
+}
+
+/* Sections & panels ----------------------------------------------------- */
+
+.openSection {
+  margin-top: 3rem;
+}
+
+.openSectionHeading {
+  text-align: center;
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+.openPanel {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 16px;
+  padding: 2rem;
+  box-shadow: var(--ifm-global-shadow-lw);
+}
+
+.openPanelTitle {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+}
+
+.openPanelSubtitle {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0 0 0.25rem;
+}
+
+.openPanelIntro {
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.openPanelHint {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.75rem;
+}
+
+.chartCaption {
+  margin: 1.25rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--ifm-color-emphasis-600);
+}
+
+/* Funding panel --------------------------------------------------------- */
+
+.fundingPanel {
+  border-radius: 16px;
+  padding: 2rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: linear-gradient(
+    135deg,
+    rgba(116, 185, 255, 0.08),
+    rgba(0, 184, 148, 0.08)
+  );
+}
+
+.fundingStats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 1.5rem 0;
+}
+
+.fundingStat {
+  flex: 1 1 200px;
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.fundingStatValue {
+  font-size: 2.5rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--ifm-color-primary);
+}
+
+.fundingStatLabel {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.fundingNote {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto;
+  line-height: 1.6;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* Community grid -------------------------------------------------------- */
+
+.communityGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media screen and (max-width: 996px) {
+  .communityGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.forumUserList {
+  margin-top: 0.5rem;
+}
+
+.forumUserRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.forumUserRow:last-child {
+  border-bottom: none;
+}
+
+.forumUserType {
+  text-transform: capitalize;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.forumUserCount {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
Lead with usage and community (homes running Gladys, community members, online since 2019) plus a prominent local-first / no lock-in reassurance; demote MRR into a framed 'how the project is funded' section so the number signals an honest indie project instead of a small one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Open page with refreshed French copy and clearer project messaging.
  * Added new project stats and funding highlights, including community members, online since, and funding details.
  * Added a new link to the latest releases and project updates.

* **Bug Fixes**
  * Improved layout behavior for Open page cards so they stretch more consistently across the page.
  * Removed fixed-height constraints that could cause uneven card sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->