### PR TITLE
SEO/GEO: Hue/Reolink docs, IKEA & weather station landings, DIY alarm vs monitored alarms

### DIFF
--- a/docs/integrations/camera.md
+++ b/docs/integrations/camera.md
@@ -1,11 +1,19 @@
 ---
 id: camera
-title: Camera
-description: "Add IP cameras to Gladys Assistant using their RTSP or HTTP stream and view them live on your dashboard."
+title: "IP camera integration: add any RTSP or HTTP camera to Gladys"
+description: "Add IP cameras to Gladys Assistant using their RTSP or HTTP stream and view them live on your dashboard. Works with any camera brand, locally and without the cloud."
 sidebar_label: Camera
+keywords:
+  - rtsp camera
+  - ip camera home automation
+  - camera integration
+  - rtsp stream url
+  - http camera stream
 ---
 
-Gladys supports cameras that expose a RTSP or HTTP stream.
+import JsonLd from '@site/src/components/seo/JsonLd';
+
+Gladys supports cameras that expose a RTSP or HTTP stream. Because Gladys connects to the camera directly on your local network, your video feed stays at home and never transits through a manufacturer's cloud.
 
 You'll first need to find RTSP/HTTP URL of the stream. 
 
@@ -34,6 +42,10 @@ For example, this is for a Xiaomi camera:
 ![RTSP camera URL generator iSpyConnect](../../static/img/docs/en/configuration/camera/camera-ispy.jpg)
 
 If you don't find the iformation you are looking for on this website, I suggest you to Google "your camera name + RTSP". This should bring up search results that you can use to see if there is an open stream available.
+
+:::tip
+Using a Reolink camera? We have a dedicated guide with the exact RTSP URL format for Reolink: [Reolink camera in Gladys](/docs/integrations/reolink).
+:::
 
 ## Trying to display the stream in VLC
 
@@ -102,3 +114,62 @@ And... magic!
 ![Ask for a camera image in Gladys Assistant](../../static/img/docs/en/configuration/camera/chat-camera-en.jpg)
 
 It should work in Telegram as well, if you have configured Telegram in Gladys.
+
+## Frequently asked questions
+
+### How do I find the RTSP URL of my camera?
+
+Check your camera's user manual or the manufacturer's website first, as the path differs between brands. If you can't find it, the [iSpyConnect camera database](https://www.ispyconnect.com/sources.aspx) lists connection details and even generates URLs for most models, or you can search "your camera model + RTSP" online. For Reolink cameras, see our [dedicated Reolink guide](/docs/integrations/reolink).
+
+### Which cameras work with Gladys?
+
+Any IP camera that exposes a standard RTSP or HTTP stream works with Gladys, regardless of the brand. USB webcams are also supported. If your camera only works through a closed manufacturer app or cloud, it will not be compatible.
+
+### Does Gladys send my camera feed to the cloud?
+
+No. Gladys connects to your camera directly on your local network using its RTSP or HTTP stream, so the video stays inside your home. This is a core part of Gladys being a local and open source home automation solution.
+
+### The stream won't connect, what should I check?
+
+First confirm the URL works in [VLC](https://www.videolan.org/vlc/). If VLC can't open it either, check that the machine running Gladys is on the same network as the camera, that the credentials are correct, and that RTSP is enabled in the camera's settings.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "How do I find the RTSP URL of my camera?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Check your camera's user manual or the manufacturer's website first, as the path differs between brands. If you can't find it, the iSpyConnect camera database lists connection details and even generates URLs for most models, or you can search for your camera model plus RTSP online.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Which cameras work with Gladys?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Any IP camera that exposes a standard RTSP or HTTP stream works with Gladys, regardless of the brand. USB webcams are also supported. If your camera only works through a closed manufacturer app or cloud, it will not be compatible.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Does Gladys send my camera feed to the cloud?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "No. Gladys connects to your camera directly on your local network using its RTSP or HTTP stream, so the video stays inside your home. This is a core part of Gladys being a local and open source home automation solution.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "The camera stream won't connect, what should I check?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "First confirm the URL works in VLC. If VLC can't open it either, check that the machine running Gladys is on the same network as the camera, that the credentials are correct, and that RTSP is enabled in the camera's settings.",
+        },
+      },
+    ],
+  }}
+/>

