### PR TITLE
docs(docker): document reboot/shutdown host feature

### DIFF
--- a/docs/installation/2_docker.md
+++ b/docs/installation/2_docker.md
@@ -54,6 +54,7 @@ sudo docker run -d \
 -v /var/lib/gladysassistant:/var/lib/gladysassistant \
 -v /dev:/dev \
 -v /run/udev:/run/udev:ro \
+-v /run/dbus:/run/dbus:ro \
 gladysassistant/gladys:v4
 ```
 
@@ -68,7 +69,19 @@ Note:
 - `--network=host` => Use host network stack
 - `-e` => Set environment variables
 - `-v` => Mount volumes
+- `-v /run/dbus:/run/dbus:ro` => Give Gladys read access to the host system D-Bus socket. This is what allows the **Reboot / Shutdown host** buttons (System settings) to power off or reboot the host machine through systemd-logind. If you omit this volume, those buttons are automatically disabled.
 - `TZ=Europe/Paris` => Timezone used by container. Feel free to consult [this list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) on wikipedia if you need to change this value.
+
+## Reboot / Shutdown the host from Gladys
+
+From the **Settings → System** page, Gladys can reboot or power off the machine it runs on (for example your Raspberry Pi). This is handy to add a shutdown/reboot button to a dashboard through a scene, or to restart the host remotely.
+
+This feature talks to `systemd-logind` over the host system D-Bus socket, so it requires:
+
+- a host running **systemd** (standard on Raspberry Pi OS, Debian, Ubuntu…),
+- the container started with `--privileged` and the D-Bus socket mounted: `-v /run/dbus:/run/dbus:ro` (both already included in the command above).
+
+If these conditions are not met, the buttons stay disabled with an explanatory tooltip. After a **reboot**, the Gladys container comes back automatically thanks to `--restart=always`; after a **shutdown**, the machine stays off until you power it back on manually.
 
 ## Auto-Upgrade Gladys with Watchtower
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/installation/2_docker.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/installation/2_docker.md
@@ -46,6 +46,7 @@ sudo docker run -d \
 -v /var/lib/gladysassistant:/var/lib/gladysassistant \
 -v /dev:/dev \
 -v /run/udev:/run/udev:ro \
+-v /run/dbus:/run/dbus:ro \
 gladysassistant/gladys:v4
 ```
 
@@ -60,6 +61,19 @@ gladysassistant/gladys:v4
 - Cette image a été buildée pour toutes les architectures connues du marché. Vous pouvez donc lancer cette commande que vous soyez sur un Raspberry Pi, sur un NAS Synology, sur une VM Ubuntu, etc... Tout est possible !
 
 - Le `--network=host` n'est pas forcément adapté à tous les systèmes, il ne fonctionne pas sous MacOS ou Windows par exemple.
+
+- `-v /run/dbus:/run/dbus:ro` : Donne à Gladys un accès en lecture au socket D-Bus système de l'hôte. C'est ce qui permet aux boutons **Redémarrer / Éteindre l'hôte** (réglages Système) d'éteindre ou de redémarrer la machine hôte via systemd-logind. Si vous omettez ce volume, ces boutons sont automatiquement désactivés.
+
+## Redémarrer / Éteindre l'hôte depuis Gladys
+
+Depuis la page **Réglages → Système**, Gladys peut redémarrer ou éteindre la machine sur laquelle il tourne (par exemple votre Raspberry Pi). Pratique pour ajouter un bouton d'arrêt/redémarrage sur un dashboard via une scène, ou pour relancer l'hôte à distance.
+
+Cette fonctionnalité communique avec `systemd-logind` via le socket D-Bus système de l'hôte, elle nécessite donc :
+
+- un hôte utilisant **systemd** (standard sur Raspberry Pi OS, Debian, Ubuntu…),
+- le conteneur lancé avec `--privileged` et le socket D-Bus monté : `-v /run/dbus:/run/dbus:ro` (déjà inclus dans la commande ci-dessus).
+
+Si ces conditions ne sont pas réunies, les boutons restent désactivés avec une infobulle explicative. Après un **redémarrage**, le conteneur Gladys revient automatiquement grâce à `--restart=always` ; après une **extinction**, la machine reste éteinte jusqu'à ce que vous la rallumiez manuellement.
 
 ## Mise à jour automatique avec Watchtower
 


### PR DESCRIPTION
Documents the new **Reboot / Shutdown host** feature added in GladysAssistant/Gladys#2709.

- Add `-v /run/dbus:/run/dbus:ro` to the `docker run` command so the buttons (Settings → System) can reach systemd-logind over the system D-Bus socket.
- Add a "Reboot / Shutdown the host from Gladys" section explaining the requirements (systemd host, `--privileged`, D-Bus socket) and behaviour.
- English (`docs/`) and French (`i18n/fr`) versions.

Companion PR: GladysAssistant/Gladys#2709

🤖 Generated with [Claude Code](https://claude.com/claude-code)