### PR TITLE
Document Gladys 4.85 external integrations: weather, location, ports

### DIFF
--- a/docs/dev/5_external-integrations.md
+++ b/docs/dev/5_external-integrations.md
@@ -11,6 +11,17 @@ There is **no pull request to open, no code review to wait for, and no maintaine
 
 This page is a complete, step-by-step tutorial for developers.
 
+:::tip[New in Gladys 4.85 (SDK 0.11.0)]
+
+- **[Weather providers](#weather-providers)**: a new `weather` integration type. Answer one handler with the pivot weather format, and your provider feeds the dashboard widget, the chat assistant and the weather-alert scene triggers — taking precedence over the built-in OpenWeather with zero configuration.
+- **[House coordinates](#house-coordinates)**: declare `location: true` and read the coordinates of the user's houses, instead of asking for a latitude and a longitude again.
+- **[Named ports and form placeholders](#guiding-the-user-sections-and-placeholders)**: `{{gladys_host}}` and `{{port:<name>}}` in your section texts, to spell out an address of the instance itself.
+- **[Non-browsable ports](#sub-containers-and-hardware)**: `browsable: false` for a port that serves no web UI.
+- **[A single HTTPS redirect URI for OAuth2](#oauth2-cloud-services)**, whether the user reaches Gladys locally or through Gladys Plus.
+- **More device categories** in the SDK constants: charging station, water heater, thermostat mode and operating state, battery storage, water valve, doorbell, air-conditioning fan speed and swing.
+
+:::
+
 ## Why external integrations?
 
 Historically, adding an integration to Gladys meant [contributing to the core project](/docs/dev/developing-a-service/): forking the repository, coding the service in the Gladys codebase, writing unit tests, opening a pull request, and waiting for a maintainer to review and merge it. That path still exists and is great for protocols that belong in the core, but it has friction: you need to know the Gladys internals, respect the coding conventions, and the maintainer is a bottleneck.
@@ -37,9 +48,13 @@ An external integration is a **Docker container** that talks to Gladys through t
 
 You do not have to implement any of this plumbing yourself: the official [JavaScript SDK](https://github.com/GladysAssistant/integration-sdk-js) handles authentication, the WebSocket connection, automatic reconnection with exponential backoff, command acknowledgments, and state resynchronization for you. You can write your integration in any language, but the SDK saves you a lot of work.
 
-On top of the basics (devices, states, configuration), the platform also supports **cameras**, **OAuth2 cloud services**, **on-demand action buttons**, **local/cloud transport badges** (with a degraded state), **mediated network discovery** (mDNS, SSDP, UDP broadcast), **sub-containers with hardware access**, **messaging channels**, and **incoming webhooks** (through Gladys Plus). Each of these is covered in its own section below.
+On top of the basics (devices, states, configuration), the platform also supports **cameras**, **OAuth2 cloud services**, **on-demand action buttons**, **local/cloud transport badges** (with a degraded state), **mediated network discovery** (mDNS, SSDP, UDP broadcast), **sub-containers with hardware access**, **messaging channels**, **weather providers**, **the coordinates of the user's houses**, and **incoming webhooks** (through Gladys Plus). Each of these is covered in its own section below.
 
-Most integrations are of type `device` (they expose devices to Gladys). A second type, `communication`, lets you build a messaging channel instead (a chat or notification bridge, like Telegram); see [Messaging channels](#messaging-channels).
+An integration declares one of **three types** in its manifest:
+
+- **`device`** (by far the most common): it publishes the devices it discovers — sensors, switches, lights, cameras, and so on.
+- **`communication`**: a messaging channel instead of devices, a chat or notification bridge like Telegram; see [Messaging channels](#messaging-channels).
+- **`weather`**: a weather provider (Météo France, Open-Meteo, AccuWeather…) that answers the weather requests of the Gladys core and feeds the dashboard widget, the chat assistant and the weather-alert scene triggers; see [Weather providers](#weather-providers).
 
 A few important design rules to keep in mind:
 
@@ -48,7 +63,7 @@ A few important design rules to keep in mind:
 
 ## Prerequisites
 
-- A Gladys Assistant instance running on version **4.84.0 or later** (external integrations were introduced in this version).
+- A Gladys Assistant instance running on version **4.84.0 or later** (external integrations were introduced in this version). The most recent capabilities — [weather providers](#weather-providers), [house coordinates](#house-coordinates), and the [named ports and placeholders](#guiding-the-user-sections-and-placeholders) of the configuration form — require **4.85.0 or later**, so set the `gladys_version` range of your manifest accordingly.
 - [Docker](https://www.docker.com/) installed on your development machine.
 - [Node.js 24 or later](https://nodejs.org/) if you use the JavaScript SDK (the SDK requires Node.js 20 or later, but 24 is recommended).
 - A public Docker registry to host your image. The simplest option is the [GitHub Container Registry](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`), which keeps your image in the same place as your code, and which the official template publishes to automatically. Docker Hub or any other public registry works too, as long as the image is anonymously pullable.
@@ -128,6 +143,8 @@ await gladys.connect();
 
 That is the entire integration. The SDK reads the credentials Gladys injects into the container as environment variables, so there is no configuration to wire up by hand. Using the exported `DEVICE_FEATURE_CATEGORIES`, `DEVICE_FEATURE_TYPES`, and `DEVICE_FEATURE_UNITS` constants (instead of raw strings) keeps your features aligned with the categories, types, and units Gladys understands.
 
+Those constants are a verbatim mirror of the ones in the Gladys core, resynchronized at every SDK release: the latest versions added **charging stations**, **water heaters**, **thermostat modes and operating states**, **battery storage**, **water valves**, **doorbells**, and the **fan speed and swing** of air conditioners. Keeping `@gladysassistant/integration-sdk` up to date is how you get them (the current version is `0.11.0`).
+
 ### The SDK API in a nutshell
 
 Register your event handlers **before** calling `connect()`.
@@ -141,14 +158,14 @@ Register your event handlers **before** calling `connect()`.
 
 **Devices**
 
-- `publishDiscoveredDevices(devices)`: publishes the complete list of devices you offer (shown to the user in the Discovery tab).
+- `publishDiscoveredDevices(devices)`: publishes the complete list of devices you offer (shown to the user in the Discovery tab), up to **2,000 devices** per publication. Re-publishing a device the user already created silently updates its `params` (a LAN IP that moved in DHCP, for example) without touching its name or its features; a structural change shows an "Update" button in the Discovery tab instead.
 - `getDevices()`: returns the devices the user actually created.
 - `externalIds(type, platformId)`: returns `{ device, feature(key) }`, the recommended way to build stable, correctly formatted identifiers for a device and its features.
 - `externalId(suffix)`: the lower-level helper if you prefer to build a single identifier yourself.
 
 **State**
 
-- `publishState(featureExternalId, value)`: publishes a single state update (a number or an object).
+- `publishState(featureExternalId, value)`: publishes a single state update — a number, `{ text }` for a text feature, or `{ state, created_at }` to record a past state.
 - `publishStates(states)`: publishes a batch of updates (up to 100 per request). The host API rate-limits state updates at **300 states per minute** per integration, so publish state *changes*, not full snapshots.
 
 The limit is sized for changes, so keep the last value you sent for each feature and publish only what actually moved:
@@ -180,7 +197,12 @@ await gladys.publishStates(
 - `onOAuthAuthorizeUrl(cb)` / `onOAuthCallback(cb)`: OAuth2 cloud login (see OAuth2).
 - `onHardwareUpdated(cb)`: a hardware grant for a sub-container changed.
 - `onSendMessage(cb)`: deliver a message to a contact (see Messaging channels).
+- `onWeatherGet(cb)` / `onWeatherGetImage(cb)`: Gladys asks for the weather, or for a provider image (see Weather providers).
 - `onWebhook(key, cb)` / `onWebhookUpdated(cb)`: incoming webhooks (see Incoming webhooks).
+
+**Weather providers**
+
+- `requestWeatherRefresh()`: fire-and-forget nudge asking the core to re-pull your weather right now, instead of waiting for its next scheduled check (see Weather providers).
 
 Commands acknowledge automatically on success; throwing from a handler acknowledges the command as failed. You can also inspect the local state directly through `gladys.devices`, `gladys.config`, and `gladys.connected`, and listen to the `connected` and `disconnected` events.
 
@@ -228,6 +250,8 @@ gladys.onOAuthCallback(async (key, { code, state: returnedState, redirectUri }) 
 ```
 
 Refreshing the token is your integration's responsibility. When it expires, report it with `setConnectionStatus(false, { en: "Token expired, please reconnect.", fr: "Token expire, reconnectez-vous." })`.
+
+**Never hardcode the redirect URI**: use the `redirectUri` Gladys hands you, and give it back byte for byte in the token exchange. Providers now require an HTTPS callback (Spotify has enforced it since 2025), which a Gladys reached at `http://192.168.1.50:1443` can never satisfy, so the flow goes through a fixed HTTPS page hosted by Gladys, which bounces the browser back to the instance. The practical consequence for you and your users: **a single redirect URI has to be declared at the provider**, whether Gladys is reached locally or through Gladys Plus. The Configuration screen shows the exact URL to copy into the provider's developer application.
 
 ### Action buttons
 
@@ -317,6 +341,19 @@ const detector = coral.granted && coral.available ? "edgetpu" : "cpu";
 
 `getContainers()`, `startContainer(name, options?)`, `stopContainer(name)`, and `restartContainer(name)` control the companion containers. When the user grants or revokes access to a piece of hardware, the `onHardwareUpdated` handler fires so you can regenerate configuration and restart the relevant container.
 
+Each entry of `container.ports` mirrors your manifest declaration, plus the host port Gladys allocated:
+
+```js
+// [{ container_port: 5000, protocol: "tcp", host_port: 42115, label: { en: "Frigate UI" },
+//    name: "frigate_ui", browsable: true }]
+const [{ host_port: frigatePort }] = frigate.ports;
+```
+
+The host port is **chosen by Gladys** (a free port, persisted across recreations, never declared in the manifest), so read it here rather than assuming one; it is `null` as long as the container has never started. Two optional manifest fields complete a port declaration:
+
+- `browsable` (default `true`): a port serving a web UI gets an "Open `<label>`" link on the supervision screen. Set it to `false` for a port a browser cannot open — a WebSocket endpoint waiting for devices, for instance — and Gladys shows a plain `<label>: <host_port>` badge instead.
+- `name` (`[a-z0-9_]`, 2 to 20 characters, unique across the whole manifest): makes the allocated host port referenceable from the `{{port:<name>}}` placeholder of your configuration form, so you can spell out an address of the instance in a sentence shown to the user (see [Guiding the user](#guiding-the-user-sections-and-placeholders)).
+
 ### Logging
 
 The SDK ships a structured logger so your container logs are readable straight from `docker logs`:
@@ -357,7 +394,131 @@ await gladys.publishMessage(contactId, "The house is now empty.");
 - `linkContact(code, contactId, name?)`: links a provider contact to a Gladys user from a single-use pairing code (valid 15 minutes), and returns the user selector, first name, and language.
 - `getContacts()`: lists the contacts currently linked to this channel.
 
-A `communication` integration has a Configuration screen (from its `config_schema`) but no Devices or Discovery tab.
+A `communication` integration declares which of the **two families** it belongs to, through the mandatory `messaging` manifest field:
+
+- **Bidirectional chat channels** (`"messaging": { "receive": true }`, Telegram-style bots): the user links their account with a short code sent in the channel, then talks to the Gladys brain from it. `onSendMessage` receives `{ id }`, the linked contact.
+- **Send-only notification channels** (`"messaging": { "receive": false }`, Free Mobile SMS or CallMeBot style): there is no incoming path at all, so no linking code either. Each user enters their own credentials in the "My account" block of the Configuration screen, described by the manifest `contact_schema` (same flat format as `config_schema`), and Gladys passes them to your handler with every outgoing message:
+
+```json
+"messaging": { "receive": false },
+"contact_schema": [
+  { "key": "username", "type": "string", "label": { "en": "Free Mobile login" }, "required": true },
+  { "key": "access_token", "type": "secret", "label": { "en": "SMS API key" }, "required": true }
+]
+```
+
+```js
+gladys.onSendMessage(async (contact, message) => {
+  // contact holds the target user's contact_schema values
+  await sendFreeMobileSms(contact.username, contact.access_token, message.text);
+});
+```
+
+Users without a linked account or configured credentials are skipped by Gladys and never reach your handler. A `communication` integration has a Configuration screen (from its `config_schema`) but no Devices or Discovery tab.
+
+### Weather providers
+
+*Requires Gladys 4.85.0 or later.*
+
+Set `"type": "weather"` in your manifest and your integration becomes a **weather provider**: Météo France, Open-Meteo, AccuWeather, a national meteorological service, or your own aggregation. Like a messaging channel, it has no Devices and no Discovery tab, publishes no device and no state — it answers the weather requests of the Gladys core through a **dedicated provider API**, and Gladys feeds the dashboard weather widget, the chat assistant ("what's the weather like tomorrow?") and the weather-alert scene triggers with the answer.
+
+Installing a weather integration **takes precedence over the built-in OpenWeather service with zero configuration**, and stopping or uninstalling it falls back automatically. Users can also pin a specific provider from the configuration of the weather widget, when several are installed.
+
+Everything goes through one handler, which resolves the **pivot weather format** — a provider-agnostic structure, generalized from what the major providers expose, so the core never has to know your provider by name:
+
+```js
+import {
+  WEATHER_CONDITIONS,
+  WEATHER_ALERT_SEVERITIES,
+  WEATHER_ALERT_TYPES,
+} from "@gladysassistant/integration-sdk";
+
+gladys.onWeatherGet(async ({ latitude, longitude, language, units }) => {
+  const data = await fetchProviderForecast(latitude, longitude, language, units);
+  return {
+    // Required: temperature, weather (the condition), datetime.
+    temperature: data.current.temperature,
+    weather: WEATHER_CONDITIONS.RAIN,
+    datetime: new Date().toISOString(),
+    // Optional current fields, simply dropped when your provider has none:
+    apparent_temperature: data.current.feelsLike,
+    humidity: 80, // percentages are 0-100
+    pressure: 1013,
+    wind_speed: 4.2,
+    wind_direction: 220,
+    uv_index: 3,
+    sunrise: data.current.sunrise,
+    sunset: data.current.sunset,
+    is_day: data.current.isDay, // strict boolean, drives the day/night icon variant
+    // Forecasts (Gladys keeps up to 24 hours and 8 days):
+    hours: data.hours.map((h) => ({ temperature: h.temp, weather: toCondition(h), datetime: h.time })),
+    days: data.days.map((d) => ({ temperature_min: d.min, temperature_max: d.max, datetime: d.date })),
+    // CAP-style alerts, up to 10 (Météo France vigilance: yellow -> moderate, orange -> severe, red -> extreme):
+    alerts: [
+      {
+        severity: WEATHER_ALERT_SEVERITIES.SEVERE,
+        event: "Orages violents",
+        type: WEATHER_ALERT_TYPES.THUNDERSTORM,
+      },
+    ],
+  };
+});
+```
+
+The contract, point by point:
+
+- **`units` is the requesting user's preference**, `metric` (°C, m/s, hPa, mm, km) or `us` (°F, mph, in, mi): return your values in that unit system. Percentages (`humidity`, `cloud_cover`, `precipitation_probability`) are always 0 to 100, never a 0-1 fraction.
+- **`weather` is a condition of the pivot enum** (`WEATHER_CONDITIONS`): `clear`, `partly-cloudy`, `cloud`, `fog`, `drizzle`, `rain`, `pouring`, `sleet`, `hail`, `snow`, `thunderstorm`, `wind`, `night`, `unknown`. Map your provider's codes onto it; anything else is coerced to `unknown` (neutral icon).
+- **`is_day` carries the day/night signal**, an optional strict boolean on the current conditions and on each `hours` entry: `weather` keeps the meteorology, `is_day` drives the rendering variant. The `night` condition is still accepted for compatibility but is **deprecated for providers** — a rainy night is `weather: "rain", is_day: false`, not `"night"`.
+- **Each forecast entry has its own required fields**: `temperature`, `weather` and `datetime` for an `hours` entry; `temperature_min`, `temperature_max` and `datetime` for a `days` entry. `days` may or may not include the current day: consumers filter by calendar date, so you never have to lead with today.
+- **Alerts follow CAP**: `severity` (`minor`, `moderate`, `severe`, `extreme`) and `event` are required, `description`, `start`, `end` and `type` are optional. The phenomenon `type` (`wind`, `rain`, `flood`, `thunderstorm`, `snow`, `heat`, `cold`, `avalanche`, `coastal`, `fog`) lets Gladys translate and iconify the alert where free text cannot; an invalid type is dropped and the alert is kept, rendered from its `event` alone.
+- **The acknowledgment is awaited for up to 15 seconds** (instead of the standard 5), so a fresh third-party API call has time to run. Throwing — provider not configured, API down — fails the command, and Gladys falls through to the next available provider.
+- **The payload is normalized and bounded by the core**: unknown fields are dropped, numbers must be finite, dates must parse, arrays are capped (24 `hours`, 8 `days`, 10 `alerts`, 3 `images`), and alert strings are truncated (`event` up to 100 characters, `description` up to 5,000 — vigilance bulletins run long).
+
+Two optional extensions complete the type.
+
+**Provider images** (a vigilance map, a rain radar, a satellite view). The weather payload only ever declares **metadata** — an `images` array of up to three `{ key, label? }` entries, where `key` matches `^[a-z0-9][a-z0-9-]{0,31}$` — and the bytes travel on demand:
+
+```js
+gladys.onWeatherGetImage(async (key) => {
+  const png = await fetchVigilanceMap(); // returns a Buffer
+  return png.toString("base64"); // RAW base64, without any "data:" prefix
+});
+```
+
+Gladys validates the decoded bytes (PNG or JPEG, up to 500 KB), caches them for 10 minutes per key, and serves them to the browser from its own origin, so your users' IP addresses never reach a third-party server. Only a key declared in your last weather payload can be requested.
+
+**The freshness nudge.** Gladys re-evaluates the weather-alert scene triggers on a 30-minute scheduled check, pulled through `onWeatherGet` and diffed on the normalized alerts. A provider that *knows* something changed upstream can do better — never by pushing data:
+
+```js
+onUpstreamVigilanceChange(() => gladys.requestWeatherRefresh());
+```
+
+`requestWeatherRefresh()` means only "re-pull me now": the data re-enters through the regular `onWeatherGet` path, so the scene fires seconds later instead of within 30 minutes. It carries nothing, expects no answer, and is rate-limited to one per minute per integration (silently dropped beyond).
+
+Nothing else is required on your side: the weather-alert scene trigger is owned by the core and works identically with every provider.
+
+### House coordinates
+
+*Requires Gladys 4.85.0 or later.*
+
+An integration whose logic depends on where the user lives — air quality, pollen, water restrictions, tides — can read the coordinates of the houses configured in Gladys, instead of asking the user to type their latitude and longitude again in your configuration form.
+
+The home location is sensitive personal data, so access is an **authorization contract**, like the network captures: declare `"location": true` in your manifest (the request is then shown to the user on the install screen) and Gladys serves `GET /house` on the host API. An integration that did not declare it gets a `403`.
+
+The JavaScript SDK does not wrap this endpoint yet, so call it with the credentials Gladys injects into your container:
+
+```js
+const response = await fetch(`${process.env.GLADYS_HOST_API_URL}/api/integration/v1/house`, {
+  headers: { Authorization: `Bearer ${process.env.GLADYS_INTEGRATION_TOKEN}` },
+});
+const houses = await response.json();
+// [{ id, name, selector, latitude, longitude }], sorted by name
+```
+
+`latitude` and `longitude` are `null` when the user has not located the house, and several houses can exist: handle both cases. Only these five fields are returned — never the alarm mode, code or delay. Coordinates change rarely, so fetching them at startup and on reconnection is the nominal pattern.
+
+A `weather` integration needs neither this endpoint nor `location: true`: the coordinates of the house being displayed travel in the `options` of every weather request.
 
 ### Incoming webhooks (Gladys Plus)
 
@@ -416,7 +577,7 @@ Every external integration is described by a single file named `gladys-assistant
 | Field | Required | Description |
 | --- | --- | --- |
 | `manifest_version` | Yes | Must be `1`. |
-| `type` | Yes | `"device"` (exposes devices) or `"communication"` (a messaging channel). |
+| `type` | Yes | `"device"` (exposes devices), `"communication"` (a messaging channel) or `"weather"` (a weather provider). |
 | `name` | Yes | Display name, 3 to 30 characters. |
 | `description` | Yes | An object keyed by language. `en` is mandatory, each text is 10 to 100 characters. |
 | `version` | Yes | Strict [semantic version](https://semver.org/). Bumping it notifies users an update is available. |
@@ -427,7 +588,10 @@ Every external integration is described by a single file named `gladys-assistant
 | `transports` | No | Non-empty subset of `local` and `cloud`, if your integration is dual-channel. |
 | `actions` | No | 1 to 10 action buttons, each with a `key`, a multi-language `label`, a `timeout_seconds` (5 to 120), and optional `fields`. |
 | `network_discovery` | No | 1 to 5 mediated capture methods (`udp-broadcast`, `udp-active-broadcast`, `mdns`, `ssdp`). |
-| `containers` | No | Up to 5 companion containers, each with `name`, `docker_image`, `start` (`auto` or `manual`), and optional `env`, `volumes`, `ports`, `devices` (`coral-usb`, `coral-pcie`, `gpu`, `video`), `read_only`, `command`, `memory_mb` (32 to 4096), `cpu` (0.1 to 2), `shm_mb` (64 to 512). |
+| `containers` | No | Up to 5 companion containers, each with `name`, `docker_image`, `start` (`auto` or `manual`), and optional `env`, `volumes`, `ports` (up to 3, each with `container_port`, `protocol`, a multi-language `label`, an optional `name` and `browsable`), `devices` (`coral-usb`, `coral-pcie`, `gpu`, `video`), `read_only`, `command`, `memory_mb` (32 to 4096), `cpu` (0.1 to 2), `shm_mb` (64 to 512). |
+| `location` | No | `true` requests access to the coordinates of the user's houses (`GET /house`). Shown on the install screen, enforced server-side. |
+| `messaging` | Mandatory for `communication` | `{ "receive": true }` for a bidirectional chat channel, `{ "receive": false }` for a send-only notification channel. Forbidden for the other types. |
+| `contact_schema` | Mandatory when `messaging.receive` is `false` | The per-user credentials of a send-only channel, same field format as `config_schema` (minus `oauth2` fields). Forbidden otherwise. |
 | `webhooks` | No | Up to 3 incoming webhooks (Gladys Plus), each with a `key`, a multi-language `label`, and a `mode` (`fire_and_forget` or `sync`). |
 
 ### The config schema
@@ -437,6 +601,69 @@ Every external integration is described by a single file named `gladys-assistant
 A `select` or `multi_select` can either list static `options` or pull its choices dynamically from the user's devices with `source: "devices"`, and render as a `dropdown` or `radio` (`display`). A `section` field is presentational only: it shows a `description` and up to five documentation `links`, and stores no value.
 
 Gladys automatically generates the configuration form from this list, so you never write any frontend code. Values marked `secret` are stored securely and are never returned to the frontend.
+
+### Guiding the user: sections and placeholders
+
+A generated form is compact, but on its own it gives the user no onboarding guidance — in front of a "Client ID" field, they first need to know they have to create an application on the manufacturer's developer platform. That is what `section` fields are for: purely presentational blocks that split the form into chapters, with a title, a plain-text `description` (up to 1,000 characters per language) and up to five `links` (HTTPS only), opened in a new tab with their target domain displayed:
+
+```json
+"config_schema": [
+  {
+    "key": "intro",
+    "type": "section",
+    "label": { "en": "Getting started", "fr": "Pour commencer" },
+    "description": {
+      "en": "Create a developer account to get your API key.",
+      "fr": "Créez un compte développeur pour obtenir votre clé d'API."
+    },
+    "links": [{ "url": "https://open-meteo.com/en/docs", "label": { "en": "Open-Meteo docs" } }]
+  },
+  { "key": "api_key", "type": "secret", "label": { "en": "API key" }, "required": true }
+]
+```
+
+Sections are also allowed in an action's `fields` and in a `contact_schema`, which share the same format. They store no value: their key never appears in `gladys.config`, in `onConfigUpdated`, or in an action handler's fields.
+
+Since Gladys 4.85.0, the `label` and `description` of a section can embed two **plain-text placeholders**, substituted by the Gladys frontend when it renders the form:
+
+| Placeholder | Substituted with |
+| --- | --- |
+| `{{gladys_host}}` | The hostname of the address the browser currently uses to reach Gladys. |
+| `{{port:<name>}}` | The host port Gladys assigned to the sub-container port declaring that `name`. |
+
+They are the declarative way to spell out an address of the instance itself — the case of a device that has to connect *to* Gladys, like an OCPP charge point:
+
+```json
+"containers": [
+  {
+    "name": "ocpp",
+    "docker_image": "ghcr.io/acme/ocpp:1.2.0",
+    "ports": [
+      { "container_port": 9000, "name": "ocpp", "label": { "en": "OCPP endpoint" }, "browsable": false }
+    ]
+  }
+],
+"config_schema": [
+  {
+    "key": "charge_point",
+    "type": "section",
+    "label": { "en": "Connect your charge point" },
+    "description": {
+      "en": "Point your charge point to ws://{{gladys_host}}:{{port:ocpp}}/",
+      "fr": "Pointez votre borne vers ws://{{gladys_host}}:{{port:ocpp}}/"
+    }
+  }
+]
+```
+
+The syntax is exact — no space inside the braces, no expression, no injected code — and four rules are worth knowing:
+
+- a `{{port:<name>}}` referencing a name declared by no port of your manifest **rejects the manifest**, both in the store indexer and on the server;
+- `{{port:<name>}}` is refused in a `contact_schema`: that block is the one screen a non-admin user reaches, and their reduced view carries no container state. `{{gladys_host}}` works everywhere;
+- a valid `{{port:<name>}}` whose port has no assigned host port yet (the sub-container has never started) is left as is on screen, and resolves the next time the screen is loaded. Start the container that publishes the port before pointing the user at the sentence;
+- browsing through Gladys Plus or a reverse proxy, `{{gladys_host}}` resolves to the tunnel or proxy hostname, not to the LAN address of the instance. If the device has to reach Gladys over the LAN, say so in your repository documentation.
+
+For anything longer than a couple of sentences (screenshots, a full step-by-step), the right medium remains the mandatory repository documentation: the Configuration screen carries a permanent **"Documentation"** link to it, in the user's language, and that is exactly when they need it most.
 
 ### Cover image rules
 
@@ -494,7 +721,9 @@ Gladys renders a generic interface for every external integration, with three ta
 
 - **Devices**: the devices the user created, with standard controls.
 - **Discovery**: the devices your integration published, each with a one-click "create" button.
-- **Configuration**: the form generated from your `config_schema`, your action buttons, plus supervision controls (start, stop, restart, update, view logs, uninstall).
+- **Configuration**: the form generated from your `config_schema`, your action buttons, a permanent link to your documentation, plus supervision controls (start, stop, restart, update, view logs, uninstall).
+
+`communication` and `weather` integrations expose no device, so they only get the Configuration tab.
 
 ### Container environment
 
@@ -535,15 +764,19 @@ The maintainer approves nothing and is never a bottleneck.
 
 ## Step 6: Users install in one click
 
-From the Gladys catalog, external integrations appear alongside the built-in ones, with a **community badge** and a live status indicator. A user clicks **Install**, and Gladys pulls your image, starts the container, and shows the generated interface. Users can also install directly from a GitHub repository URL, without waiting for the next index cycle.
+From the Gladys catalog, external integrations appear alongside the built-in ones, with a **community badge**, the local/cloud badges derived from your `transports`, and a live status indicator. A user clicks **Install**, and Gladys pulls your image, starts the container, and shows the generated interface. Users can also install directly from a GitHub repository URL, without waiting for the next index cycle.
+
+Before installing, the screen shows everything your manifest declared: your documentation, the sub-containers that will run and the ports they will publish, the hardware you request, the network captures, the webhooks, and the access to the house coordinates. Declare only what you actually use — each line is a question the user has to answer before trusting your integration.
 
 ## Updating your integration
 
-Shipping a new version is one click: run the **Release** workflow again and pick the bump level. It rebuilds the multi-architecture image, pushes the new tags, and updates the manifest for you. At the next index cycle, users see that an update is available and can apply it in one click.
+Shipping a new version is one click: run the **Release** workflow again and pick the bump level. It rebuilds the multi-architecture image, pushes the new tags, and updates the manifest for you. At the next index cycle, users see that an update is available — with a counter in the Gladys header and a dedicated updates view listing every integration to upgrade — and can apply it in one click.
 
 If you publish manually, do the same two things by hand: build and push a new image tag (for example `ghcr.io/yourname/my-integration:1.1.0`), then bump `version` and `docker_image` in the manifest and push.
 
 ## Troubleshooting
+
+Installing your integration from its repository URL (or in developer mode) shows the **detailed validation errors** of your manifest, field by field, so you can fix them without waiting for the next index cycle.
 
 The indexer is fully transparent. If your integration does not appear in the catalog, check the published `rejected.json` file: it lists every repository that failed validation, along with the reason and a severity level (invalid manifest, malformed or unpullable image reference, incompatible `gladys_version` range, oversized or wrongly-sized cover, missing `docs/en.md` or `docs/fr.md`, and so on). You can catch most of these before publishing by running `npx github:GladysAssistant/integration-store .` locally. Fix the issue, release again, and wait for the next cycle.
 

--- a/docs/integrations/external.mdx
+++ b/docs/integrations/external.mdx
@@ -11,6 +11,8 @@ import ExternalIntegrations from "@site/src/components/ExternalIntegrations";
 
 Anyone can create and publish one, without review or maintainer approval: the list below grows continuously, directly from the community.
 
+An external integration can bring **devices** (sensors, switches, lights, cameras…), a **messaging channel** (a chat or notification bridge), or, since Gladys 4.85, a **weather provider** that feeds the dashboard weather widget, the chat assistant and the weather-alert scenes.
+
 Each integration has its own page, with its documentation, its configuration settings and its installation steps: click a card to open it.
 
 <ExternalIntegrations />

--- a/docs/integrations/openweather.md
+++ b/docs/integrations/openweather.md
@@ -7,6 +7,12 @@ sidebar_label: OpenWeather
 
 This integration let you display the weather forecast in Gladys Assistant.
 
+:::info[Since Gladys 4.85, weather can also come from an external integration]
+
+Weather providers can now be built as [external integrations](/docs/integrations/external/), which cover any provider (Météo France, Open-Meteo, AccuWeather…) and support weather alerts, provider images and the weather-alert scene triggers. Installing one takes precedence over this built-in OpenWeather service automatically, which is why it is now marked as deprecated in the catalog.
+
+:::
+
 ## Create an OpenWeather account
 
 To configure OpenWeather, first go to [https://openweathermap.org/api](https://openweathermap.org/api).

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dev/5_external-integrations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dev/5_external-integrations.md
@@ -11,6 +11,17 @@ Il n'y a **aucune pull request à ouvrir, aucune review de code à attendre, et 
 
 Cette page est un tutoriel complet, étape par étape, à destination des développeurs.
 
+:::tip[Nouveautés de Gladys 4.85 (SDK 0.11.0)]
+
+- **[Fournisseurs météo](#fournisseurs-météo)** : un nouveau type d'intégration `weather`. Répondez à un seul gestionnaire avec le format pivot météo, et votre fournisseur alimente le widget du tableau de bord, l'assistant conversationnel et les déclencheurs de scène sur alerte météo — en prenant le pas sur le service OpenWeather intégré, sans aucune configuration.
+- **[Coordonnées des maisons](#coordonnées-des-maisons)** : déclarez `location: true` et lisez les coordonnées des maisons de l'utilisateur, au lieu de redemander une latitude et une longitude.
+- **[Ports nommés et placeholders de formulaire](#guider-vos-utilisateurs-dans-le-formulaire)** : `{{gladys_host}}` et `{{port:<name>}}` dans vos textes de section, pour écrire une adresse de l'instance elle-même.
+- **[Ports non navigables](#sous-conteneurs-et-matériel)** : `browsable: false` pour un port qui n'expose aucune interface web.
+- **[Une seule URL de redirection HTTPS pour OAuth2](#services-cloud-oauth2)**, que l'utilisateur atteigne Gladys en local ou via Gladys Plus.
+- **De nouvelles catégories d'appareils** dans les constantes du SDK : borne de recharge, chauffe-eau, mode et état de fonctionnement de thermostat, batterie de stockage, vanne d'eau, sonnette, vitesse de ventilation et oscillation de climatisation.
+
+:::
+
 ## Pourquoi les intégrations externes ?
 
 Historiquement, ajouter une intégration à Gladys signifiait [contribuer au projet cœur](/fr/docs/dev/developing-a-service/) : forker le dépôt, coder le service dans la base de code de Gladys, écrire des tests unitaires, ouvrir une pull request, et attendre qu'un mainteneur la review et la merge. Ce chemin existe toujours et reste idéal pour les protocoles qui ont leur place dans le cœur, mais il a des frictions : il faut connaître les rouages internes de Gladys, respecter les conventions de code, et le mainteneur est un goulot d'étranglement.
@@ -37,9 +48,13 @@ Une intégration externe est un **conteneur Docker** qui dialogue avec Gladys vi
 
 Vous n'avez à implémenter aucune de cette plomberie vous-même : le [SDK JavaScript officiel](https://github.com/GladysAssistant/integration-sdk-js) gère pour vous l'authentification, la connexion WebSocket, la reconnexion automatique avec backoff exponentiel, les accusés de réception des commandes, et la resynchronisation de l'état. Vous pouvez écrire votre intégration dans n'importe quel langage, mais le SDK vous fait gagner beaucoup de temps.
 
-Au-delà des bases (appareils, états, configuration), la plateforme prend aussi en charge les **caméras**, les **services cloud OAuth2**, les **boutons d'action à la demande**, les **badges de transport local/cloud** (avec un état dégradé), la **découverte réseau médiée** (mDNS, SSDP, broadcast UDP), les **sous-conteneurs avec accès au matériel**, les **canaux de messagerie**, et les **webhooks entrants** (via Gladys Plus). Chacun de ces points est couvert dans sa propre section ci-dessous.
+Au-delà des bases (appareils, états, configuration), la plateforme prend aussi en charge les **caméras**, les **services cloud OAuth2**, les **boutons d'action à la demande**, les **badges de transport local/cloud** (avec un état dégradé), la **découverte réseau médiée** (mDNS, SSDP, broadcast UDP), les **sous-conteneurs avec accès au matériel**, les **canaux de messagerie**, les **fournisseurs météo**, les **coordonnées des maisons de l'utilisateur**, et les **webhooks entrants** (via Gladys Plus). Chacun de ces points est couvert dans sa propre section ci-dessous.
 
-La plupart des intégrations sont de type `device` (elles exposent des appareils à Gladys). Un second type, `communication`, permet de construire un canal de messagerie à la place (un pont de chat ou de notifications, comme Telegram) ; voir [Canaux de messagerie](#canaux-de-messagerie).
+Une intégration déclare dans son manifeste l'un des **trois types** suivants :
+
+- **`device`** (de loin le plus courant) : elle publie les appareils qu'elle découvre — capteurs, interrupteurs, lampes, caméras, etc.
+- **`communication`** : un canal de messagerie plutôt que des appareils, un pont de chat ou de notifications comme Telegram ; voir [Canaux de messagerie](#canaux-de-messagerie).
+- **`weather`** : un fournisseur météo (Météo France, Open-Meteo, AccuWeather…) qui répond aux demandes météo du cœur de Gladys et alimente le widget du tableau de bord, l'assistant conversationnel et les déclencheurs de scène sur alerte météo ; voir [Fournisseurs météo](#fournisseurs-météo).
 
 Quelques règles de conception importantes à garder en tête :
 
@@ -48,7 +63,7 @@ Quelques règles de conception importantes à garder en tête :
 
 ## Prérequis
 
-- Une instance Gladys Assistant en version **4.84.0 ou ultérieure** (les intégrations externes ont été introduites dans cette version).
+- Une instance Gladys Assistant en version **4.84.0 ou ultérieure** (les intégrations externes ont été introduites dans cette version). Les capacités les plus récentes — les [fournisseurs météo](#fournisseurs-météo), les [coordonnées des maisons](#coordonnées-des-maisons), et les [ports nommés et placeholders](#guider-vos-utilisateurs-dans-le-formulaire) du formulaire de configuration — nécessitent la version **4.85.0 ou ultérieure** : ajustez l'intervalle `gladys_version` de votre manifeste en conséquence.
 - [Docker](https://www.docker.com/) installé sur votre machine de développement.
 - [Node.js 24 ou ultérieur](https://nodejs.org/) si vous utilisez le SDK JavaScript (le SDK requiert Node.js 20 ou ultérieur, mais la version 24 est recommandée).
 - Un registre Docker public pour héberger votre image. L'option la plus simple est le [GitHub Container Registry](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`), qui garde votre image au même endroit que votre code, et sur lequel le template officiel publie automatiquement. Docker Hub ou n'importe quel autre registre public fonctionne aussi, tant que l'image est téléchargeable de façon anonyme.
@@ -128,6 +143,8 @@ await gladys.connect();
 
 Voilà toute l'intégration. Le SDK lit les identifiants que Gladys injecte dans le conteneur sous forme de variables d'environnement, il n'y a donc aucune configuration à câbler à la main. Utiliser les constantes exportées `DEVICE_FEATURE_CATEGORIES`, `DEVICE_FEATURE_TYPES` et `DEVICE_FEATURE_UNITS` (plutôt que des chaînes brutes) garde vos fonctionnalités alignées avec les catégories, types et unités que Gladys comprend.
 
+Ces constantes sont une copie conforme de celles du cœur de Gladys, resynchronisées à chaque version du SDK : les dernières ont ajouté les **bornes de recharge**, les **chauffe-eau**, les **modes et états de fonctionnement de thermostat**, les **batteries de stockage**, les **vannes d'eau**, les **sonnettes**, ainsi que la **vitesse de ventilation et l'oscillation** des climatisations. C'est en gardant `@gladysassistant/integration-sdk` à jour que vous en profitez (la version actuelle est la `0.11.0`).
+
 ### L'API du SDK en un coup d'œil
 
 Enregistrez vos gestionnaires d'événements **avant** d'appeler `connect()`.
@@ -141,14 +158,14 @@ Enregistrez vos gestionnaires d'événements **avant** d'appeler `connect()`.
 
 **Appareils**
 
-- `publishDiscoveredDevices(devices)` : publie la liste complète des appareils que vous proposez (affichée à l'utilisateur dans l'onglet Découverte).
+- `publishDiscoveredDevices(devices)` : publie la liste complète des appareils que vous proposez (affichée à l'utilisateur dans l'onglet Découverte), jusqu'à **2 000 appareils** par publication. Republier un appareil que l'utilisateur a déjà créé met silencieusement à jour ses `params` (une IP locale qui a changé en DHCP, par exemple) sans toucher à son nom ni à ses fonctionnalités ; un changement de structure affiche un bouton « Mettre à jour » dans l'onglet Découverte à la place.
 - `getDevices()` : retourne les appareils réellement créés par l'utilisateur.
 - `externalIds(type, platformId)` : retourne `{ device, feature(key) }`, la façon recommandée de construire des identifiants stables et correctement formatés pour un appareil et ses fonctionnalités.
 - `externalId(suffix)` : l'aide de plus bas niveau si vous préférez construire un identifiant unique vous-même.
 
 **État**
 
-- `publishState(featureExternalId, value)` : publie une mise à jour d'état unique (un nombre ou un objet).
+- `publishState(featureExternalId, value)` : publie une mise à jour d'état unique — un nombre, `{ text }` pour une fonctionnalité textuelle, ou `{ state, created_at }` pour enregistrer un état passé.
 - `publishStates(states)` : publie un lot de mises à jour (jusqu'à 100 par requête). L'API hôte limite les mises à jour d'état à **300 états par minute** par intégration, publiez donc des *changements* d'état, pas des instantanés complets.
 
 La limite est dimensionnée pour des changements : gardez la dernière valeur envoyée pour chaque fonctionnalité et ne publiez que ce qui a réellement bougé :
@@ -180,7 +197,12 @@ await gladys.publishStates(
 - `onOAuthAuthorizeUrl(cb)` / `onOAuthCallback(cb)` : connexion OAuth2 cloud (voir OAuth2).
 - `onHardwareUpdated(cb)` : une autorisation matérielle pour un sous-conteneur a changé.
 - `onSendMessage(cb)` : délivrer un message à un contact (voir Canaux de messagerie).
+- `onWeatherGet(cb)` / `onWeatherGetImage(cb)` : Gladys demande la météo, ou une image du fournisseur (voir Fournisseurs météo).
 - `onWebhook(key, cb)` / `onWebhookUpdated(cb)` : webhooks entrants (voir Webhooks entrants).
+
+**Fournisseurs météo**
+
+- `requestWeatherRefresh()` : un signal sans réponse attendue qui demande au cœur de re-solliciter votre météo immédiatement, au lieu d'attendre sa prochaine vérification planifiée (voir Fournisseurs météo).
 
 Les commandes sont acquittées automatiquement en cas de succès ; lever une exception dans un gestionnaire acquitte la commande en échec. Vous pouvez aussi inspecter l'état local directement via `gladys.devices`, `gladys.config` et `gladys.connected`, et écouter les événements `connected` et `disconnected`.
 
@@ -228,6 +250,8 @@ gladys.onOAuthCallback(async (key, { code, state: returnedState, redirectUri }) 
 ```
 
 Le rafraîchissement du token est de la responsabilité de votre intégration. Quand il expire, signalez-le avec `setConnectionStatus(false, { en: "Token expired, please reconnect.", fr: "Token expiré, reconnectez-vous." })`.
+
+**Ne codez jamais l'URL de redirection en dur** : utilisez le `redirectUri` que Gladys vous transmet, et renvoyez-le à l'octet près lors de l'échange des tokens. Les fournisseurs exigent désormais une URL de callback en HTTPS (Spotify l'impose depuis 2025), ce qu'un Gladys joignable sur `http://192.168.1.50:1443` ne pourra jamais satisfaire : le flux passe donc par une page HTTPS fixe hébergée par Gladys, qui renvoie le navigateur vers l'instance. La conséquence pratique pour vous et vos utilisateurs : **une seule URL de redirection est à déclarer chez le fournisseur**, que Gladys soit atteint en local ou via Gladys Plus. L'écran de configuration affiche l'URL exacte à copier dans l'application développeur du fournisseur.
 
 ### Boutons d'action
 
@@ -317,6 +341,19 @@ const detector = coral.granted && coral.available ? "edgetpu" : "cpu";
 
 `getContainers()`, `startContainer(name, options?)`, `stopContainer(name)` et `restartContainer(name)` contrôlent les conteneurs compagnons. Quand l'utilisateur accorde ou révoque l'accès à un matériel, le gestionnaire `onHardwareUpdated` se déclenche pour que vous puissiez régénérer la configuration et redémarrer le conteneur concerné.
 
+Chaque entrée de `container.ports` reprend votre déclaration du manifeste, plus le port hôte que Gladys a alloué :
+
+```js
+// [{ container_port: 5000, protocol: "tcp", host_port: 42115, label: { en: "Frigate UI" },
+//    name: "frigate_ui", browsable: true }]
+const [{ host_port: frigatePort }] = frigate.ports;
+```
+
+Le port hôte est **choisi par Gladys** (un port libre, conservé d'une recréation à l'autre, jamais déclaré dans le manifeste) : lisez-le ici plutôt que d'en supposer un. Il vaut `null` tant que le conteneur n'a jamais démarré. Deux champs optionnels du manifeste complètent la déclaration d'un port :
+
+- `browsable` (`true` par défaut) : un port qui sert une interface web obtient un lien « Ouvrir `<label>` » sur l'écran de supervision. Mettez-le à `false` pour un port qu'un navigateur ne peut pas ouvrir — un point d'entrée WebSocket qui attend des appareils, par exemple — et Gladys affiche un simple badge `<label> : <port hôte>` à la place.
+- `name` (`[a-z0-9_]`, de 2 à 20 caractères, unique dans tout le manifeste) : rend le port hôte alloué référençable depuis le placeholder `{{port:<name>}}` de votre formulaire de configuration, pour écrire une adresse de l'instance dans une phrase montrée à l'utilisateur (voir [Guider vos utilisateurs](#guider-vos-utilisateurs-dans-le-formulaire)).
+
 ### Journalisation
 
 Le SDK fournit un logger structuré pour que les logs de votre conteneur soient lisibles directement depuis `docker logs` :
@@ -357,7 +394,131 @@ await gladys.publishMessage(contactId, "La maison est maintenant vide.");
 - `linkContact(code, contactId, name?)` : relie un contact du fournisseur à un utilisateur Gladys à partir d'un code d'appairage à usage unique (valable 15 minutes), et retourne le selector de l'utilisateur, son prénom et sa langue.
 - `getContacts()` : liste les contacts actuellement reliés à ce canal.
 
-Une intégration `communication` a un écran de Configuration (issu de son `config_schema`) mais pas d'onglet Appareils ni Découverte.
+Une intégration `communication` déclare, via le champ obligatoire `messaging` du manifeste, à laquelle des **deux familles** elle appartient :
+
+- **Les canaux de chat bidirectionnels** (`"messaging": { "receive": true }`, les bots à la Telegram) : l'utilisateur relie son compte avec un code court envoyé dans le canal, puis dialogue avec le cerveau de Gladys depuis celui-ci. `onSendMessage` reçoit `{ id }`, le contact relié.
+- **Les canaux de notification en envoi seul** (`"messaging": { "receive": false }`, à la Free Mobile SMS ou CallMeBot) : il n'existe aucun chemin entrant, donc aucun code d'appairage non plus. Chaque utilisateur saisit ses propres identifiants dans le bloc « Mon compte » de l'écran de configuration, décrit par le `contact_schema` du manifeste (même format à plat que `config_schema`), et Gladys les transmet à votre gestionnaire avec chaque message sortant :
+
+```json
+"messaging": { "receive": false },
+"contact_schema": [
+  { "key": "username", "type": "string", "label": { "en": "Free Mobile login" }, "required": true },
+  { "key": "access_token", "type": "secret", "label": { "en": "SMS API key" }, "required": true }
+]
+```
+
+```js
+gladys.onSendMessage(async (contact, message) => {
+  // contact porte les valeurs du contact_schema de l'utilisateur ciblé
+  await sendFreeMobileSms(contact.username, contact.access_token, message.text);
+});
+```
+
+Les utilisateurs sans compte relié ou sans identifiants configurés sont ignorés par Gladys et n'atteignent jamais votre gestionnaire. Une intégration `communication` a un écran de Configuration (issu de son `config_schema`) mais pas d'onglet Appareils ni Découverte.
+
+### Fournisseurs météo
+
+*Nécessite Gladys 4.85.0 ou ultérieur.*
+
+Mettez `"type": "weather"` dans votre manifeste et votre intégration devient un **fournisseur météo** : Météo France, Open-Meteo, AccuWeather, un service météorologique national, ou votre propre agrégation. Comme un canal de messagerie, elle n'a ni onglet Appareils ni onglet Découverte, ne publie aucun appareil ni aucun état — elle répond aux demandes météo du cœur de Gladys via une **API de fournisseur dédiée**, et Gladys en alimente le widget météo du tableau de bord, l'assistant conversationnel (« quel temps fera-t-il demain ? ») et les déclencheurs de scène sur alerte météo.
+
+Installer une intégration météo **prend le pas sur le service OpenWeather intégré, sans aucune configuration**, et l'arrêter ou la désinstaller rebascule automatiquement. Les utilisateurs peuvent aussi épingler un fournisseur précis depuis la configuration du widget météo, quand plusieurs sont installés.
+
+Tout passe par un seul gestionnaire, qui résout le **format pivot météo** — une structure indépendante du fournisseur, généralisée à partir de ce qu'exposent les grands fournisseurs, pour que le cœur n'ait jamais à connaître le vôtre par son nom :
+
+```js
+import {
+  WEATHER_CONDITIONS,
+  WEATHER_ALERT_SEVERITIES,
+  WEATHER_ALERT_TYPES,
+} from "@gladysassistant/integration-sdk";
+
+gladys.onWeatherGet(async ({ latitude, longitude, language, units }) => {
+  const data = await fetchProviderForecast(latitude, longitude, language, units);
+  return {
+    // Obligatoires : temperature, weather (la condition), datetime.
+    temperature: data.current.temperature,
+    weather: WEATHER_CONDITIONS.RAIN,
+    datetime: new Date().toISOString(),
+    // Champs actuels optionnels, simplement ignorés si votre fournisseur ne les a pas :
+    apparent_temperature: data.current.feelsLike,
+    humidity: 80, // les pourcentages vont de 0 à 100
+    pressure: 1013,
+    wind_speed: 4.2,
+    wind_direction: 220,
+    uv_index: 3,
+    sunrise: data.current.sunrise,
+    sunset: data.current.sunset,
+    is_day: data.current.isDay, // booléen strict, pilote la variante d'icône jour/nuit
+    // Prévisions (Gladys conserve jusqu'à 24 heures et 8 jours) :
+    hours: data.hours.map((h) => ({ temperature: h.temp, weather: toCondition(h), datetime: h.time })),
+    days: data.days.map((d) => ({ temperature_min: d.min, temperature_max: d.max, datetime: d.date })),
+    // Alertes au format CAP, jusqu'à 10 (vigilance Météo France : jaune -> moderate, orange -> severe, rouge -> extreme) :
+    alerts: [
+      {
+        severity: WEATHER_ALERT_SEVERITIES.SEVERE,
+        event: "Orages violents",
+        type: WEATHER_ALERT_TYPES.THUNDERSTORM,
+      },
+    ],
+  };
+});
+```
+
+Le contrat, point par point :
+
+- **`units` est la préférence de l'utilisateur qui demande**, `metric` (°C, m/s, hPa, mm, km) ou `us` (°F, mph, in, mi) : retournez vos valeurs dans ce système d'unités. Les pourcentages (`humidity`, `cloud_cover`, `precipitation_probability`) vont toujours de 0 à 100, jamais sous forme de fraction entre 0 et 1.
+- **`weather` est une condition de l'énumération pivot** (`WEATHER_CONDITIONS`) : `clear`, `partly-cloudy`, `cloud`, `fog`, `drizzle`, `rain`, `pouring`, `sleet`, `hail`, `snow`, `thunderstorm`, `wind`, `night`, `unknown`. Faites correspondre les codes de votre fournisseur à ces valeurs ; toute autre valeur est ramenée à `unknown` (icône neutre).
+- **`is_day` porte le signal jour/nuit**, un booléen strict optionnel sur les conditions actuelles et sur chaque entrée de `hours` : `weather` porte la météo, `is_day` pilote la variante de rendu. La condition `night` reste acceptée pour compatibilité mais est **dépréciée côté fournisseurs** — une nuit pluvieuse, c'est `weather: "rain", is_day: false`, pas `"night"`.
+- **Chaque entrée de prévision a ses propres champs obligatoires** : `temperature`, `weather` et `datetime` pour une entrée de `hours` ; `temperature_min`, `temperature_max` et `datetime` pour une entrée de `days`. `days` peut inclure ou non le jour courant : les consommateurs filtrent par date calendaire, vous n'avez donc jamais à commencer par aujourd'hui.
+- **Les alertes suivent le standard CAP** : `severity` (`minor`, `moderate`, `severe`, `extreme`) et `event` sont obligatoires, `description`, `start`, `end` et `type` sont optionnels. Le `type` de phénomène (`wind`, `rain`, `flood`, `thunderstorm`, `snow`, `heat`, `cold`, `avalanche`, `coastal`, `fog`) permet à Gladys de traduire et d'illustrer l'alerte là où du texte libre ne le permet pas ; un type invalide est ignoré et l'alerte est conservée, rendue à partir de son seul `event`.
+- **L'accusé de réception est attendu jusqu'à 15 secondes** (au lieu des 5 standard), ce qui laisse le temps à un appel frais vers l'API d'un tiers. Lever une exception — fournisseur non configuré, API en panne — met la commande en échec, et Gladys bascule sur le fournisseur disponible suivant.
+- **La charge utile est normalisée et bornée par le cœur** : les champs inconnus sont ignorés, les nombres doivent être finis, les dates doivent être analysables, les tableaux sont plafonnés (24 `hours`, 8 `days`, 10 `alerts`, 3 `images`), et les chaînes des alertes sont tronquées (`event` jusqu'à 100 caractères, `description` jusqu'à 5 000 — les bulletins de vigilance sont longs).
+
+Deux extensions optionnelles complètent le type.
+
+**Les images du fournisseur** (une carte de vigilance, un radar de pluie, une vue satellite). La charge utile météo ne déclare jamais que des **métadonnées** — un tableau `images` d'au plus trois entrées `{ key, label? }`, où `key` respecte `^[a-z0-9][a-z0-9-]{0,31}$` — et les octets voyagent à la demande :
+
+```js
+gladys.onWeatherGetImage(async (key) => {
+  const png = await fetchVigilanceMap(); // retourne un Buffer
+  return png.toString("base64"); // base64 BRUT, sans préfixe « data: »
+});
+```
+
+Gladys valide les octets décodés (PNG ou JPEG, jusqu'à 500 Ko), les met en cache 10 minutes par clé, et les sert au navigateur depuis sa propre origine : l'adresse IP de vos utilisateurs n'atteint donc jamais un serveur tiers. Seule une clé déclarée dans votre dernière charge utile météo peut être demandée.
+
+**Le signal de fraîcheur.** Gladys réévalue les déclencheurs de scène sur alerte météo lors d'une vérification planifiée toutes les 30 minutes, obtenue via `onWeatherGet` et comparée sur les alertes normalisées. Un fournisseur qui *sait* que quelque chose a changé en amont peut faire mieux — jamais en poussant des données :
+
+```js
+onUpstreamVigilanceChange(() => gladys.requestWeatherRefresh());
+```
+
+`requestWeatherRefresh()` signifie uniquement « re-sollicite-moi maintenant » : les données réentrent par le chemin habituel `onWeatherGet`, et la scène se déclenche quelques secondes plus tard au lieu d'attendre 30 minutes. Le signal ne transporte rien, n'attend aucune réponse, et est limité à un par minute et par intégration (silencieusement ignoré au-delà).
+
+Rien d'autre n'est requis de votre côté : le déclencheur de scène sur alerte météo appartient au cœur et fonctionne à l'identique avec tous les fournisseurs.
+
+### Coordonnées des maisons
+
+*Nécessite Gladys 4.85.0 ou ultérieur.*
+
+Une intégration dont la logique dépend de l'endroit où vit l'utilisateur — qualité de l'air, pollens, restrictions d'eau, marées — peut lire les coordonnées des maisons configurées dans Gladys, au lieu de demander à l'utilisateur de ressaisir une latitude et une longitude dans votre formulaire de configuration.
+
+La localisation du domicile est une donnée personnelle sensible : l'accès est donc un **contrat d'autorisation**, comme les captures réseau. Déclarez `"location": true` dans votre manifeste (la demande est alors affichée à l'utilisateur sur l'écran d'installation) et Gladys sert `GET /house` sur l'API hôte. Une intégration qui ne l'a pas déclaré reçoit un `403`.
+
+Le SDK JavaScript n'encapsule pas encore ce point d'entrée : appelez-le avec les identifiants que Gladys injecte dans votre conteneur.
+
+```js
+const response = await fetch(`${process.env.GLADYS_HOST_API_URL}/api/integration/v1/house`, {
+  headers: { Authorization: `Bearer ${process.env.GLADYS_INTEGRATION_TOKEN}` },
+});
+const houses = await response.json();
+// [{ id, name, selector, latitude, longitude }], triées par nom
+```
+
+`latitude` et `longitude` valent `null` quand l'utilisateur n'a pas localisé la maison, et plusieurs maisons peuvent exister : gérez les deux cas. Seuls ces cinq champs sont retournés — jamais le mode d'alarme, le code ni le délai. Les coordonnées changent rarement : les récupérer au démarrage et à la reconnexion est le schéma nominal.
+
+Une intégration `weather` n'a besoin ni de ce point d'entrée ni de `location: true` : les coordonnées de la maison affichée voyagent dans les `options` de chaque demande météo.
 
 ### Webhooks entrants (Gladys Plus)
 
@@ -416,7 +577,7 @@ Chaque intégration externe est décrite par un unique fichier nommé `gladys-as
 | Champ | Requis | Description |
 | --- | --- | --- |
 | `manifest_version` | Oui | Doit valoir `1`. |
-| `type` | Oui | `"device"` (expose des appareils) ou `"communication"` (un canal de messagerie). |
+| `type` | Oui | `"device"` (expose des appareils), `"communication"` (un canal de messagerie) ou `"weather"` (un fournisseur météo). |
 | `name` | Oui | Nom d'affichage, de 3 à 30 caractères. |
 | `description` | Oui | Un objet indexé par langue. `en` est obligatoire, chaque texte fait de 10 à 100 caractères. |
 | `version` | Oui | [Version sémantique](https://semver.org/) stricte. L'incrémenter notifie les utilisateurs qu'une mise à jour est disponible. |
@@ -427,7 +588,10 @@ Chaque intégration externe est décrite par un unique fichier nommé `gladys-as
 | `transports` | Non | Sous-ensemble non vide de `local` et `cloud`, si votre intégration est à double canal. |
 | `actions` | Non | De 1 à 10 boutons d'action, chacun avec une `key`, un `label` multilingue, un `timeout_seconds` (de 5 à 120) et des `fields` optionnels. |
 | `network_discovery` | Non | De 1 à 5 méthodes de capture médiée (`udp-broadcast`, `udp-active-broadcast`, `mdns`, `ssdp`). |
-| `containers` | Non | Jusqu'à 5 conteneurs compagnons, chacun avec `name`, `docker_image`, `start` (`auto` ou `manual`), et optionnellement `env`, `volumes`, `ports`, `devices` (`coral-usb`, `coral-pcie`, `gpu`, `video`), `read_only`, `command`, `memory_mb` (de 32 à 4096), `cpu` (de 0,1 à 2), `shm_mb` (de 64 à 512). |
+| `containers` | Non | Jusqu'à 5 conteneurs compagnons, chacun avec `name`, `docker_image`, `start` (`auto` ou `manual`), et optionnellement `env`, `volumes`, `ports` (jusqu'à 3, chacun avec `container_port`, `protocol`, un `label` multilingue, un `name` optionnel et `browsable`), `devices` (`coral-usb`, `coral-pcie`, `gpu`, `video`), `read_only`, `command`, `memory_mb` (de 32 à 4096), `cpu` (de 0,1 à 2), `shm_mb` (de 64 à 512). |
+| `location` | Non | `true` demande l'accès aux coordonnées des maisons de l'utilisateur (`GET /house`). Affiché sur l'écran d'installation, appliqué côté serveur. |
+| `messaging` | Obligatoire pour `communication` | `{ "receive": true }` pour un canal de chat bidirectionnel, `{ "receive": false }` pour un canal de notification en envoi seul. Interdit pour les autres types. |
+| `contact_schema` | Obligatoire quand `messaging.receive` vaut `false` | Les identifiants propres à chaque utilisateur d'un canal en envoi seul, même format de champs que `config_schema` (hors champs `oauth2`). Interdit sinon. |
 | `webhooks` | Non | Jusqu'à 3 webhooks entrants (Gladys Plus), chacun avec une `key`, un `label` multilingue, et un `mode` (`fire_and_forget` ou `sync`). |
 
 ### Le schéma de configuration
@@ -437,6 +601,69 @@ Chaque intégration externe est décrite par un unique fichier nommé `gladys-as
 Un `select` ou un `multi_select` peut soit lister des `options` statiques, soit tirer ses choix dynamiquement des appareils de l'utilisateur avec `source: "devices"`, et s'afficher en `dropdown` ou en `radio` (`display`). Un champ `section` est purement présentationnel : il affiche une `description` et jusqu'à cinq liens de documentation (`links`), et ne stocke aucune valeur.
 
 Gladys génère automatiquement le formulaire de configuration à partir de cette liste, vous n'écrivez donc jamais de code frontend. Les valeurs marquées `secret` sont stockées de façon sécurisée et ne sont jamais renvoyées au frontend.
+
+### Guider vos utilisateurs dans le formulaire
+
+Un formulaire généré est compact, mais il ne donne à lui seul aucune aide à la prise en main : devant un champ « Client ID », l'utilisateur doit d'abord savoir qu'il lui faut créer une application sur la plateforme développeur du fabricant. C'est le rôle des champs `section` : des blocs purement présentationnels qui découpent le formulaire en chapitres, avec un titre, une `description` en texte brut (jusqu'à 1 000 caractères par langue) et jusqu'à cinq `links` (HTTPS uniquement), ouverts dans un nouvel onglet avec leur domaine cible affiché :
+
+```json
+"config_schema": [
+  {
+    "key": "intro",
+    "type": "section",
+    "label": { "en": "Getting started", "fr": "Pour commencer" },
+    "description": {
+      "en": "Create a developer account to get your API key.",
+      "fr": "Créez un compte développeur pour obtenir votre clé d'API."
+    },
+    "links": [{ "url": "https://open-meteo.com/en/docs", "label": { "fr": "Doc Open-Meteo", "en": "Open-Meteo docs" } }]
+  },
+  { "key": "api_key", "type": "secret", "label": { "en": "API key", "fr": "Clé d'API" }, "required": true }
+]
+```
+
+Les sections sont aussi autorisées dans les `fields` d'une action et dans un `contact_schema`, qui partagent le même format. Elles ne stockent aucune valeur : leur clé n'apparaît jamais dans `gladys.config`, dans `onConfigUpdated`, ni dans les champs reçus par le gestionnaire d'une action.
+
+Depuis Gladys 4.85.0, le `label` et la `description` d'une section peuvent contenir deux **placeholders en texte brut**, substitués par le frontend de Gladys au moment du rendu du formulaire :
+
+| Placeholder | Remplacé par |
+| --- | --- |
+| `{{gladys_host}}` | Le nom d'hôte de l'adresse par laquelle le navigateur atteint actuellement Gladys. |
+| `{{port:<name>}}` | Le port hôte que Gladys a attribué au port de sous-conteneur déclarant ce `name`. |
+
+C'est la façon déclarative d'écrire une adresse de l'instance elle-même — le cas d'un appareil qui doit se connecter *à* Gladys, comme une borne de recharge OCPP :
+
+```json
+"containers": [
+  {
+    "name": "ocpp",
+    "docker_image": "ghcr.io/acme/ocpp:1.2.0",
+    "ports": [
+      { "container_port": 9000, "name": "ocpp", "label": { "en": "OCPP endpoint" }, "browsable": false }
+    ]
+  }
+],
+"config_schema": [
+  {
+    "key": "charge_point",
+    "type": "section",
+    "label": { "en": "Connect your charge point", "fr": "Connectez votre borne" },
+    "description": {
+      "en": "Point your charge point to ws://{{gladys_host}}:{{port:ocpp}}/",
+      "fr": "Pointez votre borne vers ws://{{gladys_host}}:{{port:ocpp}}/"
+    }
+  }
+]
+```
+
+La syntaxe est exacte — aucun espace dans les accolades, aucune expression, aucun code injecté — et quatre règles sont à connaître :
+
+- un `{{port:<name>}}` qui référence un nom déclaré par aucun port de votre manifeste **rejette le manifeste**, aussi bien dans l'indexeur du store que sur le serveur ;
+- `{{port:<name>}}` est refusé dans un `contact_schema` : ce bloc est le seul écran qu'atteint un utilisateur non-administrateur, et sa vue réduite ne porte aucun état des conteneurs. `{{gladys_host}}`, lui, fonctionne partout ;
+- un `{{port:<name>}}` valide dont le port n'a pas encore de port hôte attribué (le sous-conteneur n'a jamais démarré) est laissé tel quel à l'écran, et se résout au prochain chargement de l'écran. Démarrez le conteneur qui publie le port avant de renvoyer l'utilisateur vers la phrase ;
+- en navigant via Gladys Plus ou un reverse proxy, `{{gladys_host}}` se résout en nom d'hôte du tunnel ou du proxy, pas en adresse locale de l'instance. Si l'appareil doit joindre Gladys sur le réseau local, dites-le dans la documentation de votre dépôt.
+
+Pour tout ce qui dépasse deux ou trois phrases (captures d'écran, pas-à-pas complet), le bon support reste la documentation obligatoire de votre dépôt : l'écran de configuration porte un lien **« Documentation »** permanent vers celle-ci, dans la langue de l'utilisateur, et c'est précisément au moment de configurer qu'il en a le plus besoin.
 
 ### Règles de l'image de couverture
 
@@ -494,7 +721,9 @@ Gladys affiche une interface générique pour chaque intégration externe, avec 
 
 - **Appareils** : les appareils que l'utilisateur a créés, avec des contrôles standards.
 - **Découverte** : les appareils que votre intégration a publiés, chacun avec un bouton « créer » en un clic.
-- **Configuration** : le formulaire généré à partir de votre `config_schema`, vos boutons d'action, ainsi que les contrôles de supervision (démarrer, arrêter, redémarrer, mettre à jour, voir les logs, désinstaller).
+- **Configuration** : le formulaire généré à partir de votre `config_schema`, vos boutons d'action, un lien permanent vers votre documentation, ainsi que les contrôles de supervision (démarrer, arrêter, redémarrer, mettre à jour, voir les logs, désinstaller).
+
+Les intégrations `communication` et `weather` n'exposent aucun appareil : elles n'ont donc que l'onglet Configuration.
 
 ### Environnement du conteneur
 
@@ -535,15 +764,19 @@ Le mainteneur ne valide rien et n'est jamais un goulot d'étranglement.
 
 ## Étape 6 : Les utilisateurs installent en un clic
 
-Depuis le catalogue de Gladys, les intégrations externes apparaissent aux côtés des intégrations intégrées, avec un **badge communautaire** et un indicateur de statut en direct. Un utilisateur clique sur **Installer**, et Gladys télécharge votre image, démarre le conteneur, et affiche l'interface générée. Les utilisateurs peuvent aussi installer directement depuis une URL de dépôt GitHub, sans attendre le prochain cycle d'indexation.
+Depuis le catalogue de Gladys, les intégrations externes apparaissent aux côtés des intégrations intégrées, avec un **badge communautaire**, les badges local/cloud déduits de vos `transports`, et un indicateur de statut en direct. Un utilisateur clique sur **Installer**, et Gladys télécharge votre image, démarre le conteneur, et affiche l'interface générée. Les utilisateurs peuvent aussi installer directement depuis une URL de dépôt GitHub, sans attendre le prochain cycle d'indexation.
+
+Avant l'installation, l'écran montre tout ce que votre manifeste a déclaré : votre documentation, les sous-conteneurs qui vont tourner et les ports qu'ils vont exposer, le matériel que vous demandez, les captures réseau, les webhooks, et l'accès aux coordonnées des maisons. Ne déclarez que ce dont vous vous servez réellement : chaque ligne est une question à laquelle l'utilisateur doit répondre avant de vous faire confiance.
 
 ## Mettre à jour votre intégration
 
-Livrer une nouvelle version tient en un clic : relancez le workflow **Release** et choisissez le niveau d'incrément. Il reconstruit l'image multi-architectures, pousse les nouveaux tags, et met à jour le manifeste pour vous. Au prochain cycle d'indexation, les utilisateurs voient qu'une mise à jour est disponible et peuvent l'appliquer en un clic.
+Livrer une nouvelle version tient en un clic : relancez le workflow **Release** et choisissez le niveau d'incrément. Il reconstruit l'image multi-architectures, pousse les nouveaux tags, et met à jour le manifeste pour vous. Au prochain cycle d'indexation, les utilisateurs voient qu'une mise à jour est disponible — avec un compteur dans l'en-tête de Gladys et une vue dédiée listant toutes les intégrations à mettre à jour — et peuvent l'appliquer en un clic.
 
 Si vous publiez manuellement, faites les deux mêmes choses à la main : construisez et poussez un nouveau tag d'image (par exemple `ghcr.io/yourname/my-integration:1.1.0`), puis incrémentez `version` et `docker_image` dans le manifeste et poussez.
 
 ## Dépannage
+
+Installer votre intégration depuis l'URL de son dépôt (ou en mode développeur) affiche les **erreurs de validation détaillées** de votre manifeste, champ par champ, pour les corriger sans attendre le prochain cycle d'indexation.
 
 L'indexeur est totalement transparent. Si votre intégration n'apparaît pas dans le catalogue, consultez le fichier `rejected.json` publié : il liste chaque dépôt qui a échoué à la validation, avec la raison et un niveau de sévérité (manifeste invalide, référence d'image mal formée ou non téléchargeable, plage `gladys_version` incompatible, couverture trop lourde ou aux mauvaises dimensions, `docs/en.md` ou `docs/fr.md` manquant, etc.). Vous pouvez détecter la plupart de ces problèmes avant de publier en lançant `npx github:GladysAssistant/integration-store .` en local. Corrigez le problème, republiez, et attendez le prochain cycle.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external.mdx
@@ -11,6 +11,8 @@ Les **intégrations externes** sont des intégrations créées par la communaut�
 
 N'importe qui peut en créer et en publier une, sans review ni validation du mainteneur : la liste ci-dessous grandit en continu, directement grâce à la communauté.
 
+Une intégration externe peut apporter des **appareils** (capteurs, interrupteurs, lampes, caméras…), un **canal de messagerie** (un pont de chat ou de notifications), ou, depuis Gladys 4.85, un **fournisseur météo** qui alimente le widget météo du tableau de bord, l'assistant conversationnel et les scènes d'alerte météo.
+
 Chaque intégration dispose de sa propre page, avec sa documentation, ses paramètres de configuration et ses étapes d'installation : cliquez sur une carte pour l'ouvrir.
 
 <ExternalIntegrations />

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/openweather.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/openweather.md
@@ -7,6 +7,12 @@ sidebar_label: OpenWeather
 
 Cette intégration vous permet de récupérer la météo dans Gladys Assistant.
 
+:::info[Depuis Gladys 4.85, la météo peut aussi venir d'une intégration externe]
+
+Les fournisseurs météo peuvent désormais être développés sous forme d'[intégrations externes](/fr/docs/integrations/external/), qui couvrent n'importe quel fournisseur (Météo France, Open-Meteo, AccuWeather…) et gèrent les alertes météo, les images du fournisseur et les déclencheurs de scène sur alerte météo. En installer une prend automatiquement le pas sur ce service OpenWeather intégré, qui est pour cette raison marqué comme déprécié dans le catalogue.
+
+:::
+
 ## Créez un compte OpenWeather
 
 Rendez-vous sur le site d'OpenWeather : [https://openweathermap.org/api](https://openweathermap.org/api).


### PR DESCRIPTION
## Summary

This PR documents the new features introduced in Gladys 4.85 (SDK 0.11.0) for external integrations, including weather providers, house location access, named ports with placeholders, and additional device categories.

## Key Changes

- **Weather providers**: Added comprehensive documentation for the new `weather` integration type, including:
  - The pivot weather format with required and optional fields
  - Weather conditions, alert severities, and alert types enums
  - Provider images support with base64 encoding
  - Weather refresh nudge mechanism via `requestWeatherRefresh()`
  - Integration with dashboard widget, chat assistant, and weather-alert scene triggers

- **House coordinates access**: Documented the `location: true` manifest declaration allowing integrations to read user house coordinates via the `/api/integration/v1/house` endpoint instead of asking users to re-enter latitude/longitude

- **Named ports and form placeholders**: Explained the new `name` and `browsable` port manifest fields, enabling:
  - `{{port:<name>}}` placeholders in configuration form text
  - `{{gladys_host}}` placeholder for instance address
  - `browsable: false` for non-web-UI ports (e.g., WebSocket endpoints)

- **New device categories**: Updated SDK constants documentation to include charging stations, water heaters, thermostat modes/states, battery storage, water valves, doorbells, and air-conditioning fan speed/swing

- **OAuth2 improvements**: Documented the single HTTPS redirect URI pattern for OAuth2, explaining how Gladys handles local vs. cloud access through a fixed HTTPS page

- **State publishing enhancements**: Clarified `publishState()` now supports text features (`{ text }`) and historical states (`{ state, created_at }`)

- **Device discovery limits**: Updated `publishDiscoveredDevices()` documentation to specify the 2,000 device per publication limit and silent update behavior for existing devices

- **Version requirements**: Added clear version requirements (4.85.0+) for new features in prerequisites section

## Notable Details

- Documentation is provided in both English and French
- Updated OpenWeather integration page to note that external weather providers now take precedence
- Included practical code examples for weather handler implementation
- Clarified the 15-second acknowledgment timeout for weather requests (vs. standard 5 seconds)
- Documented alert normalization and field truncation by the core

https://claude.ai/code/session_01495vn365vqMWo4n8bqFGU2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code modified.
> 
> **Overview**
> **Documents Gladys 4.85 / SDK 0.11.0** for external-integration authors in the EN and FR developer guides, with smaller catalog and OpenWeather user-facing updates.
> 
> The developer guide adds a 4.85 tip block and expands coverage of the **`weather`** type (pivot format, `onWeatherGet` / `onWeatherGetImage`, `requestWeatherRefresh`), **`location: true`** and `GET /house`, sub-container **`name` / `browsable`** ports plus **`{{gladys_host}}`** and **`{{port:<name>}}`** in section text, send-only **`messaging` / `contact_schema`**, OAuth2’s single HTTPS redirect URI, and refreshed manifest/SDK notes (discovery limits, `publishState` shapes, new device categories). Install/update/troubleshooting sections mention the pre-install manifest summary, header update counter, and field-level validation when installing from a repo URL.
> 
> The external integrations catalog pages note that integrations can be **weather providers** since 4.85. **OpenWeather** docs gain an info callout that external weather integrations override the built-in service (deprecated in catalog).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d122df1be5a4ee736a78c2df0f17ee5e7531d882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented support for external weather providers powering the weather widget, conversational assistant, and weather-alert scenes.
  - Added guidance for weather forecasts, alerts, images, refresh requests, and provider configuration.
  - Documented new integration capabilities, including OAuth2 redirects, named and non-browsable ports, form placeholders, device categories, and communication channels.
  - Clarified that external weather providers take precedence over the built-in OpenWeather integration, which is now deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->