--- a/docs/integrations/camera.md
+++ b/docs/integrations/camera.md
@@ -33,7 +33,7 @@ Here is an example of an HTTP URL:
 http://user:password@192.168.1.20/video?profile=0
 ```
 
-If you can't find this information on your camera manual, try using this website: [https://www.ispyconnect.com/sources.aspx](https://www.ispyconnect.com/sources.aspx) (this is a database of cameras with their relevant connection information).
+If you can't find this information on your camera manual, try using this website: [https://www.ispyconnect.com/cameras](https://www.ispyconnect.com/cameras) (this is a database of cameras with their relevant connection information).
 
 There is a even a built-in URL generator.
 
@@ -119,7 +119,7 @@ It should work in Telegram as well, if you have configured Telegram in Gladys.
 
 ### How do I find the RTSP URL of my camera?
 
-Check your camera's user manual or the manufacturer's website first, as the path differs between brands. If you can't find it, the [iSpyConnect camera database](https://www.ispyconnect.com/sources.aspx) lists connection details and even generates URLs for most models, or you can search "your camera model + RTSP" online. For Reolink cameras, see our [dedicated Reolink guide](/docs/integrations/reolink).
+Check your camera's user manual or the manufacturer's website first, as the path differs between brands. If you can't find it, the [iSpyConnect camera database](https://www.ispyconnect.com/cameras) lists connection details and even generates URLs for most models, or you can search "your camera model + RTSP" online. For Reolink cameras, see our [dedicated Reolink guide](/docs/integrations/reolink).
 
 ### Which cameras work with Gladys?
 

--- a/docs/integrations/philips-hue.md
+++ b/docs/integrations/philips-hue.md
@@ -1,9 +1,31 @@
 ---
 id: philips-hue
-title: Philips Hue
-description: "Connect your Philips Hue bridge and lights to Gladys Assistant to control them locally from your dashboard and scenes."
+title: "Philips Hue integration: control your lights locally with Gladys"
+description: "Connect your Philips Hue bridge and lights to Gladys Assistant. Control them locally, without the cloud, and trigger them from your dashboard, scenes and voice assistant."
 sidebar_label: Philips Hue
+keywords:
+  - philips hue integration
+  - philips hue integrations
+  - philips hue local control
+  - philips hue without cloud
+  - connect philips hue
+  - philips hue bridge
+  - philips hue home automation
 ---
+
+import JsonLd from '@site/src/components/seo/JsonLd';
+
+The Philips Hue integration connects your Hue bridge and lights directly to Gladys Assistant. Because Gladys talks to your bridge locally over your own network, your lights keep working even when your internet connection is down, and no data leaves your home.
+
+Once your lights are connected, you can switch them on and off, dim them, change their colour, group them by room, and use them in [scenes](/docs/scenes/intro/): turn the hallway on at sunset, flash the living room when a door opens, or wake up to a gradual sunrise. You can also control them with the [voice assistant](/docs/dashboard/voice-assistant) or from the [mobile app](/docs/installation/phone).
+
+Gladys connects to the bridge, which speaks Zigbee to your bulbs, so any light, plug or accessory paired to your Hue bridge shows up in Gladys. If you would rather not use a bridge at all, you can also pair Hue bulbs directly through the [Zigbee2mqtt integration](/docs/integrations/zigbee2mqtt/).
+
+## What you need
+
+- A **Philips Hue Bridge v2** (the square one). The original round bridge (v1) is not supported.
+- Your Hue bridge connected to the same local network as the machine running Gladys.
+- Your Hue lights already paired to the bridge (for example through the official Hue app).
 
 To connect your Philips Hue to Gladys, go to `Integrations / Philips Hue` (in Gladys).
 
@@ -30,3 +52,75 @@ Make sure you have the Hue Bridge v2 (the square one). The integration will not 
 In `Devices`, click on `Connect` on each lamp you want to control in Gladys.
 
 Success!
+
+## Frequently asked questions
+
+### Does the Philips Hue integration work locally, without the cloud?
+
+Yes. Gladys communicates with your Hue bridge directly over your local network, so your lights can be controlled even without an internet connection and none of your data is sent to a third party server. This is one of the main reasons to use Gladys, a local and open source home automation solution, instead of a cloud only app.
+
+### Do I need a Philips Hue Bridge?
+
+For the official Philips Hue integration, yes: Gladys connects to the Hue Bridge v2, which then controls your bulbs over Zigbee. If you prefer not to buy a bridge, you can instead pair your Hue bulbs directly with a Zigbee dongle through the [Zigbee2mqtt integration](/docs/integrations/zigbee2mqtt/).
+
+### Which Philips Hue Bridge is supported?
+
+You need the Hue Bridge v2, the square shaped model. The original round Hue Bridge (v1) is not supported by the integration.
+
+### Can I use my Philips Hue lights in scenes?
+
+Yes. Once your lights are connected, they are available in the [scenes](/docs/scenes/intro) editor. You can turn them on or off, set their brightness and colour, and combine them with any other device, sensor or schedule, for example turning the lights on automatically at sunset or when motion is detected.
+
+### Can I control Philips Hue with my voice in Gladys?
+
+Yes. Connected Hue lights can be controlled through the Gladys [voice assistant](/docs/dashboard/voice-assistant) and from the chat, so you can say things like "turn off the living room lights" and Gladys will send the command to your bridge locally.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Does the Philips Hue integration work locally, without the cloud?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Gladys communicates with your Hue bridge directly over your local network, so your lights can be controlled even without an internet connection and none of your data is sent to a third party server.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Do I need a Philips Hue Bridge to use the integration?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "For the official Philips Hue integration, yes: Gladys connects to the Hue Bridge v2, which then controls your bulbs over Zigbee. If you prefer not to buy a bridge, you can instead pair your Hue bulbs directly with a Zigbee dongle through the Zigbee2mqtt integration.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Which Philips Hue Bridge is supported by Gladys?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "You need the Hue Bridge v2, the square shaped model. The original round Hue Bridge (v1) is not supported by the integration.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I use my Philips Hue lights in scenes?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Once your lights are connected, they are available in the scenes editor. You can turn them on or off, set their brightness and colour, and combine them with any other device, sensor or schedule.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I control Philips Hue with my voice in Gladys?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Connected Hue lights can be controlled through the Gladys voice assistant and from the chat, so you can say things like turn off the living room lights and Gladys will send the command to your bridge locally.",
+        },
+      },
+    ],
+  }}
+/>
+

--- a/docs/integrations/reolink.md
+++ b/docs/integrations/reolink.md
@@ -1,0 +1,128 @@
+---
+id: reolink
+title: "Reolink in Gladys: RTSP URL and camera setup"
+description: "Connect a Reolink camera to Gladys Assistant over RTSP, locally and without the cloud. Includes the exact Reolink RTSP URL format for the main and sub streams."
+sidebar_label: Reolink
+keywords:
+  - reolink rtsp url
+  - reolink gladys
+  - reolink home automation
+  - reolink rtsp
+  - connect reolink camera
+  - reolink local
+---
+
+import JsonLd from '@site/src/components/seo/JsonLd';
+
+Reolink cameras are an affordable, widely used choice, and they work great with Gladys Assistant. They are actually the cameras we [recommend for Gladys](/docs/installation/recommended-hardware).
+
+Reolink cameras expose a standard **RTSP** stream, so they connect through the generic [camera integration](/docs/integrations/camera). Gladys talks to the camera directly on your local network, which means your video feed stays at home and never transits through the Reolink cloud.
+
+## Reolink RTSP URL
+
+Reolink exposes two RTSP streams on port `554`: a high resolution **main** stream and a lighter **sub** stream. Replace `username`, `password` and the IP address with your own values:
+
+```
+# Main (high resolution) stream, H.264:
+rtsp://username:password@192.168.1.20:554/h264Preview_01_main
+
+# Sub (low resolution) stream, H.264:
+rtsp://username:password@192.168.1.20:554/h264Preview_01_sub
+```
+
+If your Reolink camera streams in H.265 (HEVC), swap the codec in the path:
+
+```
+rtsp://username:password@192.168.1.20:554/h265Preview_01_main
+```
+
+A few things worth knowing:
+
+- The `01` in the path is the channel number. On a standalone camera it is always `01`. If the camera is connected through a Reolink NVR, increment it for each channel (`02`, `03`, and so on).
+- For a smooth live view on your dashboard, the **sub** stream is often enough and puts less load on your Gladys server. Use the **main** stream when you want full resolution.
+- Some battery powered Reolink models (for example the Argus range) do not expose an RTSP stream. On those, RTSP is not available and the camera cannot be added to Gladys.
+
+## Enable RTSP on your Reolink camera
+
+RTSP is enabled by default on most Reolink cameras, but if the stream does not respond you can check it:
+
+1. Open the Reolink app (or the web interface at the camera's IP address) and log in.
+2. Go to **Settings → Network → Advanced → Port Settings** (or **Server Settings** depending on the model).
+3. Make sure **RTSP** is enabled and note the port (`554` by default).
+
+It is also good practice to create a dedicated user for Gladys instead of using the `admin` account, so you can revoke it at any time.
+
+## Test the URL in VLC
+
+Before adding the camera to Gladys, confirm your RTSP URL works in [VLC](https://www.videolan.org/vlc/): open **File → Open Network...**, paste the URL and check that the stream plays. If it works in VLC, it will work in Gladys.
+
+## Add your Reolink camera to Gladys
+
+Once your RTSP URL is confirmed, adding the camera to Gladys takes a minute:
+
+1. In Gladys, go to the **Integrations** tab and open the **Camera** integration.
+2. Click **New**, then paste your Reolink RTSP URL and give the camera a name.
+3. Click **Test connection**, then **Save**.
+4. Add the camera to your dashboard, and optionally ask Gladys to show it from the chat or on Telegram.
+
+The full walkthrough with screenshots is on the [camera integration page](/docs/integrations/camera).
+
+## Frequently asked questions
+
+### What is the RTSP URL of a Reolink camera?
+
+Reolink cameras expose two RTSP streams on port 554: the main (high resolution) stream at `rtsp://username:password@CAMERA_IP:554/h264Preview_01_main` and a lighter sub stream at `rtsp://username:password@CAMERA_IP:554/h264Preview_01_sub`. Replace the username, password and IP with your own. If your camera uses H.265, swap `h264` for `h265` in the path.
+
+### Does the Reolink integration work without the cloud?
+
+Yes. Gladys connects to your Reolink camera directly over your local network using its RTSP stream, so the video never goes through the Reolink cloud and keeps working without an internet connection.
+
+### Why does my Reolink RTSP URL not connect?
+
+The most common causes are a wrong channel number (`01` for a single camera), the wrong codec (`h264` vs `h265`, main vs sub), incorrect credentials, or RTSP being disabled in the camera settings. Test the URL in VLC first: if VLC cannot open it either, the problem is with the URL or the camera, not with Gladys.
+
+### Can I add a Reolink camera connected to a Reolink NVR?
+
+Yes. Use the NVR's IP address and increment the channel number in the path for each camera, for example `h264Preview_02_main` for the second channel.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "What is the RTSP URL of a Reolink camera?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Reolink cameras expose two RTSP streams on port 554: the main (high resolution) stream at rtsp://username:password@CAMERA_IP:554/h264Preview_01_main and a lighter sub stream at rtsp://username:password@CAMERA_IP:554/h264Preview_01_sub. Replace the username, password and IP with your own. If your camera uses H.265, swap h264 for h265 in the path.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Does the Reolink integration work without the cloud?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Gladys connects to your Reolink camera directly over your local network using its RTSP stream, so the video never goes through the Reolink cloud and keeps working without an internet connection.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Why does my Reolink RTSP URL not connect?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "The most common causes are a wrong channel number, the wrong codec (h264 vs h265, main vs sub), incorrect credentials, or RTSP being disabled in the camera settings. Test the URL in VLC first: if VLC cannot open it either, the problem is with the URL or the camera, not with Gladys.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Can I add a Reolink camera connected to a Reolink NVR?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Yes. Use the NVR's IP address and increment the channel number in the path for each camera, for example h264Preview_02_main for the second channel.",
+        },
+      },
+    ],
+  }}
+/>
+

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/camera.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/camera.md
@@ -29,7 +29,7 @@ Voilà un exemple d'une API HTTP pour récuperer une image d'une caméra :
 http://user:password@192.168.1.20/video?profile=0
 ```
 
-Si vous ne trouvez pas dans votre manuel, je peux vous conseiller ce site [https://www.ispyconnect.com/sources.aspx](https://www.ispyconnect.com/sources.aspx) qui est une base de donnée de toutes les informations de connexion des caméras qui existent dans le commerce.
+Si vous ne trouvez pas dans votre manuel, je peux vous conseiller ce site [https://www.ispyconnect.com/cameras](https://www.ispyconnect.com/cameras) qui est une base de donnée de toutes les informations de connexion des caméras qui existent dans le commerce.
 
 Il propose même un générateur d'URL en fonction de la marque, le modèle de votre caméra, et les informations de connexion (nom d'utilisateur + mot de passe) de votre caméra.
 
@@ -143,7 +143,7 @@ Une fois que la caméra fonctionne, cliquez sur le bouton "Sauvegarder".
 
 ### Comment trouver l'URL RTSP de ma caméra ?
 
-Consultez d'abord le manuel de votre caméra ou le site du fabricant, car le chemin diffère selon les marques. Si vous ne le trouvez pas, la [base de données iSpyConnect](https://www.ispyconnect.com/sources.aspx) liste les informations de connexion et génère même les URL pour la plupart des modèles. Vous pouvez aussi chercher "modèle de votre caméra + RTSP" en ligne. Pour une caméra Reolink, consultez notre [guide Reolink dédié](/docs/integrations/reolink).
+Consultez d'abord le manuel de votre caméra ou le site du fabricant, car le chemin diffère selon les marques. Si vous ne le trouvez pas, la [base de données iSpyConnect](https://www.ispyconnect.com/cameras) liste les informations de connexion et génère même les URL pour la plupart des modèles. Vous pouvez aussi chercher "modèle de votre caméra + RTSP" en ligne. Pour une caméra Reolink, consultez notre [guide Reolink dédié](/docs/integrations/reolink).
 
 ### Quelles caméras sont compatibles avec Gladys ?
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/camera.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/camera.md
@@ -1,11 +1,19 @@
 ---
 id: camera
-title: Caméra
-description: "Ajoutez des caméras IP à Gladys Assistant via leur flux RTSP ou HTTP et regardez-les en direct sur votre tableau de bord."
+title: "Intégration caméra IP : ajoutez n'importe quelle caméra RTSP ou HTTP à Gladys"
+description: "Ajoutez des caméras IP à Gladys Assistant via leur flux RTSP ou HTTP et regardez-les en direct sur votre tableau de bord. Compatible avec toutes les marques, en local et sans le cloud."
 sidebar_label: Caméra
+keywords:
+  - caméra rtsp
+  - caméra ip domotique
+  - flux rtsp
+  - flux http caméra
+  - intégration caméra
 ---
 
-Gladys est compatible avec les caméras qui exposent des flux RTSP ou HTTP et avec les webcam USB (méthode expliquée à la fin).
+import JsonLd from '@site/src/components/seo/JsonLd';
+
+Gladys est compatible avec les caméras qui exposent des flux RTSP ou HTTP et avec les webcam USB (méthode expliquée à la fin). Comme Gladys se connecte à la caméra directement sur votre réseau local, votre flux vidéo reste chez vous et ne transite jamais par le cloud du fabricant.
 
 Vous trouverez en général dans le manuel utilisateur de votre caméra, ou sur le site du constructeur, les informations du flux RTSP ou HTTP.
 
@@ -32,6 +40,10 @@ Exemple avec une caméra Xiaomi :
 Si vous ne trouvez rien sur ce site, une recherche Google peut vous aider, en cherchant "NOM DE LA CAMERA + RTSP", vous trouverez votre bonheur si la caméra expose un flux.
 
 Si vous ne trouvez rien, peut-être que votre caméra utilise un protocole fermé, et dans ce cas là vous n'avez pas beaucoup de choix que de changer de caméra.
+
+:::tip
+Vous avez une caméra Reolink ? Nous avons un guide dédié avec le format exact des URL RTSP Reolink : [Caméra Reolink dans Gladys](/docs/integrations/reolink).
+:::
 
 ## Testez la connexion à votre caméra avec VLC
 
@@ -126,6 +138,65 @@ J'ai mis une photo du port de Dieppe devant ma webcam 😄
 ![Ajouter une caméra à Gladys Assistant](../../../../../static/img/docs/fr/configuration/camera/z_ajouter_webcam_usb_gladys_assistant_02-test.jpg)
 
 Une fois que la caméra fonctionne, cliquez sur le bouton "Sauvegarder".
+
+## Questions fréquentes
+
+### Comment trouver l'URL RTSP de ma caméra ?
+
+Consultez d'abord le manuel de votre caméra ou le site du fabricant, car le chemin diffère selon les marques. Si vous ne le trouvez pas, la [base de données iSpyConnect](https://www.ispyconnect.com/sources.aspx) liste les informations de connexion et génère même les URL pour la plupart des modèles. Vous pouvez aussi chercher "modèle de votre caméra + RTSP" en ligne. Pour une caméra Reolink, consultez notre [guide Reolink dédié](/docs/integrations/reolink).
+
+### Quelles caméras sont compatibles avec Gladys ?
+
+Toute caméra IP qui expose un flux RTSP ou HTTP standard fonctionne avec Gladys, quelle que soit la marque. Les webcams USB sont également prises en charge. Si votre caméra ne fonctionne qu'à travers une application ou un cloud fermé du fabricant, elle ne sera pas compatible.
+
+### Gladys envoie-t-il mon flux caméra dans le cloud ?
+
+Non. Gladys se connecte à votre caméra directement sur votre réseau local via son flux RTSP ou HTTP : la vidéo reste chez vous. C'est un élément clé de Gladys, une solution de domotique locale et open source.
+
+### Le flux ne se connecte pas, que vérifier ?
+
+Vérifiez d'abord que l'URL fonctionne dans [VLC](https://www.videolan.org/vlc/index.fr.html). Si VLC ne l'ouvre pas non plus, assurez-vous que la machine qui fait tourner Gladys est sur le même réseau que la caméra, que les identifiants sont corrects et que le RTSP est activé dans les réglages de la caméra.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Comment trouver l'URL RTSP de ma caméra ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Consultez d'abord le manuel de votre caméra ou le site du fabricant, car le chemin diffère selon les marques. Si vous ne le trouvez pas, la base de données iSpyConnect liste les informations de connexion et génère même les URL pour la plupart des modèles. Vous pouvez aussi chercher le modèle de votre caméra plus RTSP en ligne.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Quelles caméras sont compatibles avec Gladys ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Toute caméra IP qui expose un flux RTSP ou HTTP standard fonctionne avec Gladys, quelle que soit la marque. Les webcams USB sont également prises en charge. Si votre caméra ne fonctionne qu'à travers une application ou un cloud fermé du fabricant, elle ne sera pas compatible.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Gladys envoie-t-il mon flux caméra dans le cloud ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Non. Gladys se connecte à votre caméra directement sur votre réseau local via son flux RTSP ou HTTP : la vidéo reste chez vous. C'est un élément clé de Gladys, une solution de domotique locale et open source.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Le flux caméra ne se connecte pas, que vérifier ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Vérifiez d'abord que l'URL fonctionne dans VLC. Si VLC ne l'ouvre pas non plus, assurez-vous que la machine qui fait tourner Gladys est sur le même réseau que la caméra, que les identifiants sont corrects et que le RTSP est activé dans les réglages de la caméra.",
+        },
+      },
+    ],
+  }}
+/>
 
 ## Le tutoriel en vidéo
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/philips-hue.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/philips-hue.md
@@ -1,9 +1,24 @@
 ---
 id: philips-hue
-title: Connecter ses Philips Hue dans Gladys Assistant
-description: "Connectez votre pont et vos ampoules Philips Hue à Gladys Assistant pour les piloter localement depuis votre tableau de bord et vos scènes."
+title: "Intégration Philips Hue : pilotez vos lumières en local avec Gladys"
+description: "Connectez votre pont et vos ampoules Philips Hue à Gladys Assistant pour les piloter localement, sans le cloud, depuis votre tableau de bord, vos scènes et l'assistant vocal."
 sidebar_label: Philips Hue
+keywords:
+  - intégration philips hue
+  - philips hue gladys
+  - philips hue local
+  - philips hue sans cloud
+  - connecter philips hue
+  - pont philips hue
 ---
+
+import JsonLd from '@site/src/components/seo/JsonLd';
+
+L'intégration Philips Hue connecte votre pont et vos ampoules Hue directement à Gladys Assistant. Gladys communique avec votre pont **en local**, sur votre propre réseau : vos lumières continuent donc de fonctionner même sans connexion internet, et aucune donnée ne sort de chez vous.
+
+Une fois vos ampoules connectées, vous pouvez les allumer, les éteindre, régler leur intensité, changer leur couleur, les regrouper par pièce et les utiliser dans vos [scènes](/docs/scenes/intro) : allumer l'entrée au coucher du soleil, faire clignoter le salon quand une porte s'ouvre, ou simuler un lever de soleil le matin. Vous pouvez aussi les piloter à la voix ou depuis l'[application mobile](/docs/installation/phone).
+
+Gladys se connecte au pont, qui parle en Zigbee à vos ampoules : toute ampoule, prise ou accessoire appairé à votre pont Hue apparaît donc dans Gladys. Si vous préférez vous passer de pont, vous pouvez aussi appairer vos ampoules Hue directement via l'[intégration Zigbee2mqtt](/docs/integrations/zigbee2mqtt).
 
 Car c'est toujours mieux en vidéo, voilà une petite démonstration de l'intégration Philips Hue dans Gladys 🙂
 
@@ -38,3 +53,62 @@ Assurez-vous d'avoir le Pont Philips Hue v2 (le carré). L'intégration ne fonct
 Dans `Périphériques`, cliquez sur `Connecter` sur chaque ampoule que vous voulez ajouter à Gladys.
 
 Et voilà !
+
+## Questions fréquentes
+
+### L'intégration Philips Hue fonctionne-t-elle en local, sans le cloud ?
+
+Oui. Gladys communique directement avec votre pont Hue sur votre réseau local : vos lumières restent pilotables même sans connexion internet et aucune donnée n'est envoyée sur un serveur tiers. C'est l'une des principales raisons d'utiliser Gladys, une solution de domotique locale et open source, plutôt qu'une application uniquement dans le cloud.
+
+### Ai-je besoin d'un pont Philips Hue ?
+
+Pour l'intégration Philips Hue officielle, oui : Gladys se connecte au pont Hue v2, qui pilote ensuite vos ampoules en Zigbee. Si vous préférez ne pas acheter de pont, vous pouvez appairer vos ampoules Hue directement avec une clé Zigbee via l'[intégration Zigbee2mqtt](/docs/integrations/zigbee2mqtt).
+
+### Quel pont Philips Hue est compatible ?
+
+Il vous faut le pont Hue v2, le modèle carré. Le pont Hue d'origine (v1, rond) n'est pas compatible avec l'intégration.
+
+### Puis-je utiliser mes ampoules Philips Hue dans des scènes ?
+
+Oui. Une fois connectées, vos ampoules sont disponibles dans l'éditeur de [scènes](/docs/scenes/intro). Vous pouvez les allumer, les éteindre, régler leur intensité et leur couleur, et les combiner avec n'importe quel autre appareil, capteur ou horaire, par exemple allumer les lumières automatiquement au coucher du soleil ou lors d'une détection de mouvement.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "L'intégration Philips Hue fonctionne-t-elle en local, sans le cloud ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui. Gladys communique directement avec votre pont Hue sur votre réseau local : vos lumières restent pilotables même sans connexion internet et aucune donnée n'est envoyée sur un serveur tiers.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Ai-je besoin d'un pont Philips Hue ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Pour l'intégration Philips Hue officielle, oui : Gladys se connecte au pont Hue v2, qui pilote ensuite vos ampoules en Zigbee. Si vous préférez ne pas acheter de pont, vous pouvez appairer vos ampoules Hue directement avec une clé Zigbee via l'intégration Zigbee2mqtt.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Quel pont Philips Hue est compatible avec Gladys ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Il vous faut le pont Hue v2, le modèle carré. Le pont Hue d'origine (v1, rond) n'est pas compatible avec l'intégration.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Puis-je utiliser mes ampoules Philips Hue dans des scènes ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui. Une fois connectées, vos ampoules sont disponibles dans l'éditeur de scènes. Vous pouvez les allumer, les éteindre, régler leur intensité et leur couleur, et les combiner avec n'importe quel autre appareil, capteur ou horaire.",
+        },
+      },
+    ],
+  }}
+/>

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/reolink.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/reolink.md
@@ -1,0 +1,128 @@
+---
+id: reolink
+title: "Reolink dans Gladys : URL RTSP et configuration de la caméra"
+description: "Connectez une caméra Reolink à Gladys Assistant en RTSP, en local et sans le cloud. Avec le format exact des URL RTSP Reolink pour les flux principal et secondaire."
+sidebar_label: Reolink
+keywords:
+  - url rtsp reolink
+  - reolink gladys
+  - reolink domotique
+  - reolink rtsp
+  - connecter caméra reolink
+  - reolink local
+---
+
+import JsonLd from '@site/src/components/seo/JsonLd';
+
+Les caméras Reolink sont un choix abordable et très répandu, et elles fonctionnent parfaitement avec Gladys Assistant. Ce sont d'ailleurs les caméras que nous [recommandons pour Gladys](/docs/installation/recommended-hardware).
+
+Les caméras Reolink exposent un flux **RTSP** standard : elles se connectent donc via l'[intégration caméra](/docs/integrations/camera) générique. Gladys communique avec la caméra directement sur votre réseau local, ce qui signifie que votre flux vidéo reste chez vous et ne transite jamais par le cloud Reolink.
+
+## URL RTSP d'une caméra Reolink
+
+Reolink expose deux flux RTSP sur le port `554` : un flux **principal** en haute résolution et un flux **secondaire** plus léger. Remplacez `username`, `password` et l'adresse IP par vos propres valeurs :
+
+```
+# Flux principal (haute résolution), H.264 :
+rtsp://username:password@192.168.1.20:554/h264Preview_01_main
+
+# Flux secondaire (basse résolution), H.264 :
+rtsp://username:password@192.168.1.20:554/h264Preview_01_sub
+```
+
+Si votre caméra Reolink diffuse en H.265 (HEVC), remplacez le codec dans le chemin :
+
+```
+rtsp://username:password@192.168.1.20:554/h265Preview_01_main
+```
+
+Quelques points utiles :
+
+- Le `01` dans le chemin est le numéro de canal. Sur une caméra seule il vaut toujours `01`. Si la caméra passe par un NVR Reolink, incrémentez-le pour chaque canal (`02`, `03`, etc.).
+- Pour un affichage fluide sur votre tableau de bord, le flux **secondaire** suffit souvent et sollicite moins votre serveur Gladys. Utilisez le flux **principal** pour la pleine résolution.
+- Certains modèles Reolink sur batterie (par exemple la gamme Argus) n'exposent pas de flux RTSP. Sur ceux-là, le RTSP n'est pas disponible et la caméra ne peut pas être ajoutée à Gladys.
+
+## Activer le RTSP sur votre caméra Reolink
+
+Le RTSP est activé par défaut sur la plupart des caméras Reolink, mais si le flux ne répond pas vous pouvez le vérifier :
+
+1. Ouvrez l'application Reolink (ou l'interface web à l'adresse IP de la caméra) et connectez-vous.
+2. Allez dans **Paramètres → Réseau → Avancé → Réglages des ports** (ou **Réglages serveur** selon le modèle).
+3. Vérifiez que le **RTSP** est activé et notez le port (`554` par défaut).
+
+C'est aussi une bonne pratique de créer un utilisateur dédié pour Gladys plutôt que d'utiliser le compte `admin`, afin de pouvoir le révoquer à tout moment.
+
+## Tester l'URL dans VLC
+
+Avant d'ajouter la caméra à Gladys, vérifiez que votre URL RTSP fonctionne dans [VLC](https://www.videolan.org/vlc/index.fr.html) : ouvrez **Fichier → Ouvrir un flux réseau**, collez l'URL et vérifiez que le flux se lit. Si ça fonctionne dans VLC, ça fonctionnera dans Gladys.
+
+## Ajouter votre caméra Reolink à Gladys
+
+Une fois votre URL RTSP validée, l'ajout de la caméra à Gladys prend une minute :
+
+1. Dans Gladys, allez dans l'onglet **Intégrations** et ouvrez l'intégration **Caméras**.
+2. Cliquez sur **Nouveau**, puis collez votre URL RTSP Reolink et donnez un nom à la caméra.
+3. Cliquez sur **Tester la connexion**, puis **Sauvegarder**.
+4. Ajoutez la caméra à votre tableau de bord, et éventuellement demandez à Gladys de l'afficher depuis le chat ou par Telegram.
+
+Le tutoriel complet avec captures d'écran est sur la [page de l'intégration caméra](/docs/integrations/camera).
+
+## Questions fréquentes
+
+### Quelle est l'URL RTSP d'une caméra Reolink ?
+
+Les caméras Reolink exposent deux flux RTSP sur le port 554 : le flux principal (haute résolution) à l'adresse `rtsp://username:password@IP_CAMERA:554/h264Preview_01_main` et un flux secondaire plus léger à l'adresse `rtsp://username:password@IP_CAMERA:554/h264Preview_01_sub`. Remplacez le nom d'utilisateur, le mot de passe et l'IP par les vôtres. Si votre caméra diffuse en H.265, remplacez `h264` par `h265` dans le chemin.
+
+### L'intégration Reolink fonctionne-t-elle sans le cloud ?
+
+Oui. Gladys se connecte à votre caméra Reolink directement sur votre réseau local via son flux RTSP : la vidéo ne passe jamais par le cloud Reolink et continue de fonctionner sans connexion internet.
+
+### Pourquoi mon URL RTSP Reolink ne se connecte-t-elle pas ?
+
+Les causes les plus fréquentes sont un mauvais numéro de canal (`01` pour une seule caméra), un mauvais codec (`h264` vs `h265`, principal vs secondaire), des identifiants incorrects, ou le RTSP désactivé dans les réglages de la caméra. Testez d'abord l'URL dans VLC : si VLC ne l'ouvre pas non plus, le problème vient de l'URL ou de la caméra, pas de Gladys.
+
+### Puis-je ajouter une caméra Reolink connectée à un NVR Reolink ?
+
+Oui. Utilisez l'adresse IP du NVR et incrémentez le numéro de canal dans le chemin pour chaque caméra, par exemple `h264Preview_02_main` pour le deuxième canal.
+
+<JsonLd
+  data={{
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: [
+      {
+        "@type": "Question",
+        name: "Quelle est l'URL RTSP d'une caméra Reolink ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Les caméras Reolink exposent deux flux RTSP sur le port 554 : le flux principal (haute résolution) à l'adresse rtsp://username:password@IP_CAMERA:554/h264Preview_01_main et un flux secondaire plus léger à l'adresse rtsp://username:password@IP_CAMERA:554/h264Preview_01_sub. Remplacez le nom d'utilisateur, le mot de passe et l'IP par les vôtres. Si votre caméra diffuse en H.265, remplacez h264 par h265 dans le chemin.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "L'intégration Reolink fonctionne-t-elle sans le cloud ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui. Gladys se connecte à votre caméra Reolink directement sur votre réseau local via son flux RTSP : la vidéo ne passe jamais par le cloud Reolink et continue de fonctionner sans connexion internet.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Pourquoi mon URL RTSP Reolink ne se connecte-t-elle pas ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Les causes les plus fréquentes sont un mauvais numéro de canal, un mauvais codec (h264 vs h265, principal vs secondaire), des identifiants incorrects, ou le RTSP désactivé dans les réglages de la caméra. Testez d'abord l'URL dans VLC : si VLC ne l'ouvre pas non plus, le problème vient de l'URL ou de la caméra, pas de Gladys.",
+        },
+      },
+      {
+        "@type": "Question",
+        name: "Puis-je ajouter une caméra Reolink connectée à un NVR Reolink ?",
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: "Oui. Utilisez l'adresse IP du NVR et incrémentez le numéro de canal dans le chemin pour chaque caméra, par exemple h264Preview_02_main pour le deuxième canal.",
+        },
+      },
+    ],
+  }}
+/>
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -32,6 +32,7 @@ module.exports = {
         "integrations/broadlink",
         "integrations/caldav",
         "integrations/camera",
+        "integrations/reolink",
         "integrations/callmebot",
         "integrations/enedis",
         "integrations/energy-monitoring",

--- a/src/components/UseCasePage.js
+++ b/src/components/UseCasePage.js
@@ -116,6 +116,43 @@ export default function UseCasePage({ content, faq, schemaData, lang }) {
             <p className={styles.blockOutro}>{content.problem.outro}</p>
           </section>
 
+          {/* OPTIONAL COMPARISON TABLE (only pages that define it) */}
+          {content.comparison && (
+            <section className={styles.section} aria-labelledby="comparison-title">
+              <h2 id="comparison-title" className={styles.sectionTitle}>
+                {content.comparison.title}
+              </h2>
+              {content.comparison.intro && (
+                <p className={styles.blockIntro}>{content.comparison.intro}</p>
+              )}
+              <div className={styles.tableWrapper}>
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th scope="col">{content.comparison.cols.feature}</th>
+                      <th scope="col" className={styles.gladysCol}>
+                        {content.comparison.cols.gladys}
+                      </th>
+                      <th scope="col">{content.comparison.cols.other}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {content.comparison.rows.map((row, i) => (
+                      <tr key={i}>
+                        <th scope="row">{row.feature}</th>
+                        <td>{row.gladys}</td>
+                        <td>{row.other}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {content.comparison.outro && (
+                <p className={styles.blockOutro}>{content.comparison.outro}</p>
+              )}
+            </section>
+          )}
+
           {/* FEATURES */}
           <section className={styles.section} aria-labelledby="features-title">
             <h2 id="features-title" className={styles.sectionTitle}>

--- a/src/data/alarmSystemData.js
+++ b/src/data/alarmSystemData.js
@@ -7,16 +7,16 @@
 const alarmContent = {
   en: {
     meta: {
-      title: "DIY home alarm system: build your own, local and private",
+      title: "DIY home alarm system: local, private, and yours to own",
       description:
-        "Build a real DIY home alarm system with Gladys Assistant: armed, partial and panic modes, motion and door sensors, camera snapshots and instant alerts, all running locally on hardware you own, open-source and with your data kept at home.",
+        "Build a real DIY home alarm system with Gladys Assistant, a local alternative to monitored alarms like Verisure or ADT: you own your hardware and installation, everything runs locally, with armed, partial and panic modes, affordable sensors and instant alerts.",
     },
     screenshotCaption:
       "Arm, disarm and monitor your home from Gladys, locally and on your own terms.",
     hero: {
       title: "Build your own home alarm system, local and private",
       subtitle:
-        "A real DIY alarm with motion sensors, door contacts, cameras and instant alerts, running locally on hardware you own.",
+        "A real DIY alarm with motion sensors, door contacts, cameras and instant alerts, running locally on hardware you own and control.",
       intro: [
         "Traditional alarm systems lock you into proprietary hardware, a company's cloud, and rules you can't change. Your home security shouldn't be a black box you rent from someone else.",
         "With Gladys Assistant you build a real alarm system from affordable, off-the-shelf sensors. It runs locally on your own machine, alerts you instantly, and behaves exactly the way you decide.",
@@ -28,8 +28,8 @@ const alarmContent = {
       },
     },
     problem: {
-      title: "The problem with traditional alarm systems",
-      intro: "Off-the-shelf monitored alarms are convenient, but the trade-offs are steep:",
+      title: "The problem with traditional monitored alarms",
+      intro: "Off-the-shelf monitored alarms (Verisure, ADT, Ring Alarm and the like) are convenient, but the trade-offs are steep:",
       points: [
         "Proprietary hardware and sensors locked to a single vendor.",
         "Your security data and camera feeds routed through a company's cloud.",
@@ -39,6 +39,55 @@ const alarmContent = {
       ],
       outro:
         "A self-hosted alarm flips all of that: your rules, your hardware, your data, kept at home.",
+    },
+    comparison: {
+      title: "Gladys DIY alarm vs a monitored subscription alarm",
+      intro:
+        "How a self-hosted Gladys alarm compares to a traditional monitored alarm (Verisure, ADT, Ring Alarm and similar):",
+      cols: {
+        feature: "",
+        gladys: "Gladys DIY alarm",
+        other: "Monitored subscription alarm",
+      },
+      rows: [
+        {
+          feature: "Ownership",
+          gladys: "You own the hardware and your installation",
+          other: "You rent the whole system",
+        },
+        {
+          feature: "Your data",
+          gladys: "Stays on your local network",
+          other: "Routed through their cloud",
+        },
+        {
+          feature: "Works offline",
+          gladys: "Yes, fully local",
+          other: "Limited without their service",
+        },
+        {
+          feature: "Sensors & hardware",
+          gladys: "Any Zigbee or Matter sensor, your choice",
+          other: "Proprietary, locked to them",
+        },
+        {
+          feature: "Rules & automations",
+          gladys: "Your own, fully customizable",
+          other: "Theirs, fixed scenarios",
+        },
+        {
+          feature: "Subscription",
+          gladys: "Optional Gladys Plus for remote access, backups and camera streaming",
+          other: "Mandatory, the system is the subscription",
+        },
+        {
+          feature: "If the company shuts down",
+          gladys: "Keeps working, it's yours",
+          other: "Can be left useless",
+        },
+      ],
+      outro:
+        "Both can involve a subscription. The difference is what you get for it: with Gladys you own your hardware and your installation, everything runs locally, and your data stays home, instead of renting a system you never control.",
     },
     features: {
       title: "What your Gladys alarm can do",
@@ -136,16 +185,16 @@ const alarmContent = {
 
   fr: {
     meta: {
-      title: "Alarme maison DIY : créez la vôtre, locale et privée",
+      title: "Alarme maison locale : l'alternative à Homiris et Verisure",
       description:
-        "Créez une vraie alarme maison DIY avec Gladys Assistant : modes armé, partiel et panique, détecteurs de mouvement et d'ouverture, photos de caméra et alertes instantanées, le tout en local sur du matériel qui vous appartient, open source et avec vos données gardées chez vous.",
+        "Créez une vraie alarme maison DIY avec Gladys Assistant, l'alternative locale aux alarmes télésurveillées type Homiris ou Verisure : vous restez propriétaire de votre matériel et de votre installation, tout tourne en local, avec des capteurs abordables et des alertes instantanées.",
     },
     screenshotCaption:
       "Armez, désarmez et surveillez votre maison depuis Gladys, en local et selon vos règles.",
     hero: {
       title: "Créez votre propre alarme maison, locale et privée",
       subtitle:
-        "Une vraie alarme DIY avec détecteurs de mouvement, contacts d'ouverture, caméras et alertes instantanées, qui tourne en local sur du matériel qui vous appartient.",
+        "Une vraie alarme DIY avec détecteurs de mouvement, contacts d'ouverture, caméras et alertes instantanées, qui tourne en local sur du matériel qui vous appartient et que vous contrôlez de bout en bout.",
       intro: [
         "Les systèmes d'alarme classiques vous enferment dans du matériel propriétaire, le cloud d'une entreprise, et des règles que vous ne pouvez pas changer. La sécurité de votre maison ne devrait pas être une boîte noire que vous louez à quelqu'un d'autre.",
         "Avec Gladys Assistant, vous construisez une vraie alarme à partir de capteurs abordables du commerce. Elle tourne en local sur votre propre machine, vous alerte instantanément, et se comporte exactement comme vous l'avez décidé.",
@@ -157,9 +206,9 @@ const alarmContent = {
       },
     },
     problem: {
-      title: "Le problème des systèmes d'alarme classiques",
+      title: "Le problème des alarmes télésurveillées classiques",
       intro:
-        "Les alarmes télésurveillées du commerce sont pratiques, mais les compromis sont lourds :",
+        "Les alarmes télésurveillées classiques (Homiris, Verisure et compagnie) sont pratiques, mais les compromis sont lourds :",
       points: [
         "Du matériel et des capteurs propriétaires, verrouillés sur un seul fournisseur.",
         "Vos données de sécurité et vos flux de caméra qui transitent par le cloud d'une entreprise.",
@@ -169,6 +218,55 @@ const alarmContent = {
       ],
       outro:
         "Une alarme auto-hébergée inverse tout cela : vos règles, votre matériel, vos données, gardées chez vous.",
+    },
+    comparison: {
+      title: "Alarme DIY Gladys vs alarme télésurveillée sur abonnement",
+      intro:
+        "Comment une alarme Gladys auto-hébergée se compare à une alarme télésurveillée classique (Homiris, Verisure et similaires) :",
+      cols: {
+        feature: "",
+        gladys: "Alarme DIY Gladys",
+        other: "Alarme télésurveillée sur abonnement",
+      },
+      rows: [
+        {
+          feature: "Propriété",
+          gladys: "Vous possédez le matériel et votre installation",
+          other: "Vous louez tout le système",
+        },
+        {
+          feature: "Vos données",
+          gladys: "Restent sur votre réseau local",
+          other: "Transitent par leur cloud",
+        },
+        {
+          feature: "Fonctionne hors ligne",
+          gladys: "Oui, 100 % local",
+          other: "Limité sans leur service",
+        },
+        {
+          feature: "Capteurs & matériel",
+          gladys: "N'importe quel capteur Zigbee ou Matter, à votre choix",
+          other: "Propriétaire, verrouillé chez eux",
+        },
+        {
+          feature: "Règles & automatisations",
+          gladys: "Les vôtres, entièrement personnalisables",
+          other: "Les leurs, scénarios figés",
+        },
+        {
+          feature: "Abonnement",
+          gladys: "Gladys Plus en option pour l'accès distant, les sauvegardes et le streaming caméra",
+          other: "Obligatoire, le système est l'abonnement",
+        },
+        {
+          feature: "Si l'entreprise ferme",
+          gladys: "Continue de fonctionner, il est à vous",
+          other: "Peut devenir inutilisable",
+        },
+      ],
+      outro:
+        "Les deux peuvent impliquer un abonnement. La différence, c'est ce qu'il recouvre : avec Gladys, vous possédez votre matériel et votre installation, tout tourne en local et vos données restent chez vous, au lieu de louer un système que vous ne contrôlez jamais.",
     },
     features: {
       title: "Ce que votre alarme Gladys peut faire",
@@ -292,6 +390,11 @@ export const alarmFaqEn = [
       "A Gladys alarm is very capable and flexible, but it's a system you build and maintain yourself. For many people a well-built local alarm is plenty; if you want professional monitoring too, you can combine both.",
   },
   {
+    question: "Is Gladys an alternative to a subscription alarm like Verisure?",
+    answer:
+      "Yes, but in a different way. With Gladys you own your hardware and your installation, and your alarm runs locally on your own machine, with your data kept at home. Gladys offers an optional subscription, Gladys Plus, for encrypted remote access and camera streaming, so it isn't about avoiding a subscription altogether, it's that you stay the owner of your system and your data instead of renting a monitored service you never control.",
+  },
+  {
     question: "Is my security data private?",
     answer:
       "Yes. Gladys is self-hosted, so your sensor data and camera feeds stay on your local network, with no mandatory cloud and no data resale.",
@@ -323,6 +426,11 @@ export const alarmFaqFr = [
     question: "Une alarme DIY vaut-elle une alarme professionnelle ?",
     answer:
       "Une alarme Gladys est très capable et flexible, mais c'est un système que vous construisez et maintenez vous-même. Pour beaucoup de gens, une bonne alarme locale suffit largement ; si vous voulez aussi une télésurveillance professionnelle, vous pouvez combiner les deux.",
+  },
+  {
+    question: "Gladys est-il une alternative à Homiris ou Verisure ?",
+    answer:
+      "Oui, mais autrement. Avec Gladys, vous possédez votre matériel et votre installation, et votre alarme tourne en local sur votre propre machine, avec vos données gardées chez vous. Gladys propose un abonnement optionnel, Gladys Plus, pour l'accès distant chiffré et le streaming caméra : il ne s'agit donc pas d'éviter tout abonnement, mais de rester propriétaire de votre système et de vos données, au lieu de louer un service télésurveillé que vous ne contrôlez jamais.",
   },
   {
     question: "Mes données de sécurité sont-elles privées ?",

--- a/src/data/bestZigbeeDongleData.js
+++ b/src/data/bestZigbeeDongleData.js
@@ -128,6 +128,16 @@ const bestZigbeeDongleContent = {
           text: "The step-by-step guide to setting up your dongle with Zigbee2MQTT.",
         },
         {
+          label: "IKEA smart home with Gladys",
+          href: "/ikea-smart-home/",
+          text: "Use your IKEA Tradfri and Dirigera devices locally, over Zigbee2MQTT or Matter.",
+        },
+        {
+          label: "Home weather station",
+          href: "/home-weather-station/",
+          text: "Build a local weather station from Zigbee and Matter sensors Gladys reads directly.",
+        },
+        {
           label: "Zigbee vs Matter vs Z-Wave",
           href: "/zigbee-vs-matter-vs-zwave/",
           text: "Which wireless standard to choose for your smart home devices.",
@@ -261,6 +271,16 @@ const bestZigbeeDongleContent = {
           label: "Connecter des appareils Zigbee à Gladys",
           href: "/fr/docs/integrations/zigbee2mqtt/",
           text: "Le guide pas à pas pour configurer votre clé avec Zigbee2MQTT.",
+        },
+        {
+          label: "Maison connectée IKEA avec Gladys",
+          href: "/fr/ikea-smart-home/",
+          text: "Utilisez vos appareils IKEA Tradfri et Dirigera en local, via Zigbee2MQTT ou Matter.",
+        },
+        {
+          label: "Station météo maison",
+          href: "/fr/home-weather-station/",
+          text: "Montez une station météo locale avec des capteurs Zigbee et Matter lus par Gladys.",
         },
         {
           label: "Zigbee vs Matter vs Z-Wave",

--- a/src/data/homeWeatherStationData.js
+++ b/src/data/homeWeatherStationData.js
@@ -1,0 +1,380 @@
+// Content for the "home weather station" buyer's-guide landing page.
+// Targets the on-theme "home weather station / wireless weather station /
+// station météo connectée" cluster (Search Console: e.g. "top rated wireless
+// weather stations for home in france", position ~8). The angle is balanced:
+// we recommend the local-first route (Zigbee & Matter sensors that Gladys
+// controls locally) but also cover the connected-station route (Netatmo via
+// its integration, plus OpenWeather for forecast data with no hardware).
+
+// Amazon affiliate links (Gladys is an Amazon Associate).
+// Tags: gladproj-20 on amazon.com (EN), gladproj-21 on amazon.fr (FR).
+// Affiliate-tagged search links keyed to the exact product name, so every link
+// is valid, lands on the right marketplace and carries the affiliate tag.
+const amazonUS = (query) =>
+  `https://www.amazon.com/s?k=${encodeURIComponent(query)}&tag=gladproj-20`;
+const amazonFR = (query) =>
+  `https://www.amazon.fr/s?k=${encodeURIComponent(query)}&tag=gladproj-21`;
+
+const homeWeatherStationContent = {
+  en: {
+    meta: {
+      title: "Best home weather station for a smart home (Zigbee, Matter, Netatmo)",
+      description:
+        "Which weather station works with a local smart home? A practical guide to wireless weather sensors for Gladys Assistant: local Zigbee and Matter sensors, the Netatmo station, and OpenWeather for forecast data.",
+    },
+    hero: {
+      title: "The best home weather station for your smart home",
+      subtitle:
+        "How to measure temperature, humidity and more at home, in a way that actually works with Gladys, either fully local with Zigbee and Matter sensors, or with a connected station.",
+      intro: [
+        "A weather station tells you what is happening at home and outside: temperature, humidity, atmospheric pressure, and sometimes wind and rain. But most consumer weather stations lock their data inside a manufacturer app and cloud, which is a poor fit for a local smart home.",
+        "With Gladys Assistant you have two good options. The most local one is to build your own station from Zigbee and Matter sensors that Gladys reads directly on your network. If you want a ready-made station with a wind and rain gauge, the Netatmo Weather Station connects through its integration. This guide covers both.",
+      ],
+      primaryCta: { label: "See local sensors", href: "#local" },
+      secondaryCta: {
+        label: "Get started with Gladys →",
+        href: "/docs/",
+      },
+    },
+    criteria: {
+      title: "What to look for in a smart weather station",
+      intro:
+        "Before buying, a few things matter more than the number of features on the box:",
+      points: [
+        "Local vs cloud: can you read the data on your own network, or does it only live in the manufacturer's app? A local sensor keeps working even without internet and never depends on a cloud that could shut down.",
+        "Indoor and outdoor coverage: for a real weather picture you usually want at least one indoor and one outdoor sensor (temperature and humidity, ideally atmospheric pressure too).",
+        "Protocol: for a local setup, prefer Zigbee (via Zigbee2MQTT) or Matter. Both are open and let Gladys read the values directly.",
+        "Extras: only a few products measure wind and rain. If you need those, a connected station like Netatmo is the realistic option today.",
+        "Battery life and range: outdoor sensors run on batteries and sit far from the house, so good battery life and range matter for reliability.",
+      ],
+      outro:
+        "The good news: whichever route you pick below, Gladys brings the readings into one dashboard and lets you automate on them.",
+    },
+    local: {
+      title: "The local route: Zigbee and Matter sensors",
+      intro:
+        "This is the most local option: compose your own weather station from sensors Gladys reads directly, with no manufacturer cloud. These are supported through Zigbee2MQTT or Matter:",
+      items: [
+        {
+          name: "Aqara Temperature and Humidity Sensor",
+          tag: "Best indoor, Zigbee",
+          text: "A tiny, affordable Zigbee sensor that reports temperature, humidity and atmospheric pressure. One of the devices we already recommend for Gladys. Pairs through Zigbee2MQTT.",
+          buyHref: amazonUS("Aqara Temperature and Humidity Sensor"),
+          buyLabel: "View on Amazon →",
+          docHref: "/docs/integrations/zigbee2mqtt/",
+          docLabel: "How to pair Zigbee",
+        },
+        {
+          name: "SONOFF SNZB-02D",
+          tag: "Indoor with display, Zigbee",
+          text: "A Zigbee temperature and humidity sensor with an e-ink screen, so you also get a readout on the wall. Reliable and cheap, pairs through Zigbee2MQTT.",
+          buyHref: amazonUS("SONOFF SNZB-02D Zigbee temperature humidity sensor"),
+          buyLabel: "View on Amazon →",
+        },
+        {
+          name: "OWON THS-317-ET",
+          tag: "Outdoor probe, Zigbee",
+          text: "A Zigbee temperature sensor with a waterproof external probe, ideal for measuring outdoor or fridge/freezer temperature. Listed in the Gladys Zigbee catalogue.",
+          buyHref: amazonUS("OWON THS-317-ET Zigbee temperature sensor"),
+          buyLabel: "View on Amazon →",
+        },
+        {
+          name: "Eve Weather",
+          tag: "Matter over Thread",
+          text: "A weatherproof outdoor sensor measuring temperature, humidity and barometric pressure. It speaks Thread and Matter, so Gladys can read it locally through the Matter integration.",
+          buyHref: amazonUS("Eve Weather Matter Thread"),
+          buyLabel: "View on Amazon →",
+          docHref: "/docs/integrations/matter/",
+          docLabel: "How Matter works",
+        },
+      ],
+      outro:
+        "To pair the Zigbee sensors you just need a Zigbee dongle. See our guide to picking the right one.",
+    },
+    cloud: {
+      title: "The connected-station route: Netatmo and OpenWeather",
+      intro:
+        "Want a ready-made station with a wind and rain gauge, or weather data with no hardware at all? These connect to Gladys too:",
+      items: [
+        {
+          name: "Netatmo Weather Station",
+          tag: "Full station, wind and rain",
+          text: "A complete connected weather station: indoor and outdoor modules, with optional wind and rain gauges. It runs through Netatmo's cloud, and Gladys reads its values through the Netatmo integration. The realistic choice if you want wind and rain today.",
+          buyHref: amazonUS("Netatmo Weather Station"),
+          buyLabel: "View on Amazon →",
+          docHref: "/docs/integrations/netatmo/",
+          docLabel: "Netatmo integration",
+        },
+        {
+          name: "OpenWeather (no hardware)",
+          tag: "Free forecast data",
+          text: "If you just want current conditions and forecasts for your location, the OpenWeather integration brings weather data into Gladys for free, without buying any sensor. Great to complement your own sensors.",
+          docHref: "/docs/integrations/openweather/",
+          docLabel: "Set up OpenWeather →",
+        },
+      ],
+      outro:
+        "Cloud stations are convenient and feature-rich, but remember they depend on the manufacturer's servers. For anything you want to keep working offline, prefer the local sensors above.",
+    },
+    gladys: {
+      title: "Why bring your weather station into Gladys",
+      paragraphs: [
+        "On their own, each sensor or station lives in its own app. With Gladys, all your indoor and outdoor readings sit in one local dashboard, next to every other device in your home, and the historical data stays on your own hardware.",
+        "From there you can automate on the weather: close the blinds when it gets too hot, boost the heating when the outdoor temperature drops, send a frost alert before a cold night, or turn on a fan when indoor humidity climbs.",
+      ],
+      link: { label: "Discover local, open-source home automation →", href: "/open-source-home-automation/" },
+    },
+    related: {
+      title: "Go further",
+      intro:
+        "Adding weather sensors is part of building a local smart home:",
+      links: [
+        {
+          label: "Connect Zigbee devices to Gladys",
+          href: "/docs/integrations/zigbee2mqtt/",
+          text: "The step-by-step guide to pairing Zigbee sensors with Zigbee2MQTT.",
+        },
+        {
+          label: "Best Zigbee USB dongle",
+          href: "/best-zigbee-dongle/",
+          text: "Which Zigbee coordinator to buy to pair your weather sensors locally.",
+        },
+        {
+          label: "IKEA smart home with Gladys",
+          href: "/ikea-smart-home/",
+          text: "Control your IKEA Tradfri and Dirigera devices locally, over Zigbee2MQTT or Matter.",
+        },
+        {
+          label: "Netatmo in Gladys",
+          href: "/docs/integrations/netatmo/",
+          text: "Connect a Netatmo Weather Station and read its modules in Gladys.",
+        },
+        {
+          label: "Recommended hardware",
+          href: "/docs/installation/recommended-hardware/",
+          text: "The full list of Zigbee devices we recommend for a reliable Gladys home.",
+        },
+      ],
+    },
+    faqTitle: "Frequently asked questions",
+    cta: {
+      title: "Build your local weather station",
+      text: "Gladys is free, open-source, and installs in a single Docker command. Pair a few sensors and read your home's climate locally, with automations that react to it.",
+      primary: { label: "Get started", href: "/docs/" },
+      secondary: {
+        label: "Set up Zigbee2MQTT",
+        href: "/docs/integrations/zigbee2mqtt/",
+      },
+    },
+  },
+
+  fr: {
+    meta: {
+      title: "Quelle station météo connectée pour une maison connectée (Zigbee, Matter, Netatmo)",
+      description:
+        "Quelle station météo fonctionne avec une maison connectée locale ? Guide des capteurs météo sans fil pour Gladys Assistant : capteurs Zigbee et Matter locaux, station Netatmo, et OpenWeather pour les prévisions.",
+    },
+    hero: {
+      title: "La meilleure station météo pour votre maison connectée",
+      subtitle:
+        "Comment mesurer température, humidité et plus chez vous, d'une façon qui fonctionne vraiment avec Gladys : soit 100 % local avec des capteurs Zigbee et Matter, soit avec une station connectée.",
+      intro: [
+        "Une station météo vous indique ce qui se passe chez vous et dehors : température, humidité, pression atmosphérique, parfois vent et pluie. Mais la plupart des stations grand public enferment leurs données dans une application et un cloud de fabricant, ce qui colle mal à une maison connectée locale.",
+        "Avec Gladys Assistant, vous avez deux bonnes options. La plus locale : composer votre propre station avec des capteurs Zigbee et Matter que Gladys lit directement sur votre réseau. Si vous voulez une station toute prête avec anémomètre et pluviomètre, la station Netatmo se connecte via son intégration. Ce guide couvre les deux.",
+      ],
+      primaryCta: { label: "Voir les capteurs locaux", href: "#local" },
+      secondaryCta: {
+        label: "Commencer avec Gladys →",
+        href: "/fr/docs/",
+      },
+    },
+    criteria: {
+      title: "Ce qu'il faut regarder dans une station météo connectée",
+      intro:
+        "Avant d'acheter, quelques points comptent plus que le nombre de fonctions sur la boîte :",
+      points: [
+        "Local ou cloud : pouvez-vous lire les données sur votre propre réseau, ou ne vivent-elles que dans l'application du fabricant ? Un capteur local continue de fonctionner même sans internet et ne dépend pas d'un cloud qui pourrait fermer.",
+        "Intérieur et extérieur : pour une vraie vision météo, il faut en général au moins un capteur intérieur et un extérieur (température et humidité, idéalement la pression atmosphérique aussi).",
+        "Le protocole : pour une installation locale, privilégiez le Zigbee (via Zigbee2MQTT) ou le Matter. Les deux sont ouverts et permettent à Gladys de lire les valeurs directement.",
+        "Les extras : peu de produits mesurent le vent et la pluie. Si vous en avez besoin, une station connectée comme Netatmo est l'option réaliste aujourd'hui.",
+        "Autonomie et portée : les capteurs extérieurs fonctionnent sur pile et sont loin de la maison, donc une bonne autonomie et une bonne portée comptent pour la fiabilité.",
+      ],
+      outro:
+        "Bonne nouvelle : quelle que soit la voie choisie ci-dessous, Gladys réunit les mesures dans un seul tableau de bord et vous laisse les automatiser.",
+    },
+    local: {
+      title: "La voie locale : capteurs Zigbee et Matter",
+      intro:
+        "C'est l'option la plus locale : composez votre station météo avec des capteurs que Gladys lit directement, sans cloud de fabricant. Ceux-ci sont pris en charge via Zigbee2MQTT ou Matter :",
+      items: [
+        {
+          name: "Capteur de température et d'humidité Aqara",
+          tag: "Meilleur intérieur, Zigbee",
+          text: "Un petit capteur Zigbee abordable qui remonte température, humidité et pression atmosphérique. L'un des appareils que nous recommandons déjà pour Gladys. S'appaire via Zigbee2MQTT.",
+          buyHref: amazonFR("Aqara capteur température humidité"),
+          buyLabel: "Voir sur Amazon →",
+          docHref: "/fr/docs/integrations/zigbee2mqtt/",
+          docLabel: "Appairer du Zigbee",
+        },
+        {
+          name: "SONOFF SNZB-02D",
+          tag: "Intérieur avec écran, Zigbee",
+          text: "Un capteur Zigbee de température et d'humidité avec écran e-ink, pour avoir aussi l'affichage au mur. Fiable et peu cher, s'appaire via Zigbee2MQTT.",
+          buyHref: amazonFR("SONOFF SNZB-02D capteur Zigbee température humidité"),
+          buyLabel: "Voir sur Amazon →",
+        },
+        {
+          name: "OWON THS-317-ET",
+          tag: "Sonde extérieure, Zigbee",
+          text: "Un capteur de température Zigbee avec sonde externe étanche, idéal pour mesurer la température extérieure ou d'un frigo/congélateur. Présent dans le catalogue Zigbee de Gladys.",
+          buyHref: amazonFR("OWON THS-317-ET capteur Zigbee température"),
+          buyLabel: "Voir sur Amazon →",
+        },
+        {
+          name: "Eve Weather",
+          tag: "Matter via Thread",
+          text: "Un capteur extérieur étanche qui mesure température, humidité et pression barométrique. Il parle Thread et Matter, donc Gladys peut le lire en local via l'intégration Matter.",
+          buyHref: amazonFR("Eve Weather Matter Thread"),
+          buyLabel: "Voir sur Amazon →",
+          docHref: "/fr/docs/integrations/matter/",
+          docLabel: "Comment marche Matter",
+        },
+      ],
+      outro:
+        "Pour appairer les capteurs Zigbee, il vous suffit d'une clé Zigbee. Voir notre guide pour choisir la bonne.",
+    },
+    cloud: {
+      title: "La voie station connectée : Netatmo et OpenWeather",
+      intro:
+        "Vous voulez une station toute prête avec anémomètre et pluviomètre, ou des données météo sans aucun matériel ? Elles se connectent aussi à Gladys :",
+      items: [
+        {
+          name: "Station météo Netatmo",
+          tag: "Station complète, vent et pluie",
+          text: "Une station météo connectée complète : modules intérieur et extérieur, avec anémomètre et pluviomètre en option. Elle passe par le cloud Netatmo, et Gladys lit ses valeurs via l'intégration Netatmo. Le choix réaliste si vous voulez le vent et la pluie aujourd'hui.",
+          buyHref: amazonFR("Station météo Netatmo"),
+          buyLabel: "Voir sur Amazon →",
+          docHref: "/fr/docs/integrations/netatmo/",
+          docLabel: "Intégration Netatmo",
+        },
+        {
+          name: "OpenWeather (sans matériel)",
+          tag: "Prévisions gratuites",
+          text: "Si vous voulez simplement les conditions actuelles et les prévisions pour votre localité, l'intégration OpenWeather ramène les données météo dans Gladys gratuitement, sans acheter de capteur. Parfait en complément de vos propres capteurs.",
+          docHref: "/fr/docs/integrations/openweather/",
+          docLabel: "Configurer OpenWeather →",
+        },
+      ],
+      outro:
+        "Les stations cloud sont pratiques et complètes, mais rappelez-vous qu'elles dépendent des serveurs du fabricant. Pour tout ce que vous voulez garder fonctionnel hors ligne, privilégiez les capteurs locaux ci-dessus.",
+    },
+    gladys: {
+      title: "Pourquoi intégrer votre station météo à Gladys",
+      paragraphs: [
+        "Seuls, chaque capteur ou station vit dans sa propre application. Avec Gladys, toutes vos mesures intérieures et extérieures se retrouvent dans un seul tableau de bord local, à côté de tous les autres appareils de la maison, et l'historique reste sur votre propre matériel.",
+        "À partir de là, vous automatisez selon la météo : fermer les stores quand il fait trop chaud, monter le chauffage quand la température extérieure baisse, envoyer une alerte gel avant une nuit froide, ou lancer un ventilateur quand l'humidité intérieure grimpe.",
+      ],
+      link: { label: "Découvrir la domotique locale et open source →", href: "/fr/open-source-home-automation/" },
+    },
+    related: {
+      title: "Aller plus loin",
+      intro:
+        "Ajouter des capteurs météo fait partie de la construction d'une maison connectée locale :",
+      links: [
+        {
+          label: "Connecter des appareils Zigbee à Gladys",
+          href: "/fr/docs/integrations/zigbee2mqtt/",
+          text: "Le guide pas à pas pour appairer des capteurs Zigbee avec Zigbee2MQTT.",
+        },
+        {
+          label: "Quelle clé Zigbee USB choisir",
+          href: "/fr/best-zigbee-dongle/",
+          text: "Quel coordinateur Zigbee acheter pour appairer vos capteurs météo en local.",
+        },
+        {
+          label: "Maison connectée IKEA avec Gladys",
+          href: "/fr/ikea-smart-home/",
+          text: "Pilotez vos appareils IKEA Tradfri et Dirigera en local, via Zigbee2MQTT ou Matter.",
+        },
+        {
+          label: "Netatmo dans Gladys",
+          href: "/fr/docs/integrations/netatmo/",
+          text: "Connecter une station météo Netatmo et lire ses modules dans Gladys.",
+        },
+        {
+          label: "Matériel recommandé",
+          href: "/fr/docs/installation/recommended-hardware/",
+          text: "La liste complète des appareils Zigbee que nous recommandons pour une maison Gladys fiable.",
+        },
+      ],
+    },
+    faqTitle: "Questions fréquentes",
+    cta: {
+      title: "Montez votre station météo locale",
+      text: "Gladys est gratuit, open source, et s'installe en une seule commande Docker. Appairez quelques capteurs et lisez le climat de votre maison en local, avec des automatisations qui y réagissent.",
+      primary: { label: "Commencer", href: "/fr/docs/" },
+      secondary: {
+        label: "Configurer Zigbee2MQTT",
+        href: "/fr/docs/integrations/zigbee2mqtt/",
+      },
+    },
+  },
+};
+
+export const homeWeatherStationFaqEn = [
+  {
+    question: "Can I use a weather station locally with Gladys, without the cloud?",
+    answer:
+      "Yes. The most local option is to build your own station from Zigbee or Matter sensors. Zigbee sensors like the Aqara Temperature and Humidity Sensor or the Sonoff SNZB-02D pair through Zigbee2MQTT, and a Matter sensor like the Eve Weather is read over your network. Gladys reads these directly, with no manufacturer cloud, so they keep working offline.",
+  },
+  {
+    question: "Which weather sensors work with Gladys?",
+    answer:
+      "Any Zigbee temperature, humidity or pressure sensor supported by Zigbee2MQTT works, including Aqara, Sonoff and OWON models, as does any Matter temperature or humidity sensor such as the Eve Weather. For a full station with wind and rain, the Netatmo Weather Station connects through its integration.",
+  },
+  {
+    question: "Does Gladys work with the Netatmo Weather Station?",
+    answer:
+      "Yes. Gladys has a Netatmo integration that reads your indoor and outdoor modules, including the optional wind and rain gauges. Note that Netatmo relies on its cloud, so unlike local Zigbee or Matter sensors it needs an internet connection to work.",
+  },
+  {
+    question: "Can I get weather data in Gladys without buying a sensor?",
+    answer:
+      "Yes. The OpenWeather integration brings current conditions and forecasts for your location into Gladys for free, with no hardware. It is a great complement to your own indoor and outdoor sensors.",
+  },
+  {
+    question: "Can I automate my home based on the weather?",
+    answer:
+      "Yes, that is the main reason to bring weather data into Gladys. You can close the blinds when it gets too hot, boost the heating when the outdoor temperature drops, send a frost alert before a cold night, or start a fan when indoor humidity rises.",
+  },
+];
+
+export const homeWeatherStationFaqFr = [
+  {
+    question: "Puis-je utiliser une station météo en local avec Gladys, sans le cloud ?",
+    answer:
+      "Oui. L'option la plus locale est de composer votre propre station avec des capteurs Zigbee ou Matter. Des capteurs Zigbee comme le capteur de température et d'humidité Aqara ou le Sonoff SNZB-02D s'appairent via Zigbee2MQTT, et un capteur Matter comme l'Eve Weather est lu sur votre réseau. Gladys les lit directement, sans cloud de fabricant, donc ils continuent de fonctionner hors ligne.",
+  },
+  {
+    question: "Quels capteurs météo fonctionnent avec Gladys ?",
+    answer:
+      "Tout capteur Zigbee de température, d'humidité ou de pression pris en charge par Zigbee2MQTT fonctionne, dont les modèles Aqara, Sonoff et OWON, tout comme n'importe quel capteur Matter de température ou d'humidité comme l'Eve Weather. Pour une station complète avec vent et pluie, la station Netatmo se connecte via son intégration.",
+  },
+  {
+    question: "Gladys fonctionne-t-il avec la station météo Netatmo ?",
+    answer:
+      "Oui. Gladys dispose d'une intégration Netatmo qui lit vos modules intérieur et extérieur, y compris l'anémomètre et le pluviomètre en option. Notez que Netatmo dépend de son cloud : contrairement aux capteurs Zigbee ou Matter locaux, il lui faut une connexion internet pour fonctionner.",
+  },
+  {
+    question: "Puis-je avoir des données météo dans Gladys sans acheter de capteur ?",
+    answer:
+      "Oui. L'intégration OpenWeather ramène gratuitement les conditions actuelles et les prévisions de votre localité dans Gladys, sans matériel. C'est un excellent complément à vos propres capteurs intérieurs et extérieurs.",
+  },
+  {
+    question: "Puis-je automatiser ma maison en fonction de la météo ?",
+    answer:
+      "Oui, c'est la principale raison d'intégrer les données météo à Gladys. Vous pouvez fermer les stores quand il fait trop chaud, monter le chauffage quand la température extérieure baisse, envoyer une alerte gel avant une nuit froide, ou lancer un ventilateur quand l'humidité intérieure grimpe.",
+  },
+];
+
+export default homeWeatherStationContent;

--- a/src/data/ikeaSmartHomeData.js
+++ b/src/data/ikeaSmartHomeData.js
@@ -1,0 +1,283 @@
+// Content for the "IKEA smart home / Dirigera" landing page.
+// Targets the on-theme, qualified "dirigera", "ikea smart home", "tradfri
+// without hub", "ikea zigbee" search cluster (Search Console: ~33 impressions
+// at position ~10). IKEA device owners looking for a local brain are a great
+// fit for Gladys. The page explains the two ways to control IKEA devices with
+// Gladys (Zigbee2MQTT directly, or Matter through the DIRIGERA hub) and links
+// out to the existing integration docs for the how-to.
+
+const ikeaSmartHomeContent = {
+  en: {
+    meta: {
+      title: "IKEA smart home with Gladys: Dirigera, Tradfri and Matter",
+      description:
+        "Control your IKEA smart home devices (Tradfri bulbs, sensors, blinds) locally with Gladys Assistant, with or without the Dirigera hub, over Zigbee2MQTT or Matter.",
+    },
+    hero: {
+      title: "Your IKEA smart home, running locally with Gladys",
+      subtitle:
+        "Control your IKEA Tradfri and Dirigera devices from one local, open-source dashboard, with real automations and no cloud.",
+      intro: [
+        "IKEA makes some of the best value smart home hardware out there: Tradfri bulbs, motion and door sensors, smart plugs, remotes and Fyrtur blinds. On their own, they rely on the IKEA app and the Dirigera (or older Tradfri) gateway.",
+        "With Gladys Assistant you can bring all of these devices into a single local dashboard, mix them freely with other brands, and build automations that actually react to your home. There are two ways to connect IKEA to Gladys, and you can even skip the IKEA hub entirely.",
+      ],
+      primaryCta: { label: "Connect Zigbee to Gladys", href: "/docs/integrations/zigbee2mqtt/" },
+      secondaryCta: {
+        label: "Get started with Gladys →",
+        href: "/docs/",
+      },
+    },
+    methods: {
+      title: "Two ways to use IKEA devices with Gladys",
+      intro:
+        "IKEA smart devices are Zigbee devices, so you have two options depending on whether you want to keep the IKEA hub or not:",
+      items: [
+        {
+          name: "1. Directly over Zigbee2MQTT (no IKEA hub)",
+          tag: "Recommended, fully local",
+          text: "IKEA Tradfri devices are standard Zigbee, so you can pair them straight to Gladys with a Zigbee USB dongle through Zigbee2MQTT, no Dirigera or Tradfri gateway required. This is the most local option: your bulbs, sensors and remotes talk directly to Gladys, and you can mix them with Philips Hue, Aqara, Sonoff and any other Zigbee brand on the same network.",
+          link: { href: "/docs/integrations/zigbee2mqtt/", label: "Set up Zigbee2MQTT →" },
+        },
+        {
+          name: "2. Through the Dirigera hub over Matter",
+          tag: "Keep your IKEA gateway",
+          text: "The newer IKEA DIRIGERA hub acts as a Matter bridge. If you want to keep managing your devices in the IKEA app, you can expose them to Gladys over Matter: the hub is already on your Wi-Fi or Ethernet, so Gladys can control the connected devices directly, locally, without the IKEA cloud.",
+          link: { href: "/docs/integrations/matter/", label: "Read the Matter guide →" },
+        },
+      ],
+      outro:
+        "Not sure which to pick? If you want the most local, brand-agnostic setup, go with Zigbee2MQTT and a dongle. If you already own a Dirigera hub and like the IKEA app, the Matter route is the quickest.",
+    },
+    devices: {
+      title: "Which IKEA devices work with Gladys",
+      intro:
+        "Paired over Zigbee2MQTT, the vast majority of the IKEA Tradfri range works with Gladys, including:",
+      points: [
+        "Tradfri LED bulbs (E27, E14, GU10), white spectrum and colour",
+        "Smart plugs (Tradfri control outlet)",
+        "Motion sensors and door/window sensors",
+        "Tradfri and Styrbar remotes and dimmers",
+        "Fyrtur and Kadrilj smart blinds",
+        "Vindstyrka and other Zigbee air quality sensors",
+      ],
+      outro:
+        "A Zigbee USB dongle is all you need to pair them. See our guide to picking the right one.",
+    },
+    gladys: {
+      title: "Why run your IKEA devices through Gladys",
+      paragraphs: [
+        "The IKEA app is fine for basic control, but it keeps your devices in a silo and leans on the cloud. With Gladys, your IKEA lights and sensors live in the same place as every other device in your home, and everything runs locally on your own hardware.",
+        "From there you can build real automations: turn on the Tradfri lights when an IKEA motion sensor fires, close the Fyrtur blinds at sunset, or trigger a whole scene from a Styrbar remote, combining IKEA gear with any other brand you own.",
+      ],
+      link: { label: "Discover local, open-source home automation →", href: "/open-source-home-automation/" },
+    },
+    related: {
+      title: "Go further",
+      intro:
+        "Connecting your IKEA devices is part of building a local smart home:",
+      links: [
+        {
+          label: "Connect Zigbee devices to Gladys",
+          href: "/docs/integrations/zigbee2mqtt/",
+          text: "The step-by-step guide to pairing Zigbee devices, including IKEA Tradfri, with Zigbee2MQTT.",
+        },
+        {
+          label: "Best Zigbee USB dongle",
+          href: "/best-zigbee-dongle/",
+          text: "Which Zigbee coordinator to buy to pair your IKEA and other Zigbee devices locally.",
+        },
+        {
+          label: "Home weather station",
+          href: "/home-weather-station/",
+          text: "Measure temperature and humidity locally with Zigbee and Matter sensors.",
+        },
+        {
+          label: "Matter in Gladys",
+          href: "/docs/integrations/matter/",
+          text: "How to use Matter bridges like the IKEA Dirigera hub with Gladys.",
+        },
+        {
+          label: "Build a local smart home",
+          href: "/local-smart-home/",
+          text: "Why local-first matters and how to build a home that runs without the cloud.",
+        },
+      ],
+    },
+    faqTitle: "Frequently asked questions",
+    cta: {
+      title: "Bring your IKEA devices home",
+      text: "Gladys is free, open-source, and installs in a single Docker command. Pair your Tradfri devices locally and automate your whole home, IKEA and beyond.",
+      primary: { label: "Get started", href: "/docs/" },
+      secondary: {
+        label: "Set up Zigbee2MQTT",
+        href: "/docs/integrations/zigbee2mqtt/",
+      },
+    },
+  },
+
+  fr: {
+    meta: {
+      title: "Maison connectée IKEA avec Gladys : Dirigera, Tradfri et Matter",
+      description:
+        "Pilotez vos appareils connectés IKEA (ampoules Tradfri, capteurs, stores) en local avec Gladys Assistant, avec ou sans le hub Dirigera, via Zigbee2MQTT ou Matter.",
+    },
+    hero: {
+      title: "Votre maison connectée IKEA, en local avec Gladys",
+      subtitle:
+        "Pilotez vos appareils IKEA Tradfri et Dirigera depuis un seul tableau de bord local et open source, avec de vraies automatisations et sans cloud.",
+      intro: [
+        "IKEA propose parmi le meilleur matériel domotique en rapport qualité/prix : ampoules Tradfri, détecteurs de mouvement et d'ouverture, prises connectées, télécommandes et stores Fyrtur. Seuls, ces appareils dépendent de l'application IKEA et de la passerelle Dirigera (ou de l'ancienne Tradfri).",
+        "Avec Gladys Assistant, vous réunissez tous ces appareils dans un seul tableau de bord local, vous les mélangez librement avec d'autres marques, et vous créez des automatisations qui réagissent vraiment à votre maison. Il y a deux façons de connecter IKEA à Gladys, et vous pouvez même vous passer totalement du hub IKEA.",
+      ],
+      primaryCta: { label: "Connecter le Zigbee à Gladys", href: "/fr/docs/integrations/zigbee2mqtt/" },
+      secondaryCta: {
+        label: "Commencer avec Gladys →",
+        href: "/fr/docs/",
+      },
+    },
+    methods: {
+      title: "Deux façons d'utiliser vos appareils IKEA avec Gladys",
+      intro:
+        "Les appareils connectés IKEA sont des appareils Zigbee : vous avez donc deux options selon que vous souhaitez garder le hub IKEA ou non :",
+      items: [
+        {
+          name: "1. Directement en Zigbee2MQTT (sans hub IKEA)",
+          tag: "Recommandé, 100 % local",
+          text: "Les appareils IKEA Tradfri sont du Zigbee standard : vous pouvez donc les appairer directement à Gladys avec une clé Zigbee USB via Zigbee2MQTT, sans passerelle Dirigera ni Tradfri. C'est l'option la plus locale : vos ampoules, capteurs et télécommandes dialoguent directement avec Gladys, et vous pouvez les mélanger avec du Philips Hue, de l'Aqara, du Sonoff et n'importe quelle autre marque Zigbee sur le même réseau.",
+          link: { href: "/fr/docs/integrations/zigbee2mqtt/", label: "Configurer Zigbee2MQTT →" },
+        },
+        {
+          name: "2. Via le hub Dirigera en Matter",
+          tag: "Garder sa passerelle IKEA",
+          text: "Le nouveau hub IKEA DIRIGERA agit comme un pont Matter. Si vous voulez continuer à gérer vos appareils dans l'application IKEA, vous pouvez les exposer à Gladys en Matter : le hub est déjà sur votre Wi-Fi ou votre Ethernet, donc Gladys peut piloter les appareils connectés directement, en local, sans le cloud IKEA.",
+          link: { href: "/fr/docs/integrations/matter/", label: "Lire le guide Matter →" },
+        },
+      ],
+      outro:
+        "Vous hésitez ? Pour l'installation la plus locale et multimarque, choisissez Zigbee2MQTT et une clé. Si vous possédez déjà un hub Dirigera et appréciez l'application IKEA, la voie Matter est la plus rapide.",
+    },
+    devices: {
+      title: "Quels appareils IKEA fonctionnent avec Gladys",
+      intro:
+        "Appairée en Zigbee2MQTT, la grande majorité de la gamme IKEA Tradfri fonctionne avec Gladys, notamment :",
+      points: [
+        "Les ampoules LED Tradfri (E27, E14, GU10), spectre blanc et couleur",
+        "Les prises connectées (prise Tradfri)",
+        "Les détecteurs de mouvement et d'ouverture de porte/fenêtre",
+        "Les télécommandes et variateurs Tradfri et Styrbar",
+        "Les stores connectés Fyrtur et Kadrilj",
+        "Le Vindstyrka et autres capteurs de qualité de l'air Zigbee",
+      ],
+      outro:
+        "Une clé Zigbee USB suffit pour les appairer. Consultez notre guide pour choisir la bonne.",
+    },
+    gladys: {
+      title: "Pourquoi piloter vos appareils IKEA avec Gladys",
+      paragraphs: [
+        "L'application IKEA convient pour un contrôle basique, mais elle enferme vos appareils dans un silo et s'appuie sur le cloud. Avec Gladys, vos lumières et capteurs IKEA se retrouvent au même endroit que tous les autres appareils de votre maison, et tout fonctionne en local sur votre propre matériel.",
+        "À partir de là, vous créez de vraies automatisations : allumer les lumières Tradfri quand un détecteur de mouvement IKEA se déclenche, fermer les stores Fyrtur au coucher du soleil, ou lancer une scène complète depuis une télécommande Styrbar, en combinant le matériel IKEA avec n'importe quelle autre marque.",
+      ],
+      link: { label: "Découvrir la domotique locale et open source →", href: "/fr/open-source-home-automation/" },
+    },
+    related: {
+      title: "Aller plus loin",
+      intro:
+        "Connecter vos appareils IKEA fait partie de la construction d'une maison connectée locale :",
+      links: [
+        {
+          label: "Connecter des appareils Zigbee à Gladys",
+          href: "/fr/docs/integrations/zigbee2mqtt/",
+          text: "Le guide pas à pas pour appairer des appareils Zigbee, dont les IKEA Tradfri, avec Zigbee2MQTT.",
+        },
+        {
+          label: "Quelle clé Zigbee USB choisir",
+          href: "/fr/best-zigbee-dongle/",
+          text: "Quel coordinateur Zigbee acheter pour appairer vos appareils IKEA et autres en local.",
+        },
+        {
+          label: "Station météo maison",
+          href: "/fr/home-weather-station/",
+          text: "Mesurez température et humidité en local avec des capteurs Zigbee et Matter.",
+        },
+        {
+          label: "Matter dans Gladys",
+          href: "/fr/docs/integrations/matter/",
+          text: "Comment utiliser les ponts Matter comme le hub IKEA Dirigera avec Gladys.",
+        },
+        {
+          label: "Construire une maison connectée locale",
+          href: "/fr/local-smart-home/",
+          text: "Pourquoi le local d'abord change tout, et comment bâtir une maison qui tourne sans cloud.",
+        },
+      ],
+    },
+    faqTitle: "Questions fréquentes",
+    cta: {
+      title: "Ramenez vos appareils IKEA à la maison",
+      text: "Gladys est gratuit, open source, et s'installe en une seule commande Docker. Appairez vos appareils Tradfri en local et automatisez toute votre maison, IKEA et au-delà.",
+      primary: { label: "Commencer", href: "/fr/docs/" },
+      secondary: {
+        label: "Configurer Zigbee2MQTT",
+        href: "/fr/docs/integrations/zigbee2mqtt/",
+      },
+    },
+  },
+};
+
+export const ikeaSmartHomeFaqEn = [
+  {
+    question: "Can I use IKEA smart home devices without the Dirigera hub?",
+    answer:
+      "Yes. IKEA Tradfri devices are standard Zigbee, so you can pair them directly to Gladys with a Zigbee USB dongle through Zigbee2MQTT, without any Dirigera or Tradfri gateway. Your bulbs, sensors and remotes then talk straight to Gladys, fully locally.",
+  },
+  {
+    question: "Does Gladys work with the IKEA Dirigera hub?",
+    answer:
+      "Yes. The Dirigera hub acts as a Matter bridge, so you can expose the devices connected to it to Gladys over Matter. The hub is already on your local network, which lets Gladys control them locally without the IKEA cloud. You can also skip the hub entirely and pair the devices directly over Zigbee2MQTT.",
+  },
+  {
+    question: "Which IKEA devices are compatible with Gladys?",
+    answer:
+      "Paired over Zigbee2MQTT, most of the IKEA Tradfri range works: LED bulbs (E27, E14, GU10), smart plugs, motion and door sensors, Styrbar and Tradfri remotes, and Fyrtur or Kadrilj blinds. Anything that speaks standard Zigbee can be added.",
+  },
+  {
+    question: "Do I still need the IKEA app?",
+    answer:
+      "No. If you pair your devices directly over Zigbee2MQTT, you control everything from Gladys and don't need the IKEA app at all. If you keep the Dirigera hub and use Matter, you can still manage devices in the IKEA app while also controlling them in Gladys.",
+  },
+  {
+    question: "Can I mix IKEA devices with other brands?",
+    answer:
+      "Yes, and that is one of the main reasons to use Gladys. Over Zigbee2MQTT you can freely combine IKEA Tradfri with Philips Hue, Aqara, Sonoff and other Zigbee brands, all on the same network and in the same automations.",
+  },
+];
+
+export const ikeaSmartHomeFaqFr = [
+  {
+    question: "Puis-je utiliser des appareils connectés IKEA sans le hub Dirigera ?",
+    answer:
+      "Oui. Les appareils IKEA Tradfri sont du Zigbee standard : vous pouvez donc les appairer directement à Gladys avec une clé Zigbee USB via Zigbee2MQTT, sans passerelle Dirigera ni Tradfri. Vos ampoules, capteurs et télécommandes dialoguent alors directement avec Gladys, en local.",
+  },
+  {
+    question: "Gladys fonctionne-t-il avec le hub IKEA Dirigera ?",
+    answer:
+      "Oui. Le hub Dirigera agit comme un pont Matter : vous pouvez donc exposer à Gladys les appareils qui y sont connectés, en Matter. Le hub étant déjà sur votre réseau local, Gladys les pilote en local sans le cloud IKEA. Vous pouvez aussi vous passer totalement du hub et appairer les appareils directement en Zigbee2MQTT.",
+  },
+  {
+    question: "Quels appareils IKEA sont compatibles avec Gladys ?",
+    answer:
+      "Appairée en Zigbee2MQTT, la plupart de la gamme IKEA Tradfri fonctionne : ampoules LED (E27, E14, GU10), prises connectées, détecteurs de mouvement et d'ouverture, télécommandes Styrbar et Tradfri, et stores Fyrtur ou Kadrilj. Tout ce qui parle Zigbee standard peut être ajouté.",
+  },
+  {
+    question: "Ai-je encore besoin de l'application IKEA ?",
+    answer:
+      "Non. Si vous appairez vos appareils directement en Zigbee2MQTT, vous pilotez tout depuis Gladys et n'avez pas besoin de l'application IKEA. Si vous gardez le hub Dirigera et utilisez Matter, vous pouvez continuer à gérer vos appareils dans l'application IKEA tout en les pilotant dans Gladys.",
+  },
+  {
+    question: "Puis-je mélanger des appareils IKEA avec d'autres marques ?",
+    answer:
+      "Oui, et c'est l'une des principales raisons d'utiliser Gladys. En Zigbee2MQTT, vous combinez librement l'IKEA Tradfri avec du Philips Hue, de l'Aqara, du Sonoff et d'autres marques Zigbee, sur le même réseau et dans les mêmes automatisations.",
+  },
+];
+
+export default ikeaSmartHomeContent;

--- a/src/data/structuredData.js
+++ b/src/data/structuredData.js
@@ -29,6 +29,14 @@ import {
   bestZigbeeDongleFaqEn,
   bestZigbeeDongleFaqFr,
 } from "./bestZigbeeDongleData";
+import {
+  ikeaSmartHomeFaqEn,
+  ikeaSmartHomeFaqFr,
+} from "./ikeaSmartHomeData";
+import {
+  homeWeatherStationFaqEn,
+  homeWeatherStationFaqFr,
+} from "./homeWeatherStationData";
 import { edfTempoFaqEn, edfTempoFaqFr } from "./edfTempoData";
 import { protocolsFaqEn, protocolsFaqFr } from "./protocolsComparisonData";
 import { energyFaqEn, energyFaqFr } from "./energyMonitoringData";
@@ -669,6 +677,92 @@ export function getOpenSourceHomeAutomationPageSchema(lang) {
         lang === "fr"
           ? openSourceHomeAutomationFaqFr
           : openSourceHomeAutomationFaqEn,
+        pageUrl
+      ),
+    ],
+  };
+}
+
+export function getIkeaSmartHomePageSchema(lang) {
+  const prefix = lang === "fr" ? "/fr" : "";
+  const pageUrl = `${SITE_URL}${prefix}/ikea-smart-home/`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      getOrganizationNode(),
+      getWebSiteNode(lang),
+      {
+        "@type": "Article",
+        "@id": `${pageUrl}#article`,
+        headline:
+          lang === "fr"
+            ? "Maison connectée IKEA avec Gladys : Dirigera, Tradfri et Matter"
+            : "IKEA smart home with Gladys: Dirigera, Tradfri and Matter",
+        description:
+          lang === "fr"
+            ? "Pilotez vos appareils connectés IKEA (ampoules Tradfri, capteurs, stores) en local avec Gladys Assistant, avec ou sans le hub Dirigera, via Zigbee2MQTT ou Matter."
+            : "Control your IKEA smart home devices (Tradfri bulbs, sensors, blinds) locally with Gladys Assistant, with or without the Dirigera hub, over Zigbee2MQTT or Matter.",
+        url: pageUrl,
+        inLanguage: lang === "fr" ? "fr" : "en",
+        isPartOf: { "@id": `${SITE_URL}/#website` },
+        author: {
+          "@type": "Person",
+          name: "Pierre-Gilles Leymarie",
+        },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+        about: [
+          { "@type": "Thing", name: "IKEA smart home" },
+          { "@type": "Thing", name: "IKEA Dirigera" },
+          { "@type": "Thing", name: "IKEA Tradfri" },
+          { "@type": "SoftwareApplication", name: "Gladys Assistant" },
+        ],
+      },
+      toFaqPage(
+        lang === "fr" ? ikeaSmartHomeFaqFr : ikeaSmartHomeFaqEn,
+        pageUrl
+      ),
+    ],
+  };
+}
+
+export function getHomeWeatherStationPageSchema(lang) {
+  const prefix = lang === "fr" ? "/fr" : "";
+  const pageUrl = `${SITE_URL}${prefix}/home-weather-station/`;
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      getOrganizationNode(),
+      getWebSiteNode(lang),
+      {
+        "@type": "Article",
+        "@id": `${pageUrl}#article`,
+        headline:
+          lang === "fr"
+            ? "Quelle station météo connectée pour une maison connectée (Zigbee, Matter, Netatmo)"
+            : "Best home weather station for a smart home (Zigbee, Matter, Netatmo)",
+        description:
+          lang === "fr"
+            ? "Guide des capteurs météo sans fil pour Gladys Assistant : capteurs Zigbee et Matter locaux, station Netatmo, et OpenWeather pour les prévisions."
+            : "A guide to wireless weather sensors for Gladys Assistant: local Zigbee and Matter sensors, the Netatmo station, and OpenWeather for forecast data.",
+        url: pageUrl,
+        inLanguage: lang === "fr" ? "fr" : "en",
+        isPartOf: { "@id": `${SITE_URL}/#website` },
+        author: {
+          "@type": "Person",
+          name: "Pierre-Gilles Leymarie",
+        },
+        publisher: { "@id": `${SITE_URL}/#organization` },
+        about: [
+          { "@type": "Thing", name: "Home weather station" },
+          { "@type": "Thing", name: "Weather sensor" },
+          { "@type": "Thing", name: "Zigbee" },
+          { "@type": "SoftwareApplication", name: "Gladys Assistant" },
+        ],
+      },
+      toFaqPage(
+        lang === "fr" ? homeWeatherStationFaqFr : homeWeatherStationFaqEn,
         pageUrl
       ),
     ],

--- a/src/pages/home-weather-station.js
+++ b/src/pages/home-weather-station.js
@@ -1,0 +1,191 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+import JsonLd from "../components/seo/JsonLd";
+import { getHomeWeatherStationPageSchema } from "../data/structuredData";
+import homeWeatherStationContent, {
+  homeWeatherStationFaqEn,
+  homeWeatherStationFaqFr,
+} from "../data/homeWeatherStationData";
+
+import styles from "./comparison.module.css";
+
+function ProductCard({ name, tag, text, buyHref, buyLabel, docHref, docLabel }) {
+  return (
+    <div className={styles.card}>
+      {tag && <span className={styles.cardTag}>{tag}</span>}
+      <div className={styles.cardTitle}>{name}</div>
+      <p>{text}</p>
+      {buyHref && (
+        <p className={styles.compareLink}>
+          <a href={buyHref} target="_blank" rel="noopener noreferrer sponsored">
+            {buyLabel}
+          </a>
+        </p>
+      )}
+      {docHref && (
+        <p className={styles.compareLink}>
+          <Link to={docHref}>{docLabel}</Link>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function LinkCard({ label, href, text }) {
+  return (
+    <Link to={href} className={styles.card}>
+      <div className={styles.cardTitle}>{label} →</div>
+      <p>{text}</p>
+    </Link>
+  );
+}
+
+function ProductSection({ id, titleId, section }) {
+  return (
+    <section className={styles.section} id={id} aria-labelledby={titleId}>
+      <h2 id={titleId} className={styles.sectionTitle}>
+        {section.title}
+      </h2>
+      <p className={styles.blockIntro}>{section.intro}</p>
+      <div className={styles.cardGrid}>
+        {section.items.map((item, i) => (
+          <ProductCard key={i} {...item} />
+        ))}
+      </div>
+      <p className={styles.blockOutro}>{section.outro}</p>
+    </section>
+  );
+}
+
+function WeatherContent({ content, faq }) {
+  return (
+    <main className={styles.main}>
+      <div className={`container ${styles.container}`}>
+        {/* HERO */}
+        <header className={styles.hero}>
+          <h1 className={styles.heroTitle}>{content.hero.title}</h1>
+          <p className={styles.heroSubtitle}>{content.hero.subtitle}</p>
+          <div className={styles.intro}>
+            {content.hero.intro.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+          </div>
+          <div className={styles.ctaButtons}>
+            <a
+              className="button button--primary button--lg"
+              href={content.hero.primaryCta.href}
+            >
+              {content.hero.primaryCta.label}
+            </a>
+            <Link
+              className="button button--secondary button--lg"
+              to={content.hero.secondaryCta.href}
+            >
+              {content.hero.secondaryCta.label}
+            </Link>
+          </div>
+        </header>
+
+        {/* WHAT TO LOOK FOR */}
+        <section className={styles.section} aria-labelledby="criteria-title">
+          <h2 id="criteria-title" className={styles.sectionTitle}>
+            {content.criteria.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.criteria.intro}</p>
+          <ul className={styles.bulletList}>
+            {content.criteria.points.map((point, i) => (
+              <li key={i}>{point}</li>
+            ))}
+          </ul>
+          <p className={styles.blockOutro}>{content.criteria.outro}</p>
+        </section>
+
+        {/* LOCAL SENSORS */}
+        <ProductSection id="local" titleId="local-title" section={content.local} />
+
+        {/* CONNECTED STATIONS */}
+        <ProductSection id="cloud" titleId="cloud-title" section={content.cloud} />
+
+        {/* WHY GLADYS */}
+        <section className={styles.section} aria-labelledby="gladys-title">
+          <h2 id="gladys-title" className={styles.sectionTitle}>
+            {content.gladys.title}
+          </h2>
+          <div className={styles.whyNotBoth}>
+            {content.gladys.paragraphs.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+            <p className={styles.compareLink}>
+              <Link to={content.gladys.link.href}>{content.gladys.link.label}</Link>
+            </p>
+          </div>
+        </section>
+
+        {/* RELATED / INTERNAL MESH */}
+        <section className={styles.section} aria-labelledby="related-title">
+          <h2 id="related-title" className={styles.sectionTitle}>
+            {content.related.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.related.intro}</p>
+          <div className={styles.cardGrid}>
+            {content.related.links.map((link, i) => (
+              <LinkCard key={i} {...link} />
+            ))}
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className={styles.section} aria-labelledby="faq-title">
+          <h2 id="faq-title" className={styles.sectionTitle}>
+            {content.faqTitle}
+          </h2>
+          {faq.map((item, i) => (
+            <div key={i} className={styles.faqItem}>
+              <h3 className={styles.faqQuestion}>{item.question}</h3>
+              <p className={styles.faqAnswer}>{item.answer}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* CTA */}
+        <section className={styles.cta} aria-labelledby="cta-title">
+          <h2 id="cta-title" className={styles.ctaTitle}>
+            {content.cta.title}
+          </h2>
+          <p className={styles.ctaText}>{content.cta.text}</p>
+          <div className={styles.ctaButtons}>
+            <Link
+              className="button button--primary button--lg"
+              to={content.cta.primary.href}
+            >
+              {content.cta.primary.label}
+            </Link>
+            <Link
+              className="button button--secondary button--lg"
+              to={content.cta.secondary.href}
+            >
+              {content.cta.secondary.label}
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default function HomeWeatherStationPage() {
+  const { i18n } = useDocusaurusContext();
+  const lang = i18n.currentLocale === "fr" ? "fr" : "en";
+  const content = homeWeatherStationContent[lang];
+  const faq = lang === "fr" ? homeWeatherStationFaqFr : homeWeatherStationFaqEn;
+
+  return (
+    <Layout title={content.meta.title} description={content.meta.description}>
+      <JsonLd data={getHomeWeatherStationPageSchema(lang)} />
+      <WeatherContent content={content} faq={faq} />
+    </Layout>
+  );
+}

--- a/src/pages/ikea-smart-home.js
+++ b/src/pages/ikea-smart-home.js
@@ -1,0 +1,175 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import Link from "@docusaurus/Link";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+import JsonLd from "../components/seo/JsonLd";
+import { getIkeaSmartHomePageSchema } from "../data/structuredData";
+import ikeaSmartHomeContent, {
+  ikeaSmartHomeFaqEn,
+  ikeaSmartHomeFaqFr,
+} from "../data/ikeaSmartHomeData";
+
+import styles from "./comparison.module.css";
+
+function MethodCard({ name, tag, text, link }) {
+  return (
+    <div className={styles.card}>
+      {tag && <span className={styles.cardTag}>{tag}</span>}
+      <div className={styles.cardTitle}>{name}</div>
+      <p>{text}</p>
+      {link && (
+        <p className={styles.compareLink}>
+          <Link to={link.href}>{link.label}</Link>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function LinkCard({ label, href, text }) {
+  return (
+    <Link to={href} className={styles.card}>
+      <div className={styles.cardTitle}>{label} →</div>
+      <p>{text}</p>
+    </Link>
+  );
+}
+
+function IkeaContent({ content, faq }) {
+  return (
+    <main className={styles.main}>
+      <div className={`container ${styles.container}`}>
+        {/* HERO */}
+        <header className={styles.hero}>
+          <h1 className={styles.heroTitle}>{content.hero.title}</h1>
+          <p className={styles.heroSubtitle}>{content.hero.subtitle}</p>
+          <div className={styles.intro}>
+            {content.hero.intro.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+          </div>
+          <div className={styles.ctaButtons}>
+            <Link
+              className="button button--primary button--lg"
+              to={content.hero.primaryCta.href}
+            >
+              {content.hero.primaryCta.label}
+            </Link>
+            <Link
+              className="button button--secondary button--lg"
+              to={content.hero.secondaryCta.href}
+            >
+              {content.hero.secondaryCta.label}
+            </Link>
+          </div>
+        </header>
+
+        {/* TWO METHODS */}
+        <section className={styles.section} aria-labelledby="methods-title">
+          <h2 id="methods-title" className={styles.sectionTitle}>
+            {content.methods.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.methods.intro}</p>
+          <div className={styles.cardGrid}>
+            {content.methods.items.map((item, i) => (
+              <MethodCard key={i} {...item} />
+            ))}
+          </div>
+          <p className={styles.blockOutro}>{content.methods.outro}</p>
+        </section>
+
+        {/* COMPATIBLE DEVICES */}
+        <section className={styles.section} aria-labelledby="devices-title">
+          <h2 id="devices-title" className={styles.sectionTitle}>
+            {content.devices.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.devices.intro}</p>
+          <ul className={styles.bulletList}>
+            {content.devices.points.map((point, i) => (
+              <li key={i}>{point}</li>
+            ))}
+          </ul>
+          <p className={styles.blockOutro}>{content.devices.outro}</p>
+        </section>
+
+        {/* WHY GLADYS */}
+        <section className={styles.section} aria-labelledby="gladys-title">
+          <h2 id="gladys-title" className={styles.sectionTitle}>
+            {content.gladys.title}
+          </h2>
+          <div className={styles.whyNotBoth}>
+            {content.gladys.paragraphs.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+            <p className={styles.compareLink}>
+              <Link to={content.gladys.link.href}>{content.gladys.link.label}</Link>
+            </p>
+          </div>
+        </section>
+
+        {/* RELATED / INTERNAL MESH */}
+        <section className={styles.section} aria-labelledby="related-title">
+          <h2 id="related-title" className={styles.sectionTitle}>
+            {content.related.title}
+          </h2>
+          <p className={styles.blockIntro}>{content.related.intro}</p>
+          <div className={styles.cardGrid}>
+            {content.related.links.map((link, i) => (
+              <LinkCard key={i} {...link} />
+            ))}
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className={styles.section} aria-labelledby="faq-title">
+          <h2 id="faq-title" className={styles.sectionTitle}>
+            {content.faqTitle}
+          </h2>
+          {faq.map((item, i) => (
+            <div key={i} className={styles.faqItem}>
+              <h3 className={styles.faqQuestion}>{item.question}</h3>
+              <p className={styles.faqAnswer}>{item.answer}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* CTA */}
+        <section className={styles.cta} aria-labelledby="cta-title">
+          <h2 id="cta-title" className={styles.ctaTitle}>
+            {content.cta.title}
+          </h2>
+          <p className={styles.ctaText}>{content.cta.text}</p>
+          <div className={styles.ctaButtons}>
+            <Link
+              className="button button--primary button--lg"
+              to={content.cta.primary.href}
+            >
+              {content.cta.primary.label}
+            </Link>
+            <Link
+              className="button button--secondary button--lg"
+              to={content.cta.secondary.href}
+            >
+              {content.cta.secondary.label}
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default function IkeaSmartHomePage() {
+  const { i18n } = useDocusaurusContext();
+  const lang = i18n.currentLocale === "fr" ? "fr" : "en";
+  const content = ikeaSmartHomeContent[lang];
+  const faq = lang === "fr" ? ikeaSmartHomeFaqFr : ikeaSmartHomeFaqEn;
+
+  return (
+    <Layout title={content.meta.title} description={content.meta.description}>
+      <JsonLd data={getIkeaSmartHomePageSchema(lang)} />
+      <IkeaContent content={content} faq={faq} />
+    </Layout>
+  );
+}


### PR DESCRIPTION
Suite de l'effort SEO/GEO, guidé par l'export Search Console du 09/07/2026. Trois clusters domotique, un commit chacun.

## 1. Docs Philips Hue, Caméra, Reolink

Les requêtes `philips hue integration` et `reolink rtsp url` tombaient sur des docs trop maigres.

- **`philips-hue.md`** : titre/description/keywords SEO, intro informationnelle sur le pilotage local du bridge en Zigbee, section « ce qu'il vous faut », FAQ 5 questions + schema `FAQPage`.
- **`camera.md`** : même traitement, mais le titre et l'intention restent **volontairement toute marque** (n'importe quelle caméra RTSP ou HTTP). Un `:::tip` renvoie vers le nouveau guide Reolink.
- **`reolink.md`** (nouveau) : le format exact de l'URL RTSP, comment activer le RTSP sur la caméra, comment tester dans VLC, FAQ + `FAQPage`.

Les docs ne pointent que vers d'autres docs, jamais vers les landing pages : l'entonnoir va Google → landing → doc, pas l'inverse.

## 2. Landing pages `/ikea-smart-home` et `/home-weather-station`

EN + FR, chacune avec schema `Article` + `FAQPage`.

- **`/ikea-smart-home`** : les deux façons d'utiliser du matériel IKEA avec Gladys, soit directement en Zigbee2MQTT sans hub IKEA (recommandé, 100 % local), soit via le hub Dirigera qui fait pont Matter. Liste les appareils Tradfri qui marchent réellement.
- **`/home-weather-station`** : construire une station météo à partir de matériel réellement supporté par Gladys. Capteurs Zigbee et Matter locaux d'abord, Netatmo et OpenWeather comme options cloud, plutôt que de prétendre que le local est la seule réponse.

Les deux pages sont cross-linkées depuis `/best-zigbee-dongle` et entre elles, pour ne pas les laisser orphelines puisque les docs ne remontent pas vers les landing pages.

## 3. Page alarme DIY repositionnée face aux alarmes télésurveillées

Le cluster « alternative à Homiris / Verisure » vaut le coup, mais on ne peut **ni s'intégrer avec eux, ni les recommander** : la page prend donc uniquement l'angle « alternative à ».

Plutôt que d'argumenter « sans abonnement », ce qui serait ironique vu Gladys Plus, la page s'appuie sur ce qui nous différencie vraiment : **vous possédez le matériel et votre installation, et tout tourne en local**. Le nouveau tableau comparatif le dit franchement, avec une ligne *Abonnement* qui présente Gladys Plus comme optionnel (accès distant, sauvegardes, streaming caméra), face à une alarme télésurveillée où l'abonnement **est** le système.

`UseCasePage` gagne une section comparaison optionnelle, rendue seulement si la page définit `content.comparison` : les pages économies d'énergie et simulation de présence ne bougent pas.

## Vérification

`npm run build` passe (EN + FR, `[SUCCESS]`). Les seuls warnings restants sont pré-existants : ancres cassées sur la doc Netatmo, et diagnostics du minifieur HTML sur `/fr/starter-kit` (introduits par #373).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bilingual guides for Reolink cameras, including local RTSP setup, troubleshooting, and FAQs.
  - Added IKEA smart home and home weather station landing pages with product guidance, connection options, and FAQs.
  - Added comparison tables to the DIY home alarm page, highlighting local versus subscription-based systems.
  - Added related content links for Zigbee dongles and smart home topics.

- **Documentation**
  - Expanded camera and Philips Hue integration guides with clearer requirements, local-control details, FAQs, and improved search metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->