### PR TITLE
fix(external-integrations): escape manifest values written into the MDX pages

### DIFF
--- a/docs/integrations/external/apple-tv.mdx
+++ b/docs/integrations/external/apple-tv.mdx
@@ -1,0 +1,226 @@
+---
+title: "Apple TV integration for Gladys Assistant"
+sidebar_label: "Apple TV"
+description: "Control your Apple TV: power, remote, playback, volume and applications. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/valentinhttr--gladys-apple-tv.jpg"
+keywords:
+  - "apple tv"
+  - "gladys apple tv"
+  - "apple tv gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/valentinhttr/gladys-apple-tv instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="apple-tv" />
+
+Control your Apple TV from Gladys Assistant: power, remote, playback, volume and
+applications. The integration talks to your Apple TV directly on your local
+network, using [pyatv](https://pyatv.dev) — the reference implementation of
+Apple's AirPlay and Companion protocols, and the same library Home Assistant
+uses. Nothing goes through Apple's servers, and no Apple ID is required.
+
+## Requirements
+
+- An Apple TV (HD, 4K, any generation running tvOS 15 or later).
+- Gladys 4.85.0 or later.
+- The Apple TV and your Gladys server on the **same network**. If they are on
+  different VLANs or subnets, see "Different subnets" below.
+- Physical access to the television during pairing: Apple displays a code on the
+  screen that you have to read and type into Gladys.
+
+## Setting it up
+
+Three steps, in this order. An Apple TV has to be **added** and then **paired**
+before a single command works — adding it alone gets you a device that obeys
+nothing.
+
+### 1. Find your Apple TV
+
+Open the **Discovery** tab of the integration and press **Scan**. Gladys listens
+for the AirPlay announcements on your network, and the integration checks every
+candidate address directly with pyatv. Your Apple TV appears with its name and
+its model.
+
+Press **Add to Gladys** to create the device. An Apple TV is usually named after
+the room it sits in ("Living room"), so the device is created as "Apple TV
+Living room" — clear in a device list, and it is also what makes its selector
+readable in scenes. You can rename it afterwards in the Devices tab.
+
+### 2. Pair it
+
+Pairing is what authorizes Gladys to control the device. It happens in the
+**Configuration** tab, with the first two buttons:
+
+1. **1. Pair an Apple TV** — pick your Apple TV in the dropdown and press
+   **Run**. The list holds the Apple TVs you added at step 1, so there is no IP
+   address to look up. A code appears on your television.
+2. **2. Enter the code** — type the code you see on screen, then press **Run**.
+
+Apple asks for one code **per protocol**: after the first code is accepted, a
+second one appears on the television. Two codes is normal.
+
+The second code goes in **the same field as the first one**. The form keeps
+what you typed, so you have to **clear the field and type the new code in its
+place**, then press the button again. Pressing it a second time without
+clearing does nothing useful — the integration recognizes the old code and says
+so rather than wasting the new one.
+
+Codes expire fast, and the connection carrying them closes on its own after a
+short while. If that happens, the integration says so and immediately puts a
+**new code** on your television: read the message, clear the field, enter the
+new code, and carry on. There is no need to start over from step 1.
+
+Once pairing is complete, run a scan again (or accept the **Update** that Gladys
+offers in the Discovery tab): the integration now knows what your Apple TV can
+actually do, and adds the volume control and the application shortcuts.
+
+### 3. Use it
+
+The device exposes:
+
+- **Power** — on/off. "Off" means standby, in Apple's sense: the box stays on the
+  network, the screen and the HDMI output go away.
+- **Remote** — directional pad, OK, Back, Home, Control Center.
+- **Playback** — play, pause, stop, previous, next, rewind, fast forward.
+- **Volume** — a slider, plus volume up/down buttons. The slider only appears
+  when your setup exposes a readable volume level. An Apple TV controlling a
+  soundbar over HDMI-CEC usually only supports the up/down buttons.
+- **Now playing** and **Application** — text sensors showing what is on screen.
+- **Application shortcuts** — one button per installed application, so a scene
+  can open Netflix or Disney+ directly. Disable them, or lower the maximum, in
+  the configuration.
+
+### On a dashboard
+
+Two boxes, two ways to use the same Apple TV:
+
+- **Devices in a room** — every remote key is a real button you can press:
+  the directional pad, OK, Back, Home, Control Center, play, pause, the
+  transport keys, the volume slider and the application shortcuts. This is the
+  remote.
+- **Music box** — the transport bar of a media player. Add the Apple TV to it
+  and drive it like a Sonos.
+
+The device list shows both sets, which is why some keys appear twice: the ones
+prefixed with "Media" are what the Music box uses, the short ones are the remote
+buttons. Each box only offers the features it can actually use, so you never
+have to choose between them.
+
+## Configuration
+
+| Setting                     | What it does                                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Discovery duration          | How long Gladys listens for AirPlay announcements. Increase it on a busy or slow network.                                 |
+| Manual IPv4 addresses       | Only needed when announcements do not reach Gladys (routed networks, VLANs). Added to the automatic discovery.            |
+| Refresh interval            | How often the integration reconciles what the Apple TV does not push by itself, typically the power state on some models. |
+| Application shortcuts       | Whether to expose one button per installed application.                                                                   |
+| Maximum number of shortcuts | An Apple TV can have a hundred applications; this bound keeps the device readable.                                        |
+
+## Other actions
+
+Each one acts on an Apple TV you pick in a dropdown — the same list as the
+pairing buttons, filled with the devices you added from the Discovery tab.
+
+- **Reconnect and refresh** — reopen the session and read the device again. The
+  first thing to try when something looks stale.
+- **List the installed applications** — shows the bundle identifier of every
+  application, which is what "Launch an application" expects.
+- **Launch an application** — opens an application by bundle identifier, e.g.
+  `com.netflix.Netflix`.
+- **Play a URL** — sends a video URL or a deep link to the Apple TV over AirPlay.
+- **Delete the pairing** — forgets the stored credentials. Use it when pairing
+  has to be redone, for example after a factory reset of the Apple TV.
+
+## Troubleshooting
+
+**The scan finds nothing.** Gladys captures AirPlay announcements from the host
+network. Check that your Apple TV is powered on, that AirPlay is enabled
+(Settings → AirPlay and HomeKit), and that Gladys is on the same network. If your
+Gladys server is on a different subnet, fill in the manual IPv4 address.
+
+The integration log names what it saw: if it reports announcements that
+"carried no IPv4 address", your Apple TV _was_ announced but its address never
+reached Gladys — go straight to the manual address.
+
+**You run Gladys in Docker on a Mac or on Windows.** Discovery cannot work
+there, and it is not a misconfiguration on your side. Docker Desktop, OrbStack
+and Colima run containers inside a Linux virtual machine, so `network_mode:
+host` means _the virtual machine's_ network, not your Wi-Fi. Multicast from
+your Apple TV never reaches Gladys. Unicast does, so everything else works:
+put the IP address of your Apple TV in "Manual IPv4 addresses" and the
+integration discovers, pairs and controls it normally. A Gladys running on
+Linux (Raspberry Pi, NAS, server) is on the network for real and does not need
+this.
+
+**Every command fails with "not paired yet".** The device was added but never
+paired. Run the two pairing buttons in the Configuration tab.
+
+**The pairing dropdown is empty.** It only lists Apple TVs already added to
+Gladys, so step 1 has not happened yet: go to the Discovery tab, press **Scan**,
+then **Add to Gladys**.
+
+**Pairing fails or the code is refused.** The code expires quickly — start again
+and enter it right away. If it keeps failing, remove Gladys from the Apple TV
+(Settings → General → AirPlay and HomeKit → Allow Access), run "Delete the
+pairing" in Gladys, then pair again.
+
+**The device shows as unreachable.** Check that the Apple TV is powered on and
+still has the same IP address. A scan refreshes the address the integration uses;
+a static lease on your router avoids the problem entirely.
+
+**There is no volume slider.** Your setup does not expose a readable volume
+level — a common case with HDMI-CEC. Use the volume up and volume down buttons
+instead.
+
+**Different subnets.** mDNS announcements do not cross subnets. Fill in the IPv4
+address of each Apple TV in "Manual IPv4 addresses"; the integration queries them
+directly, which works as long as the traffic is routed.
+
+## Privacy and storage
+
+The pairing credentials are stored in the integration's own writable volume
+(`/data/pyatv.json`), never in the Gladys configuration, and never leave your
+network. Deleting the integration deletes them with it.
+
+## Configuration settings
+
+These are the settings Apple TV asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| Setting up your Apple TV, step by step | `section` | No | An Apple TV has to be added AND paired before a single command works. Three steps, in this order. 1) Discovery tab: press "Scan", wait, then press "Add to Gladys" on your Apple TV. It now exists in Gladys, but obeys nothing yet. 2) Back on this page, at the bottom: run "1. Pair an Apple TV" and pick it from the list — no IP address to look up. A code appears on your television; type it in "2. Enter the code". Apple asks for one code per protocol, so a second code follows: clear the field and type the new one in its place. 3) Discovery tab again: press "Update" on your Apple TV to pick up the volume control and the application shortcuts that the pairing revealed. |
+| Finding your Apple TV | `section` | No | These two settings only affect the scan of the Discovery tab. The defaults work on a normal home network: leave them alone unless a scan comes back empty. |
+| Discovery duration (seconds) | `number` | No | How long Gladys listens for AirPlay announcements. Increase it on a busy or slow network. |
+| Manual IPv4 addresses | `string` | No | Optional, comma separated. Needed only when Gladys and your Apple TV are on different subnets or VLANs, where mDNS announcements do not travel. They are added to the automatic discovery, so the Apple TV still shows up in the Discovery tab like any other. |
+| What the device exposes | `section` | No | These settings shape the Gladys device itself. Changing one takes effect on the next "Update" you accept in the Discovery tab. |
+| Refresh interval | `select` | No | The Apple TV pushes what it can in real time. This interval reconciles what it does not push, typically the power state on some models. |
+| Application shortcuts | `boolean` | No | Add one button per installed application to the device, so scenes can open Netflix or Disney+ directly. Read from the Apple TV after pairing. |
+| Maximum number of shortcuts | `number` | No | An Apple TV can have a hundred applications. This bound keeps the device readable. |
+| Pairing and tools, with the buttons below | `section` | No | Everything below this line acts on an Apple TV you already added from the Discovery tab: pick it in the list, then press "Run". The first two buttons are the pairing itself and they go together — start with "1. Pair an Apple TV". The others are troubleshooting tools you will rarely need. |
+
+## How to install Apple TV in Gladys
+
+1. In Gladys, open **Integrations**: Apple TV appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/valentinhttr/gladys-apple-tv:1.0.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/valentinhttr/gladys-apple-tv](https://github.com/valentinhttr/gladys-apple-tv).
+
+Apple TV requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+Apple TV is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [valentinhttr](https://github.com/valentinhttr), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/valentinhttr/gladys-apple-tv) — [source of this documentation](https://github.com/valentinhttr/gladys-apple-tv/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/charger-station.mdx
+++ b/docs/integrations/external/charger-station.mdx
@@ -1,0 +1,215 @@
+---
+title: "Charger Station integration for Gladys Assistant"
+sidebar_label: "Charger Station"
+description: "Follow your charging stations in Gladys, live, through the OCPP protocol. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/sescandell--gladys-ocpp-integration.png"
+keywords:
+  - "charger station"
+  - "gladys charger station"
+  - "charger station gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/sescandell/gladys-ocpp-integration instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="charger-station" />
+
+**Read-only supervision.** This integration observes any
+number of OCPP 1.6 charge points and shows their state in Gladys
+(connector status, charging state, power, current, voltage, total energy) —
+there is no way to start, stop, or limit a charge from Gladys yet.
+
+## How it works
+
+```mermaid
+flowchart LR
+    CP(["Charge point"]) <-->|OCPP, WebSocket| Relay["OCPP relay"]
+    Relay <-->|OCPP, forwarded| Cloud[("Vendor cloud")]
+    Relay <-.->|state and config, HTTP| Gladys[("Gladys")]
+```
+
+The integration runs its own OCPP relay. Every charge point connects to the
+**same** URL — the relay tells them apart by the identity each one
+announces on connection. The moment a charge point points at that URL (see
+Setup below), the relay supervises it **automatically**, with no need to
+declare it in Gladys first: it answers it normally, so charging itself
+keeps working. But until you attach it to **its own** origin cloud, that
+cloud is completely out of the loop — nothing that goes through the
+vendor's app (remote start/stop, live status, charge history) works during
+that window, since the vendor's backend has no connection to the charge
+point at all. Attaching the origin cloud changes that: the relay then also
+forwards the charge point's traffic there, and the vendor's app works
+exactly as before again. The relay only _observes_ what passes through it
+to build the state shown in Gladys; it never invents or withholds anything
+on the wire, in either mode.
+
+## Prerequisites
+
+**Gladys 4.85.0 or later.** The charge point state is published using
+Gladys's charging-station device features, which older versions don't know
+about (they would refuse to create the device).
+
+Each charge point's vendor app or portal must let you view and change the
+OCPP server URL it connects to. Not every vendor exposes this — if yours
+doesn't, this integration cannot be used for that charge point.
+
+**Before changing anything, write down the OCPP server URL currently shown
+by the vendor app.** It is the only way back to the vendor's own cloud if
+you ever want to stop using this integration for that charger.
+
+## Setup
+
+Five steps, once per charge point. Nothing is lost along the way: the charge
+point keeps its own connection to the vendor's cloud, Gladys simply sits in
+the middle and watches.
+
+1. **Write down the OCPP server URL** your charge point currently uses, from
+   its vendor app. This is your only way back to the vendor's cloud — keep
+   it somewhere safe.
+2. **Point the charge point at Gladys**: in that same app, replace the URL
+   with the one shown in the walkthrough on the integration's
+   **Configuration** screen — it's filled in for you, address and port
+   included. The same URL works for **every** charge point.
+3. **Add it to Gladys**: it connects immediately and appears in the
+   **Discovery** tab, already supervised. Add it from there.
+4. **Give it back its cloud**: on the Configuration screen, run the
+   **"Add a charge point"** action, pick it from the list, and paste the URL
+   from step 1 — exactly as the vendor app showed it, including any trailing
+   query string some vendors use (e.g. ending in `?sn=`).
+5. **Done.** The charge point reconnects on its own within seconds and
+   carries on talking to its vendor's cloud exactly as before, through
+   Gladys — which now follows it live.
+
+Repeat for every other charge point: same Gladys URL, its own vendor URL,
+even a different vendor.
+
+To fix a mistake or change a charge point's origin cloud URL, run the action
+again for the same charge point with the corrected URL (check its current
+URL on its device card first). To detach a charge point from its cloud and
+put it back into local-only supervision, run the action for it with an
+**empty** URL — takes effect the next time that charge point reconnects (it
+keeps relaying through its current connection until then).
+
+If you **delete** a charge point's device from Gladys while it still has an
+origin cloud configured, it disappears from the picker and the action can no
+longer change it — the relay keeps using that cloud. Add the device back
+from Discovery to regain control of it.
+
+## Starting over
+
+Uninstalling the integration removes everything it created: its devices, its
+stored configuration, and the relay's own container and data. Nothing is left
+behind, so reinstalling starts genuinely fresh.
+
+To go back to your vendor's cloud directly, put the URL you noted in step 1
+back into the charge point's app — it stops going through Gladys at its next
+reconnection.
+
+## What you see on a charge point
+
+Each connector reports two state features, plus its measurements (power,
+current, voltage, total energy):
+
+- **Status** — what the connector itself is doing: _Available_, _Occupied_,
+  _Reserved_, _Unavailable_, _Faulted_.
+- **Charging state** — what the session is doing: _Charging_, _Vehicle
+  connected_, _Paused (vehicle)_, _Paused (charger)_, _Idle_.
+
+OCPP 1.6 charge points report a single, more detailed status, which is split
+across those two: `Preparing` and `Finishing` both show as "Occupied /
+Vehicle connected" (a vehicle is physically connected in both cases),
+`Charging` as "Occupied / Charging", and `SuspendedEV`/`SuspendedEVSE` as
+"Occupied / Paused (vehicle)"/"Occupied / Paused (charger)". When no session
+is in progress, the charging state reads _Idle_. Both features stay empty
+until the charge point
+has reported its status at least once.
+
+Values update **as they happen**, within a few seconds: the relay tells the
+integration about every change it observes rather than being asked at
+intervals. A charge point that connects for the first time also appears in
+Discovery on its own, without waiting for a refresh.
+
+## Multiple connectors
+
+A charge point is one device in Gladys, whatever its number of physical
+connectors. It starts with one connector's worth of features (status,
+charging state, power, current, voltage, energy); if it has more than
+one physical connector, the extra ones appear as additional features
+("Connector 2 - ...", etc.) once the gateway has actually seen them report
+their status at least once. If you've already created the device, Gladys
+shows an **Update** button once new connectors are picked up — nothing is
+added silently to a device you already created. If a connector doesn't
+appear yet, try **Rescan** from the Discovery tab after using that
+connector.
+
+## Security note
+
+Exposing the relay's OCPP port makes it reachable by anything on your LAN,
+without authentication — this is inherent to how OCPP charge points connect
+to a server. The relay only ever _observes_ what passes through it and never
+makes decisions on its own (it never invents a transaction, never authorizes
+a charge): at worst, a rogue device on your LAN could feed misleading data
+into this integration's view, but it cannot affect a real charge point,
+which keeps its own independent connection to its vendor's cloud through the
+relay. Keep this in mind on a shared or untrusted network.
+
+## Known limitations (this version)
+
+- **The relay's state resets on restart** (host reboot, a crash): it only
+  remembers what it has seen since it last started, including which charge
+  points are configured — the integration re-sends the full configured set
+  as soon as it reconnects to Gladys, so this self-heals within seconds and
+  does not require re-running the action. Freshly restarted, already-known
+  charge points briefly disappear until they reconnect (normally within
+  seconds); this does not delete any device you already created in Gladys.
+- **Starting a charge session while a charge point is still locally
+  supervised (no origin cloud attached yet), then attaching a cloud mid-session:**
+  the charge point may keep referencing the session it started locally once
+  it reconnects into relay mode, which the real origin cloud never saw. A
+  rare overlap in practice (attaching a cloud is usually done once, right
+  after first connecting) — if it happens, the affected session's data may
+  not reach the origin cloud correctly; the next session is unaffected.
+- **No control from Gladys.** Starting, stopping, or limiting a charge is not
+  possible in this version.
+
+## Troubleshooting
+
+Check the integration's logs from the Gladys UI (supervision block →
+container selector) for the main container and, separately, for the
+`gateway` sub-container — that is where the OCPP relay itself logs every
+connection, disconnection, and relayed message (full payload, both
+directions) for every charge point.
+
+## Configuration settings
+
+These are the settings Charger Station asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| Connecting a charge point | `section` | No | In your charge point's app, note down its current OCPP URL and keep every setting you find there: that's what lets you get back to normal operation if anything goes wrong. Replace that URL with ws://\{\{gladys_host\}\}:\{\{port:ocpp\}\}/ - the same one for every charge point. Your charge point reconnects right away and appears in the Discovery tab: add it to Gladys. Then come back here, in the Action section below, select your charge point and paste the OCPP URL you noted in the first step - that's what lets it keep talking to its vendor's cloud, now relayed through Gladys. |
+
+## How to install Charger Station in Gladys
+
+1. In Gladys, open **Integrations**: Charger Station appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/sescandell/gladys-ocpp-integration:1.0.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/sescandell/gladys-ocpp-integration](https://github.com/sescandell/gladys-ocpp-integration).
+
+Charger Station requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+Charger Station is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [sescandell](https://github.com/sescandell), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/sescandell/gladys-ocpp-integration) — [source of this documentation](https://github.com/sescandell/gladys-ocpp-integration/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/daikin-cloud.mdx
+++ b/docs/integrations/external/daikin-cloud.mdx
@@ -30,23 +30,25 @@ today, Gladys just becomes another remote control.
 For every air conditioner of your Daikin account, Gladys creates one device
 with the features your model actually supports:
 
-| Feature             | What it does                                                         |
-| ------------------- | -------------------------------------------------------------------- |
-| On/Off              | Turn the unit on and off                                             |
-| Mode                | Auto, Cooling, Heating, Drying, Fan only                             |
-| Target temperature  | The setpoint of the mode currently active                            |
-| Fan speed           | The fan speed, on the scale your unit declares (often 1-5)           |
-| Horizontal airflow  | The left/right airflow direction                                     |
-| Vertical airflow    | The up/down airflow direction                                        |
-| Powerful mode       | Daikin's "Powerful" mode (switch)                                    |
-| Econo mode          | Daikin's "Econo" mode (switch)                                       |
-| Streamer mode       | The "Streamer" air purification mode (switch)                        |
-| Keep dry            | The indoor unit's "Keep dry" advanced function                       |
-| Room temperature    | The temperature the unit measures (sensor, kept in history)          |
-| Outdoor temperature | The temperature the outdoor unit measures (sensor, kept in history)  |
-| Energy today        | Electrical consumption for the day, in kWh (sensor, kept in history) |
-| Energy this month   | Electrical consumption for the current month, in kWh                 |
-| Energy this year    | Electrical consumption for the current year, in kWh                  |
+| Feature                    | What it does                                                         |
+| -------------------------- | -------------------------------------------------------------------- |
+| On/Off                     | Turn the unit on and off                                             |
+| Mode                       | Auto, Cooling, Heating, Drying, Fan only                             |
+| Target temperature         | The setpoint of the mode currently active                            |
+| Fan speed                  | The fan speed, on the scale your unit declares (often 1-5)           |
+| Horizontal airflow         | The left/right airflow direction                                     |
+| Vertical airflow           | The up/down airflow direction                                        |
+| Powerful mode              | Daikin's "Powerful" mode (switch)                                    |
+| Econo mode                 | Daikin's "Econo" mode (switch)                                       |
+| Streamer mode              | The "Streamer" air purification mode (switch)                        |
+| Keep dry                   | The indoor unit's "Keep dry" advanced function                       |
+| Room temperature           | The temperature the unit measures (sensor, kept in history)          |
+| Outdoor temperature        | The temperature the outdoor unit measures (sensor, kept in history)  |
+| Energy today               | Electrical consumption for the day, in kWh (sensor, kept in history) |
+| Energy this month          | Electrical consumption for the current month, in kWh                 |
+| Energy this year           | Electrical consumption for the current year, in kWh                  |
+| Energy today (consumption) | What the unit used over the last 30 minutes, filled in by Gladys     |
+| Energy today (cost)        | What those 30 minutes cost, from your energy contract                |
 
 A model without louvers gets no airflow direction, a model without a fan gets
 no fan speed, a model without the Streamer function gets no Streamer switch:
@@ -79,6 +81,23 @@ index. Daikin splits those counters per mode (heating, cooling…); the
 integration sums them, because what a dashboard wants is what the unit consumed,
 not how it was split.
 
+Their resolution is Daikin's, not the refresh interval's: Daikin splits the day
+into two-hour slots, and the daily counter — their total — moves in **steps of
+0.1 kWh**, as soon as that extra tenth of a kWh has been used. So "Energy today"
+stays flat for a while, then jumps: refreshing more often does not make it
+smoother, it only spends your API quota faster. That daily counter is the finest
+thing the API gives, which is what makes it the right one to feed Gladys' energy
+monitoring: its midnight reset costs almost nothing (the first value after
+midnight is 0, and Gladys ignores the negative step of a counter going back to
+zero).
+
+While the unit runs, it crosses those 0.1 kWh every few tens of minutes: each
+30-minute window then gets its value, and the **Day** view of the energy
+monitoring looks like a real consumption curve, matching what the Onecta app
+shows. The step only becomes visible at very low draw: a few windows stay at
+zero, then a later one catches up. That is a shift of a few tens of minutes at
+worst, and the daily, monthly and yearly totals stay correct.
+
 Daikin reports some functions read-only depending on the model and firmware —
 "Keep dry" almost always is. Those are published as sensors, without a switch
 the API would refuse anyway.
@@ -91,6 +110,80 @@ the API would refuse anyway.
 Heat pumps (Altherma…) are partially supported: their on/off, mode and outdoor
 temperature work, but their water temperature setpoint is not exposed — this
 integration targets air conditioners.
+
+## Energy monitoring
+
+Your air conditioner can take its place in the
+[energy monitoring](https://gladysassistant.com/docs/integrations/energy-monitoring/)
+of Gladys, next to your electricity meter and your smart plugs: the Energy
+dashboard then shows, in thirty-minute steps, what the air conditioner used and
+what it cost you.
+
+### What the integration wires up on its own
+
+The integration publishes the two features that make that computation possible —
+**Energy today (consumption)** and **Energy today (cost)** — and chains them
+itself: the cost points at the consumption, which points at **Energy today**.
+Gladys fills them in every thirty minutes, from the difference between two
+readings of the daily counter and the price of a kWh in your contract; nothing
+writes them here, and there is nothing to set on those two rows. If you pick a
+different parent for them in the Energy screen, the integration will put its own
+back on the next publish.
+
+### The one step left to you
+
+In **Settings → Energy**, pick the parent of **Energy today**: the feature of
+your main meter (the daily consumption reported by your utility, a whole-house
+clamp…). That is what tells Gladys the air conditioner is a _part_ of what the
+meter already counts, rather than an extra consumption on top of it.
+
+The screen then looks like this:
+
+```
+Main meter — Daily consumption                         level 0
+└── Air conditioner — Energy today                     level 1   ← the only row to set
+    └── Air conditioner — Energy today (consumption)   level 2   ← set by the integration
+        └── Air conditioner — Energy today (cost)      level 3   ← set by the integration
+
+Air conditioner — Energy this month                    level 0   ← normal, nothing to do
+Air conditioner — Energy this year                     level 0   ← normal, nothing to do
+```
+
+The level shown in front of each row is nothing more than its depth in that
+tree: level 0 = root, that is, a feature that is not a part of anything else.
+Your main meter sits there because nothing contains it; the air conditioner sits
+below it because its kWh are part of the meter's.
+
+That choice is yours and it stays yours: the integration never sends the parent
+of **Energy today**, not even empty, precisely so that it cannot undo your
+setting on every publish.
+
+### Why "Energy this month" and "Energy this year" stay at level 0
+
+That is intended: those two rows have no parent, and there is nothing to fix.
+
+- **They are the same kWh.** The tree is a breakdown, not a list: every child
+  states "my consumption is a part of my parent's". The monthly and yearly
+  counters measure exactly the same electricity as the daily one, over a wider
+  window. Hanging them under the main meter would make the same kWh show up two
+  more times in the breakdown.
+- **They would feed nothing more.** Only the daily counter carries the 30-minute
+  pair, because it is the finest thing the Daikin API gives. A pair hung on the
+  monthly counter would be a duplicate, and the yearly counter — which only
+  moves once a day — would deliver a single block a day: the dashboard would
+  gain nothing.
+- **They are not children of "Energy today" either.** A parent is a whole and a
+  child is a part of it: a month is not a part of a day.
+- **They stay useful elsewhere**: a dashboard tile, a history chart, a scene
+  condition. They are there to be read, they do not enter the energy monitoring
+  computation.
+
+In other words, a correctly configured setup does leave two features of the air
+conditioner at level 0, next to the main meter.
+
+> **The energy monitoring needs Gladys 4.66 or newer.** On an older instance the
+> two features are simply not published, and the rest of the integration is
+> unaffected.
 
 ## Before you start: create your Daikin application
 
@@ -223,6 +316,13 @@ firmware, so check rather than assume: run **Test the connection**. A name that
 appears neither in the published features nor in the ignored characteristics is
 one the API does not expose for your unit.
 
+**The "Energy today (consumption)" and "(cost)" rows do not show up in
+Settings → Energy.**
+They need Gladys 4.66 or newer. If your version is recent enough, the device was
+created before they existed: run _Test the connection_, which re-publishes the
+discovery and completes the devices already created. They arrive already chained
+to one another; all that is left is to give **Energy today** a parent.
+
 **Nothing appears in the Discovery tab.**
 Make sure the units are visible in the Onecta app with the same account, then
 run _Test the connection_: the message tells you how many units the API
@@ -248,7 +348,7 @@ These are the settings Daikin Cloud asks for in its configuration screen in Glad
 ## How to install Daikin Cloud in Gladys
 
 1. In Gladys, open **Integrations**: Daikin Cloud appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-daikin-cloud:1.0.7`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-daikin-cloud:1.0.10`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/prohand/gladys-daikin-cloud](https://github.com/prohand/gladys-daikin-cloud).
 

--- a/docs/integrations/external/gardena-smart-system.mdx
+++ b/docs/integrations/external/gardena-smart-system.mdx
@@ -1,0 +1,218 @@
+---
+title: "GARDENA smart system integration for Gladys Assistant"
+sidebar_label: "GARDENA smart system"
+description: "Control your GARDENA mowers, valves, power sockets and sensors from Gladys. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/Nagromdark--gladys-gardena.png"
+keywords:
+  - "gardena smart system"
+  - "gladys gardena smart system"
+  - "gardena smart system gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/Nagromdark/gladys-gardena instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="gardena-smart-system" />
+
+Control your GARDENA garden from Gladys: robotic mowers, water valves, outdoor
+power sockets and soil sensors. The integration talks to the **official public
+GARDENA smart system API**, the same one the GARDENA app uses, so everything
+stays in sync in both directions.
+
+## What you need
+
+- a **GARDENA smart gateway** already installed, with your devices paired and
+  working in the GARDENA app;
+- a free account on the **Husqvarna developer portal** (GARDENA belongs to the
+  Husqvarna Group) — the API is free for personal use.
+
+The integration never talks to your devices directly: GARDENA devices speak a
+proprietary radio protocol to the gateway, and the gateway only talks to the
+GARDENA cloud. An Internet connection is therefore required.
+
+## Step 1 — Create your API application
+
+1. Go to [https://developer.husqvarnagroup.cloud/](https://developer.husqvarnagroup.cloud/) and click **Sign in**.
+2. Sign in with **your usual GARDENA account** (the one from the GARDENA app).
+   There is no separate account to create.
+3. Open **My applications** and click **New application**. Give it any name,
+   for example `Gladys`. The redirect URI is not used by this integration: you
+   can leave it empty or put `http://localhost`.
+4. On the application page, click **Connect new API** and connect the
+   **GARDENA smart system API**. This step is easy to miss, and without it the
+   API answers `403 Forbidden` to every request.
+5. Copy the **Application key** and the **Application secret** shown on that
+   page.
+
+> Keep the Authentication API connected as well — it is usually added
+> automatically, and it is the one that issues the token.
+
+## Step 2 — Configure the integration in Gladys
+
+1. Paste the **Application key** and the **Application secret** in the
+   configuration screen, then save.
+2. Click **Test the connection**: the integration authenticates and lists the
+   locations (gardens) of your account.
+3. Go to the **Discover** tab: every GARDENA device of your account appears.
+   Create the ones you want to use in Gladys.
+
+Optional settings:
+
+| Setting                    | What it does                                                                                                                                                                                 |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Location id**            | Restrict the integration to a single garden. Leave empty to use all of them.                                                                                                                 |
+| **GARDENA API refresh**    | Minimum delay between two full reads of the GARDENA API, the safety net behind the real-time stream. This is what spends your weekly request quota — see the table below. Default: one hour. |
+| **Default duration**       | How long a valve waters, or a socket stays on, when you switch it on from Gladys.                                                                                                            |
+| **Power socket switch-on** | Switch off automatically after the default duration, or stay on until switched off.                                                                                                          |
+| **Mower start**            | Starting the mower can obey its own calendar, or override it for a fixed duration.                                                                                                           |
+| **Mower stop**             | Stopping the mower can park it until its next scheduled task, or cancel the schedule until further notice.                                                                                   |
+
+## What you get in Gladys
+
+| GARDENA device                   | Features created                                                                        |
+| -------------------------------- | --------------------------------------------------------------------------------------- |
+| smart Mower (SILENO...)          | Mowing (on/off), activity, state, last error, operating hours, battery, signal          |
+| smart Water Control              | Watering (on/off), activity, watering time left, battery, signal                        |
+| smart Irrigation Control         | One watering switch, activity and time left **per outlet**, named as in the GARDENA app |
+| smart Power (outdoor socket)     | On/Off, activity, time left, signal                                                     |
+| smart Sensor / smart Soil Sensor | Soil humidity, soil temperature, ambient temperature, light intensity, battery, signal  |
+
+Switching a valve on starts a **manual watering of the configured duration**:
+the GARDENA API has no "open forever" command on a valve, which is exactly what
+you want from a home automation system connected to a water tap.
+
+The on/off state of a mower, a valve or a socket always reflects what GARDENA
+reports, not what Gladys asked for: a mower that came home because of the rain,
+or a valve opened from the GARDENA app, shows up correctly in Gladys.
+
+## Real time
+
+The integration keeps a websocket open to GARDENA for each location, which is
+the supported way to follow a garden: a change made on the device, in the
+GARDENA app or by a schedule reaches Gladys within a second or two. The
+scheduled refresh is only a safety net for a missed message.
+
+GARDENA closes that websocket about every two hours, on purpose: the
+integration reconnects on its own, and resynchronizes each time.
+
+Gladys ticks its devices every minute (its shortest supported interval), but
+that tick does **not** call GARDENA: the integration answers from the picture it
+already holds, and only re-reads the GARDENA API once the picture is older than
+the **GARDENA API refresh** setting. Whatever the number of devices in your
+garden, one refresh costs one API call.
+
+## Staying inside the GARDENA request quota
+
+GARDENA grants a **limited number of API requests per week** to a free personal
+application. This integration is built around that constraint: the real-time
+websocket costs nothing per event, so the requests it spends are almost entirely
+the periodic safety-net refresh.
+
+What one week costs, whatever the number of devices in your garden (a refresh
+reads the whole location in a single call):
+
+| GARDENA API refresh  | Refreshes | Websocket URLs | Tokens | **Total / week** |
+| -------------------- | --------- | -------------- | ------ | ---------------- |
+| 15 minutes           | 672       | 84             | 7      | **763**          |
+| 30 minutes           | 336       | 84             | 7      | **427**          |
+| **1 hour (default)** | **168**   | **84**         | **7**  | **259**          |
+| 2 hours              | 84        | 84             | 7      | **175**          |
+| 6 hours              | 28        | 84             | 7      | **119**          |
+
+The two fixed costs are unavoidable: GARDENA closes the real-time stream about
+every two hours and a new URL must be requested (~84 a week), and the access
+token is renewed daily (7 a week, on the separate authentication API).
+
+Commands add one request each — switching a valve or a socket, starting the
+mower. A hundred commands a week is a hundred requests: with the default
+refresh, that still leaves a wide margin.
+
+Two habits keep you safe:
+
+- **do not lower the refresh below one hour** unless you know your quota allows
+  it. The real-time stream already brings every change within seconds; the
+  refresh only catches what a dropped websocket could have missed;
+- **avoid restarting the integration in a loop**: each start costs one location
+  listing plus one full read.
+
+If GARDENA ever answers "too many requests", the integration **suspends its REST
+refreshes for one hour** on its own and keeps running on the real-time stream,
+instead of insisting and digging the hole deeper.
+
+## Actions
+
+- **Test the connection** — authenticates and lists the locations of the
+  account. Use it first when something looks wrong.
+- **Refresh the devices** — re-reads the account, for example after adding a
+  device in the GARDENA app.
+- **Stop all watering** — closes every valve of the chosen device until its next
+  scheduled task. Handy in a scene, or when you want to walk in the garden.
+
+## Troubleshooting
+
+**"GARDENA refused the credentials"** — the Application key or secret is wrong,
+or the **GARDENA smart system API is not connected to your application** on the
+developer portal (step 1.4). This is by far the most common cause.
+
+**A device shows an orange "unreachable" badge** — the GARDENA gateway does not
+see it anymore (radio link offline): the device is out of range, switched off,
+or its batteries are empty. Gladys keeps the last known values instead of
+pretending they are current.
+
+**"GARDENA is rate-limiting the integration"** — the API is throttling. The
+integration spaces its calls out and retries, but if you increased the refresh
+frequency a lot, put it back to a higher value: the real-time stream already
+gives you the changes.
+
+**No device in the Discover tab** — check that your devices show up in the
+GARDENA app, and that the location filter (if you set one) matches the right
+garden.
+
+---
+
+_GARDENA is a registered trademark of the Husqvarna Group. This is an
+independent community integration, neither affiliated with, endorsed by nor
+supported by GARDENA or the Husqvarna Group._
+
+## Configuration settings
+
+These are the settings GARDENA smart system asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| Connect your GARDENA account | `section` | No | This integration uses the official public GARDENA smart system API. Create a free account on the Husqvarna developer portal, sign in with your GARDENA (Husqvarna) account, create an application, connect the "GARDENA smart system API" to it, then copy its Application key and Application secret below. |
+| Application key | `string` | Yes | The Application key of your application on the Husqvarna developer portal. |
+| Application secret | `secret` | Yes | The Application secret of the same application. It is stored encrypted and never sent back to the browser. |
+| Location id (optional) | `string` | No | Restrict the integration to a single GARDENA location (garden). Leave empty to use every location of the account. |
+| GARDENA API refresh (s) | `number` | No | Minimum delay between two full reads of the GARDENA API, the safety net behind the real-time stream. GARDENA counts a weekly request quota and this is what spends it: one hour costs about 170 calls a week, fifteen minutes would cost about 670. Changes already arrive in real time, so keep it high. |
+| Default duration (min) | `number` | No | How long a valve waters, or a power socket stays on, when you switch it on from Gladys. |
+| Power socket switch-on | `select` | No | What happens when a GARDENA power socket is switched on from Gladys. |
+| Mower start | `select` | No | What starting the mower from Gladys means: let it obey its own calendar, or override it for a fixed duration. |
+| Mowing duration (min) | `number` | No | Used when the mower start mode overrides the schedule. |
+| Mower stop | `select` | No | What stopping the mower from Gladys means: park it until the next scheduled task, or cancel the schedule entirely. |
+
+## How to install GARDENA smart system in Gladys
+
+1. In Gladys, open **Integrations**: GARDENA smart system appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/nagromdark/gladys-gardena:1.0.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/Nagromdark/gladys-gardena](https://github.com/Nagromdark/gladys-gardena).
+
+GARDENA smart system requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+GARDENA smart system is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [Nagromdark](https://github.com/Nagromdark), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/Nagromdark/gladys-gardena) — [source of this documentation](https://github.com/Nagromdark/gladys-gardena/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/grdf-gazpar.mdx
+++ b/docs/integrations/external/grdf-gazpar.mdx
@@ -1,0 +1,163 @@
+---
+title: "GRDF Gazpar integration for Gladys Assistant"
+sidebar_label: "GRDF Gazpar"
+description: "Reads the daily gas consumption of your GRDF Gazpar meter from your GRDF account. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-grdf.png"
+keywords:
+  - "grdf gazpar"
+  - "gladys grdf gazpar"
+  - "grdf gazpar gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/PhilippeMA/gladys-grdf instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="grdf-gazpar" />
+
+This integration reads the gas consumption measured by your **Gazpar** meter and
+turns it into Gladys devices, so your gas shows up next to the rest of your home
+data: daily charts, scenes, and the energy screen.
+
+GRDF exposes no public API for individuals. The integration therefore signs in
+to your customer account exactly like a browser would, on
+[monespace.grdf.fr](https://monespace.grdf.fr), and reads the same daily
+readings the website shows you.
+
+## What you need
+
+- a GRDF customer account (the one you use on monespace.grdf.fr), with your
+  meter already attached to it;
+- a **Gazpar** communicating meter — the daily readings only exist for those.
+  With an older meter read twice a year by a technician, GRDF only publishes one
+  lump reading per period, and that is all the integration can show;
+- an account that does **not** ask for an extra verification step at login (a
+  one-time code sent by SMS or email, a captcha). The integration can only answer
+  the password step.
+
+## Configuration
+
+1. Open the **Configuration** tab of the integration.
+2. Enter the **email** and the **password** of your GRDF account. The password is
+   stored encrypted by Gladys and is only ever sent to GRDF.
+3. Leave **PCE to follow** empty to follow every meter of the account. If your
+   account holds several metering points and you only want some of them, list
+   their 14-digit PCE numbers, separated by commas. You will find a PCE on your
+   gas bill, and in Mon Espace GRDF.
+4. Choose the **history to import**: the number of past days fetched the first
+   time the integration synchronizes. GRDF keeps about three years, so you can
+   import several months at once if you want charts that already have a past.
+   This only applies to the first synchronization; afterwards the integration
+   only fetches what is new. Importing a long history takes a few minutes:
+   Gladys accepts a limited number of measurements per minute, so the
+   integration feeds them in gently — about one minute per two months imported.
+5. Click **Test the GRDF connection**: it signs in and lists the metering points
+   it found. This is the quickest way to check your credentials.
+6. Save, then open the **Discovery** tab and **add your meter to your home**.
+   This step is what starts the collection: until a meter is added, it is only
+   an offer, and Gladys has nowhere to store its measurements. The history is
+   imported the moment you add it.
+
+## The devices you get
+
+One device per metering point, named after the alias you gave it in Mon Espace,
+carrying four read-only sensors:
+
+| Sensor                         | Unit | What it is                                             |
+| ------------------------------ | ---- | ------------------------------------------------------ |
+| Consommation quotidienne       | kWh  | Energy consumed during the gas day — the billed value  |
+| Volume quotidien               | m³   | Raw gas volume consumed during the gas day             |
+| Index compteur                 | m³   | Meter index at the end of the gas day                  |
+| Température extérieure moyenne | °C   | Average outside temperature GRDF associates to the day |
+
+Every value is recorded with the date of the day it belongs to, not the date it
+was downloaded: your charts stay correct even though the data arrives late.
+
+## When the data arrives
+
+GRDF publishes a reading **one to two days late**, usually during the day
+following the measurement. There is nothing live here: the consumption of
+Monday typically lands on Tuesday or Wednesday. This is a limit of the Gazpar
+network itself (the meter transmits once a day), not of the integration.
+
+The integration queries GRDF on its own schedule — every six hours by default,
+which is far more than enough for a daily value. The **Refresh the data now**
+action forces a fetch immediately if you do not want to wait.
+
+## Troubleshooting
+
+**"Test the GRDF connection" fails.** Try signing in on
+[monespace.grdf.fr](https://monespace.grdf.fr) with the same credentials in a
+private browser window. If GRDF asks you for a code or a captcha there, the
+integration cannot get through either.
+
+**The sensors exist but stay empty.** Check that the meter is really added to
+your home, and not merely listed in the **Discovery** tab: Gladys only stores
+measurements for devices you added. Once added, the history is imported within
+seconds, and at worst within a minute — or use **Refresh the data now**. A long
+history takes a few minutes to appear in full: it is fed in gently (see above),
+oldest day first.
+
+**"GRDF served its HTML app shell" or "the session was not accepted".** GRDF
+answered with a web page instead of data. Their site does that when it does not
+accept the session, and also when it is simply having a bad moment — it never
+says which. The integration signs in again and retries a few times on its own;
+if it still fails, wait a few minutes and use **Refresh the data now**. If it
+lasts, check that monespace.grdf.fr works in your browser: GRDF sometimes throttles
+an account that has signed in many times in a row.
+
+**No new data for several days.** Check on the GRDF website that the readings
+are actually published for your meter: a Gazpar meter that lost its radio link
+stops feeding GRDF, and the integration can only show what GRDF has.
+
+**The values look wrong or duplicated.** The integration remembers the last day
+it published for each meter, so it never re-imports the same day twice. If you
+delete a device and add it back, its history restarts from the import window you
+configured.
+
+For the full detail of what happens, look at the integration logs from the
+Gladys interface (or `docker logs` on the host); set `LOG_LEVEL=debug` for the
+verbose version.
+
+## Privacy
+
+Your GRDF credentials and your consumption data stay between your Gladys server
+and GRDF. Nothing is sent anywhere else, and no third-party service is involved.
+
+## Configuration settings
+
+These are the settings GRDF Gazpar asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| Before you start | `section` | No | This integration signs in to your GRDF customer account, the same one you use on monespace.grdf.fr, and reads the daily readings of your Gazpar meter. GRDF publishes them one to two days late: nothing shows up in real time. Your account must not require an extra verification step at login. |
+| GRDF account email | `string` | Yes | The email address you use to sign in on monespace.grdf.fr. |
+| GRDF account password | `secret` | Yes | Stored encrypted by Gladys and only sent to GRDF. |
+| PCE to follow | `string` | No | Optional. 14-digit metering point identifiers, separated by commas. Leave empty to follow every meter of the account. |
+| History to import (days) | `number` | No | Days of past consumption imported on the first synchronization. GRDF keeps about three years. |
+| Refresh interval (s) | `number` | No | How often GRDF is queried, in seconds. A new reading appears once a day, so there is no point going below a few hours. |
+
+## How to install GRDF Gazpar in Gladys
+
+1. In Gladys, open **Integrations**: GRDF Gazpar appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/philippema/gladys-grdf:1.1.4`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/PhilippeMA/gladys-grdf](https://github.com/PhilippeMA/gladys-grdf).
+
+GRDF Gazpar requires Gladys `>=4.62.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+GRDF Gazpar is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [PhilippeMA](https://github.com/PhilippeMA), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/PhilippeMA/gladys-grdf) — [source of this documentation](https://github.com/PhilippeMA/gladys-grdf/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/home-connect.mdx
+++ b/docs/integrations/external/home-connect.mdx
@@ -1,0 +1,207 @@
+---
+title: "Home Connect integration for Gladys Assistant"
+sidebar_label: "Home Connect"
+description: "Monitor and control your Bosch, Siemens, Neff and Gaggenau appliances via Home Connect. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-homeconnect.png"
+keywords:
+  - "home connect"
+  - "gladys home connect"
+  - "home connect gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/prohand/gladys-homeconnect instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="home-connect" />
+
+This integration connects Gladys to **Home Connect**, the cloud platform behind
+Bosch, Siemens, Neff, Gaggenau, Balay, Constructa, Profilo and Thermador home
+appliances.
+
+Every appliance that shows up in the Home Connect app shows up in Gladys:
+dishwashers, washing machines, dryers, washer-dryers, ovens, microwaves,
+warming drawers, hobs, hoods, fridges, freezers, wine coolers, coffee machines,
+cleaning robots and cook processors.
+
+> **There is no local mode.** Home Connect appliances talk to the BSH cloud, and
+> only to it. If your internet connection is down, this integration is down.
+> That is a property of the appliances, not of the integration.
+
+## 1. Create a Home Connect developer application
+
+The Home Connect API is free, but each Gladys instance needs its **own**
+application credentials — BSH grants them per developer, not per product.
+
+1. Create a free account on the
+   [Home Connect developer portal](https://developer.home-connect.com/) and log
+   in. Use **the same email address as your Home Connect app account**: the
+   portal links the two, and only then can you see your own appliances.
+2. Go to **Applications → Register Application** and fill in:
+   - **Application ID**: anything, e.g. `gladys`.
+   - **OAuth Flow**: **Authorization Code Grant Flow**.
+   - **Home Connect User Account for Testing**: the email address of your Home
+     Connect app account.
+   - **Redirect URI**: see step 2 below — you need Gladys to tell you first.
+   - **Success Redirect URI**: leave empty.
+3. Once registered, the portal shows your **Client ID** and **Client Secret**.
+
+## 2. Configure the integration in Gladys
+
+1. Install the integration, then open its **Configuration** tab.
+2. Paste the **Client ID** and the **Client Secret**.
+3. Click **Save**, then click **Connect** on the _Home Connect account_ field.
+   Gladys opens the Home Connect sign-in page.
+
+If Home Connect answers _"redirect_uri mismatch"_, the URI Gladys uses is not
+the one registered in the portal. Click the **Test the connection** button once:
+it prints the exact redirect URI Gladys used. Paste it into the **Redirect URI**
+field of your developer application, save on the portal, and click **Connect**
+again.
+
+4. Sign in with your Home Connect account and allow the requested permissions.
+5. Back in Gladys, open the **Discovery** tab: your appliances are listed, ready
+   to be added.
+
+## 3. What you get per appliance
+
+Features are built from what each appliance actually reports, so no two
+appliances get the same list. Typically:
+
+| Feature                                         | Kind        | Appliances                   |
+| ----------------------------------------------- | ----------- | ---------------------------- |
+| Power                                           | on/off      | most appliances              |
+| Program running                                 | on/off      | appliances that run programs |
+| Active program / Selected program               | text        | appliances that run programs |
+| Operation state (`Run`, `Ready`, `Finished`…)   | text        | all                          |
+| Remaining time, elapsed time, progress          | sensor      | appliances that run programs |
+| Door                                            | opening     | most appliances              |
+| Remote start allowed, remote control, local use | sensor      | most appliances              |
+| Refrigerator / freezer setpoint                 | thermostat  | fridges, freezers            |
+| Super mode, eco mode, holiday mode              | on/off      | refrigeration                |
+| Cavity temperature                              | temperature | ovens                        |
+| Light, ambient light, brightness                | light       | hoods, ovens, fridges        |
+| Child lock                                      | lock        | appliances that support it   |
+| Beverage counters                               | counter     | coffee machines              |
+| Alerts (salt low, water tank empty, filter…)    | binary      | per appliance family         |
+| Connected                                       | binary      | all                          |
+
+**Door** follows the Gladys convention for opening sensors: the feature reads
+_Closed_ when the door is shut and _Open_ when it is not — a locked door counts
+as closed. **Alerts** read _Off_ until Home Connect actually raises them, so a
+dishwasher that never ran low on salt shows a cleared alert rather than an empty
+value.
+
+### Starting a program
+
+**Program running** starts the program **currently selected on the appliance**
+(or in the Home Connect app) — it does not choose one for you. This mirrors what
+the appliances allow: a remote start is a trigger, not a program picker.
+
+For it to work, the appliance must have **remote start armed**: on most models
+you press and hold the _Remote start_ button until the display confirms. Without
+it, Home Connect refuses the command and Gladys shows the refusal message.
+
+Turning **Program running** off aborts the running program.
+
+## 4. How it stays up to date
+
+The integration holds a permanent **event stream** open to Home Connect, so a
+door opening or a program finishing reaches Gladys in about a second — including
+changes made on the appliance itself.
+
+Polling (default: every 15 minutes) runs behind it as a safety net, because Home
+Connect closes the stream roughly once a day. Home Connect enforces a request
+quota, so keep the interval high unless you have a reason not to.
+
+A value that does not change is still re-sent to Gladys **at least once an
+hour**. Gladys declares a state outdated after a configurable delay (48 hours by
+default, under **Settings → System**) and then shows "No recent value" on the
+dashboard, so an appliance that sits in the same state for days — connected,
+salt tank full, no program running — has to keep saying that nothing changed.
+Those re-statements cost no Home Connect request.
+
+## 5. Testing without an appliance
+
+Enable **Use the Home Connect simulator** in the configuration. The integration
+then talks to `simulator.home-connect.com`, which serves the same API against
+the virtual appliances of your developer account. Remember to turn it back off.
+
+## 6. Troubleshooting
+
+**"Enter your Home Connect Client ID and Client Secret"** — the credentials are
+missing or empty.
+
+**"Click Connect to link your Home Connect account"** — the credentials are
+there, but the OAuth flow was never completed.
+
+**"The integration refused the connection. Try again."** in the authorization
+callback window — the authorization code exchange failed. Open the integration
+logs: the message there carries the exact reason Home Connect gave (missing
+Client Secret, redirect URI not registered in the developer portal, code already
+used…). If the integration or the machine restarted while you were signing in at
+Home Connect, simply click **Connect** again — an authorization stays valid for
+fifteen minutes.
+
+After a successful **Connect**, the window closes right away and the connection
+status reads "Account connected, reading your appliances…": the account is read
+in the background, which takes a few seconds per appliance.
+
+**"Home Connect authorization expired, click Connect again"** — the refresh
+token was refused. It expires after about two months without use, and it is also
+revoked when you remove Gladys from the authorized applications of your Home
+Connect account. Click **Connect** again.
+
+**"Home Connect rate limit reached"** — too many requests. The integration backs
+off on its own; raise the refresh interval if it keeps happening.
+
+**An appliance shows an orange "unreachable" badge** — Home Connect itself
+cannot reach it. Check that it is powered on and connected to your Wi-Fi, in the
+Home Connect app.
+
+**A command is refused** — Gladys shows the reason Home Connect gave. The
+frequent ones are _remote start not enabled_, _door open_ and _appliance
+powered off_.
+
+The integration logs everything it does. Set `LOG_LEVEL=debug` and read the
+integration logs from the Gladys interface for the full detail.
+
+## Configuration settings
+
+These are the settings Home Connect asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| Before you start | `section` | No | Home Connect has no local API: everything goes through the BSH cloud. Create a free developer account, register an application of type "Home Connect Application" with the Authorization Code Grant Flow, and paste its Client ID and Client Secret below. The redirect URI to register is shown by the "Test the connection" action once you start the connection. |
+| Client ID | `string` | Yes | Client ID of your Home Connect application. |
+| Client Secret | `secret` | No | Client Secret of your Home Connect application. Leave empty only if you registered a public client without a secret. |
+| Home Connect account | `oauth2` | Yes | Sign in with the Home Connect account your appliances are paired with, then allow Gladys. |
+| Language | `select` | No | Language of the device feature names and of the program names returned by Home Connect. |
+| Refresh interval (s) | `number` | No | Safety net behind the real-time event stream. Home Connect enforces a daily request quota, so keep it high unless you have a reason not to. |
+| OAuth scopes | `string` | No | Space-separated Home Connect scopes requested during authorization. Narrow it down if your developer application was registered with fewer permissions. |
+| Use the Home Connect simulator | `boolean` | No | Talk to simulator.home-connect.com instead of the production API, to test without real appliances. |
+
+## How to install Home Connect in Gladys
+
+1. In Gladys, open **Integrations**: Home Connect appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-homeconnect:1.0.4`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/prohand/gladys-homeconnect](https://github.com/prohand/gladys-homeconnect).
+
+Home Connect requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+Home Connect is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [prohand](https://github.com/prohand), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/prohand/gladys-homeconnect) — [source of this documentation](https://github.com/prohand/gladys-homeconnect/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/immich-slideshow.mdx
+++ b/docs/integrations/external/immich-slideshow.mdx
@@ -1,0 +1,101 @@
+---
+title: "Immich Slideshow integration for Gladys Assistant"
+sidebar_label: "Immich Slideshow"
+description: "Streams an Immich album or memories as a Gladys dashboard camera slideshow. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/gboulvin--Gladys-Immich.jpg"
+keywords:
+  - "immich slideshow"
+  - "gladys immich slideshow"
+  - "immich slideshow gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/gboulvin/Gladys-Immich instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="immich-slideshow" />
+
+## Purpose
+
+This external Gladys integration turns an **Immich album** or the **Memories — on this day** collection into a virtual camera. Add that camera to the Gladys dashboard to display an automatically changing photo slideshow. Photos remain on the configured Immich server: the integration requests only Immich preview renditions and never downloads originals.
+
+The integration is designed for Gladys **4.85.0 or newer**. It uses the established camera-image channel so the slideshow can be displayed on the current dashboard immediately. The photo selection module is also separated from the camera adapter, ready for the future native Photo-widget provider API announced by Gladys.
+
+## Prerequisites
+
+You need a reachable Immich server and an API key created in **Immich → Account settings → API keys**. Grant the key the following least-privilege permissions:
+
+| Permission    | Why it is needed                                    |
+| ------------- | --------------------------------------------------- |
+| `album.read`  | Lists albums and reads the chosen album.            |
+| `asset.view`  | Downloads a preview image for the dashboard camera. |
+| `memory.read` | Reads the optional “on this day” memory source.     |
+
+The Gladys container must be able to reach the URL entered in the configuration form. For a server on your local network, use its LAN address and Immich port, for example `http://192.168.1.20:2283`. Do not use `localhost`: it refers to the isolated integration container, not to the Gladys host or the Immich server.
+
+## Setup
+
+Open **Integrations → Immich Slideshow → Configuration** and enter the server URL and API key. Select **Album** or **Memories — on this day**. For an album, copy its UUID from the URL shown by Immich and paste it in **Album UUID**. The button **Test Immich connection** confirms that Gladys can list albums with the configured key.
+
+Choose the slide interval, how often the source list is refreshed, and the maximum number of images to keep. The source refresh is deliberately independent from the slide interval: a large album is listed only periodically while individual preview images are downloaded only when they are displayed. Videos are excluded. By default, the newest images appear first; enable random order to shuffle each refreshed list.
+
+Save the configuration, open the integration’s **Discovery** tab, and create the **Immich slideshow** camera. Add this camera to a Gladys dashboard camera box. The first image is published immediately, then the camera updates at the configured slide interval. Use **Refresh slideshow now** after changing images or to immediately fetch today’s new memories.
+
+## Privacy and image handling
+
+The API key is declared as a Gladys `secret`, so it is securely stored and is never returned to the dashboard browser. Requests sent to Immich include the `x-api-key` header inside the integration container. Preview images are corrected for orientation, resized and JPEG-compressed before they are sent through Gladys’s camera channel; this keeps the dashboard fluid and respects the channel’s payload limit.
+
+## Troubleshooting
+
+If the connection test reports an invalid key or permissions, recreate an Immich API key with the three permissions listed above. If the server is unreachable, verify the URL from the Gladys host network and make sure a reverse proxy, firewall or Docker network does not prevent the external-integration container from reaching Immich. An empty album or an empty memory collection is a normal state; add photos or choose another source. The integration log in the Gladys Configuration tab contains the HTTP-level failure category without exposing your API key.
+
+## Current dashboard model and future photo widget
+
+Gladys 4.85’s native **Photo** widget accepts a manually managed URL list; it does not yet expose an external photo-source API. This project therefore delivers a working dashboard slideshow through a virtual camera device today. The independent `src/photoProvider.js` layer already resolves albums and memories to normalized photo metadata and captions, so it is ready to be connected to the future native Photo-widget provider contract without rewriting the Immich client.
+
+## References
+
+[1] [Immich API endpoints](https://api.immich.app/endpoints)
+[2] [Gladys external integrations](https://gladysassistant.com/docs/dev/external-integrations/)
+[3] [Gladys 4.85 Photo widget announcement](https://community.gladysassistant.com/t/gladys-assistant-4-85-0-widget-photo-navigation-dans-les-graphiques-chauffe-eau-homekit/10483)
+
+## Configuration settings
+
+These are the settings Immich Slideshow asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| Connect Immich | `section` | No | Create an Immich API key with album.read, asset.view, and memory.read permissions. The key is securely stored by Gladys and is never sent to the dashboard browser. |
+| Immich server URL | `string` | Yes | For example: http://192.168.1.20:2283. The Gladys integration container must be able to reach this address. |
+| Immich API key | `secret` | Yes |  |
+| Photo source | `select` | Yes | Choose a specific album or Immich memories from this day in previous years. |
+| Album UUID | `string` | No | Required only when the source is Album. Copy the UUID from the album URL in Immich; leave it empty for Memories. |
+| Slide interval (seconds) | `number` | Yes | How long each image stays on the dashboard camera. The minimum respects Gladys camera-channel limits. |
+| Source refresh interval (seconds) | `number` | Yes | How often the integration asks Immich again for the album or today’s memories. Existing slides continue between refreshes. |
+| Maximum images | `number` | Yes | Caps large albums to keep the integration responsive. The newest images are selected unless random order is enabled. |
+| Randomize images | `boolean` | No | When disabled, the slideshow starts with the most recent image. |
+
+## How to install Immich Slideshow in Gladys
+
+1. In Gladys, open **Integrations**: Immich Slideshow appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/gboulvin/gladys-immich:0.1.2`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/gboulvin/Gladys-Immich](https://github.com/gboulvin/Gladys-Immich).
+
+Immich Slideshow requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+Immich Slideshow is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [gboulvin](https://github.com/gboulvin), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/gboulvin/Gladys-Immich) — [source of this documentation](https://github.com/gboulvin/Gladys-Immich/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/indice-uv.mdx
+++ b/docs/integrations/external/indice-uv.mdx
@@ -20,11 +20,32 @@ import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationH
 
 <ExternalIntegrationHeader slug="indice-uv" />
 
-This integration follows the **UV index** of the locations you choose. You add a
-location by its **French postal code**, and a device shows up in the
-**Discovery** tab, ready to be added to Gladys.
+This integration follows the **UV index** of the locations you choose. You add
+your **Gladys houses in one click**, or a location by its **French postal code**,
+and a device shows up in the **Discovery** tab, ready to be added to Gladys.
 
 No account to create, no API key to paste: both sources are public open data.
+
+## Adding your Gladys houses, in one click
+
+You have already told Gladys where you live: that is the map in **Settings >
+Houses**. The **"Add my Gladys houses"** button reads those houses and creates a
+location for each one that is not watched yet — no postal code to type.
+
+Three things to know:
+
+- **The access is a permission.** Where you live is personal data: Gladys only
+  shares it if you accepted the request on the integration's install screen. If
+  the button answers that the access is refused, remove and re-install the
+  integration, accepting the request it shows.
+- **A house you never placed on the map has no coordinates.** It is named in the
+  answer; locate it in Settings > Houses and run the action again.
+- **This is not a sync.** The houses are read at the moment you click. What comes
+  out is an ordinary location, renamed and removed like the others, and a house
+  moved in Gladys afterwards does not move its location.
+
+Clicking again is safe: a house that is already watched is reported, not added a
+second time.
 
 ## Adding a location
 
@@ -81,6 +102,7 @@ Two things to know about removal:
 | UV exposure level        | 0–5, the WHO categories: the feature to test in a scene                         |
 | UV exposure level (text) | Its wording: "Low", "High"…                                                     |
 | Sun protection advice    | The WHO recommendation for that level                                           |
+| Data updated at          | The hour of the forecast the values come from, in the local time of the point   |
 
 ### The scale
 
@@ -106,6 +128,22 @@ When the model has no value for a location, **nothing is published** for that
 feature and the device keeps its last known value. Publishing a 0 would look like
 sunset in the middle of the afternoon, and would fire the scenes that watch for
 it.
+
+### How old is the data?
+
+**Data updated at** is the hour of the CAMS forecast the values on the device
+come from, written in the **local time of the point** — a location in Sydney
+and one in Nantes never show the same one, which is why it sits on each station
+rather than on a device of its own.
+
+It is not the moment the integration last asked. The forecast has an hourly
+resolution, so reading it three times in an hour returns the same timestamp
+three times, and that is the point: it tells you how old the numbers are, not
+how often they were fetched. When a refresh fails, nothing is published at all —
+the timestamp stops moving and the age becomes visible on the dashboard.
+
+"Test the UV provider" ends each line with the same timestamp, so a source that
+answers with yesterday's hour shows up as what it is.
 
 ## General settings
 
@@ -155,16 +193,16 @@ These are the settings Indice UV asks for in its configuration screen in Gladys.
 | General settings | `section` | No | These settings apply to every configured location. |
 | Language of the device names | `select` | No | The language the device and feature names are written in: "Indice UV" or "UV index". Everything else this integration displays already follows your Gladys language, but the name of a device and of its features is stored as it is published, so it has to be chosen here. A device already added to Gladys keeps the names it was created with: delete it and add it again from the Discovery tab to rename it. |
 | Refresh interval (s) | `number` | No | How often each location is refreshed, in seconds. The forecast has an hourly resolution, so there is nothing to gain from going much below half an hour. |
-| Your locations | `section` | No | Use the buttons below to add, list and remove your locations. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list. |
+| Your locations | `section` | No | Use the buttons below to add, list and remove your locations. "Add my Gladys houses" adds them all in one click, from the houses you already placed on the map in Gladys. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list. |
 
 ## How to install Indice UV in Gladys
 
 1. In Gladys, open **Integrations**: Indice UV appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-uvindex:1.0.2`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-uvindex:1.0.4`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/prohand/gladys-uvindex](https://github.com/prohand/gladys-uvindex).
 
-Indice UV requires Gladys `>=4.62.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+Indice UV requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
 
 Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
 

--- a/docs/integrations/external/ipp-printers.mdx
+++ b/docs/integrations/external/ipp-printers.mdx
@@ -122,7 +122,7 @@ These are the settings IPP Printers asks for in its configuration screen in Glad
 ## How to install IPP Printers in Gladys
 
 1. In Gladys, open **Integrations**: IPP Printers appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/guim31/gladys-ipp:1.0.5`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/guim31/gladys-ipp:1.0.7`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/guim31/gladys-ipp](https://github.com/guim31/gladys-ipp).
 

--- a/docs/integrations/external/meross.mdx
+++ b/docs/integrations/external/meross.mdx
@@ -1,0 +1,213 @@
+---
+title: "Meross integration for Gladys Assistant"
+sidebar_label: "Meross"
+description: "Read and control your Meross smart plugs, switches, lights and garage doors. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-Meross.png"
+keywords:
+  - "meross"
+  - "gladys meross"
+  - "meross gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/PhilippeMA/gladys-Meross instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="meross" />
+
+Control your Meross plugs, switches, lights and garage doors from Gladys, and see their
+consumption on your dashboard.
+
+## What you get
+
+Sign in once with your Meross account and every compatible device of the account appears in
+the **Discovery** tab, ready to be added. No re-pairing, no extra hardware.
+
+| Your device                                         | What you can do in Gladys                               |
+| --------------------------------------------------- | ------------------------------------------------------- |
+| Smart plug or wall switch (MSS110, MSS210, MSS510…) | Turn it on and off                                      |
+| Plug with metering (MSS310, MOP320)                 | On/off, plus power, voltage, current and today's energy |
+| Power strip (MSS425…)                               | Each outlet on and off separately                       |
+| Bulb or light strip (MSL120, MSL320, MSL430…)       | On/off, brightness, colour and white temperature        |
+| Garage door opener (MSG100, MSG200)                 | Open and close it, and see whether it is really open    |
+| Hub (MSH300, MSH400)                                | Everything paired to it — see below                     |
+
+### Devices connected to a hub
+
+A hub is a gateway: it has nothing to switch on or off by itself. So the hub does not appear
+in Gladys — **each sensor paired to it does**, under the name you gave it in the Meross app.
+
+| Paired device                   | What you get in Gladys                                |
+| ------------------------------- | ----------------------------------------------------- |
+| Thermometer (MS100)             | Temperature, humidity, battery level                  |
+| Thermostatic valve (MTS100/150) | Target temperature, room temperature, on/off, battery |
+| Water leak sensor (MS400)       | Leak detected, battery level                          |
+| Door/window sensor (MS200)      | Opening, battery level                                |
+| Watering timer (MST100)         | Start a watering, set its duration, battery           |
+
+If your hub appears to do nothing, check that at least one sensor is **paired to it in the
+Meross app**: a hub with nothing paired has nothing to show. The **Diagnose my devices**
+button lists what the integration found behind it.
+
+The valve _mode_ (comfort, economy, schedule) is not available yet — only the target
+temperature, which is what automations need most.
+
+#### Watering timers
+
+An MST100 watering timer on an MSH400 hub gives you a **Watering** switch, a **Watering
+duration** in minutes and its **battery level**.
+
+Turn **Watering** on and the timer waters for the duration you set, then stops by itself —
+exactly like the "water now" button in the Meross app. Turn it off to stop early. The switch
+clears itself when the watering ends.
+
+The duration shown is **the one configured on the timer itself** — the same one the Meross
+app shows. Changing it from Gladys writes it to the device, so the app sees the change, and
+the other way round. There is a single value and it belongs to the hardware: Gladys never
+starts a watering with a duration of its own.
+
+Until the timer has reported one, the duration stays empty rather than showing an invented
+number.
+
+Gladys talks to your hub directly on your local network when it can reach it, and through
+the Meross servers otherwise. If a watering fails, the error names both channels and the
+address that did not answer; **Diagnose my devices** shows each device's local address and
+the channel actually in use.
+
+Watering **schedules** stay in the Meross app: the hub does not let anything else read or
+change them.
+
+## Configuration
+
+1. Open the **Configuration** tab of the integration.
+2. Enter the **email** and **password** of your Meross account — the same ones you use in
+   the Meross mobile app.
+3. Choose the **region** where your account was created (Europe, America, Asia/Pacific).
+   This is the most common cause of a refused login: if you are unsure, try Europe first,
+   then Global.
+4. Save. Click **Test the connection** to check everything works: it tells you how many
+   devices were found.
+5. Your devices appear in the **Discovery** tab.
+
+Your password is stored encrypted by Gladys. It is never sent in clear text: only a hashed
+form leaves the integration, and only to the Meross authentication server.
+
+### Local or cloud?
+
+The **Prefer the local connection** toggle (on by default) asks the integration to talk to
+your devices directly over your Wi-Fi network instead of going through Meross' servers.
+Local control is faster and keeps working when your internet connection is down.
+
+Each device shows a badge telling you the channel it _really_ uses:
+
+- **local** — commands never leave your home network;
+- **cloud** — commands go through Meross;
+- **cloud with an orange dot** — local was preferred, but this device did not answer on the
+  network; hover the badge to see why.
+
+Some Meross firmware versions refuse local control. That is a device-side limitation: the
+integration falls back to the cloud so the device keeps working.
+
+Note that even in local mode, the integration signs in to Meross once at startup: your
+devices only accept commands signed with your account key, and only Meross can hand it out.
+
+### Refresh interval
+
+Plugs that measure consumption and sensors behind a hub are read at this interval. Pick it
+from the list: **every minute** (the default, and the slowest Gladys supports) down to every
+second.
+
+Everything else — on/off, colours, the garage door position — arrives **instantly**, pushed
+by the device, including when someone presses a physical button or uses the Meross app. So
+the slowest setting suits most homes; a faster one only means more requests to Meross.
+
+## Actions
+
+- **Test the connection** — signs in with the credentials in the form and reports how many
+  devices your account holds, and how many are online.
+- **Refresh the device list** — re-reads your account. Use it after adding or renaming a
+  device in the Meross app, or after pairing a new sensor to a hub.
+- **Diagnose my devices** — lists every device on your account, what it can do, the sensors
+  found behind a hub, and how the integration handled each one. Start here when a device is
+  missing.
+
+## Troubleshooting
+
+**"Meross refused the credentials"** — check the three fields together: email, password and
+above all the **region**. An account created in Europe cannot sign in on the American
+endpoint.
+
+**A device stays offline** — check it is reachable in the Meross app first. Gladys reports
+what Meross tells it, and a device that is offline for Meross is offline here too.
+
+**The Meross app logs me out** — Meross limits the number of simultaneous sessions per
+account. Simply sign in again in the app: both sessions can coexist. The integration caches
+its session and releases it on shutdown to limit this.
+
+**A device is missing from the Discovery tab** — click **Diagnose my devices**: it tells you
+whether the device was seen, what it advertises, and whether the integration could handle it.
+If it is a sensor that should be behind a hub, check it is paired to that hub in the Meross
+app. The integration also logs a line for every device it skips, naming what it saw.
+
+**My device's local address does not answer** — the integration falls back to the cloud and
+says so in the logs, with the reason:
+
+- _no route to the device_ — Gladys is not on the same network as the device. This is the
+  usual case when Gladys runs in Docker on another subnet or another VLAN.
+- _connection refused_ — the address answers but nothing listens: it is probably not your
+  device any more (a DHCP lease that moved). Use **Refresh the device list**.
+- _no answer before the timeout_ — a firewall is dropping the packets.
+
+Click **Diagnose my devices** to test it properly: it sends a real, correctly signed request
+and reports what each address answers. A hand-written `curl` cannot tell you much here — a
+Meross device accepts the connection and then silently ignores anything that is not signed,
+so a healthy device looks exactly like a dead one.
+
+Anything other than a connection error means the device is reachable. If it is not, the fix
+is on the network side. Reading states and most commands keep working through the cloud;
+**watering does need that local channel** on MSH400 hubs.
+
+The **Diagnose my devices** button tests the local address port by port and reports what each
+one answers — more reliable than a hand-written `curl`, since a Meross device accepts the
+connection and then silently ignores any request that is not correctly signed.
+
+**Nothing works, and I want to know why** — the integration logs everything it does. Open
+the integration logs from the Gladys UI (or `docker logs` on the host); set `LOG_LEVEL` to
+`debug` for the full detail, including every message exchanged with your devices.
+
+## Configuration settings
+
+These are the settings Meross asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| Connect your Meross account | `section` | No | Sign in with the same email and password you use in the Meross mobile app. Your devices are then discovered automatically, with no pairing to redo. Meross allows a limited number of[...] |
+| Meross email | `string` | Yes | The email address of your Meross account. |
+| Meross password | `secret` | Yes | Stored encrypted by Gladys and only ever sent, hashed, to the Meross authentication server. |
+| Meross region | `select` | Yes | The region your Meross account was created in. Pick the wrong one and the login is refused. |
+| Refresh interval | `select` | No | How often metering plugs and hub sensors are read. On/off states arrive in real time and are never polled, so the slowest setting suits most homes. |
+
+## How to install Meross in Gladys
+
+1. In Gladys, open **Integrations**: Meross appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/philippema/gladys-meross:1.1.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/PhilippeMA/gladys-Meross](https://github.com/PhilippeMA/gladys-Meross).
+
+Meross requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+Meross is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [PhilippeMA](https://github.com/PhilippeMA), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/PhilippeMA/gladys-Meross) — [source of this documentation](https://github.com/PhilippeMA/gladys-Meross/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/meteo-benelux.mdx
+++ b/docs/integrations/external/meteo-benelux.mdx
@@ -1,0 +1,100 @@
+---
+title: "Météo Bénélux integration for Gladys Assistant"
+sidebar_label: "Météo Bénélux"
+description: "IRM/KMI current weather, forecasts and alerts for Belgium, Luxembourg and the Netherlands. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/placeholder.png"
+keywords:
+  - "météo bénélux"
+  - "gladys météo bénélux"
+  - "météo bénélux gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/gboulvin/Gladys-IRM-KMI-V2 instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="meteo-benelux" />
+
+## Overview
+
+This integration brings Royal Meteorological Institute of Belgium (IRM/KMI) weather data to Gladys for supported locations in Belgium, Luxembourg and the Netherlands.[1] Gladys supplies the requested location, so you do not need to configure a town, station or API key.
+
+> IRM/KMI does not publish official documentation for the mobile API used here. Its behaviour may change without notice; if the provider becomes unavailable, the integration records a clear error in its logs.[2]
+
+| Available data     | Display in Gladys                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| Current conditions | Temperature, sky condition, pressure, wind, gust and UV index whenever the provider sends them. |
+| Hourly forecasts   | Up to 24 temperature, precipitation, precipitation-probability, wind and pressure entries.      |
+| Daily forecasts    | Up to 8 full days with minimum and maximum temperatures, precipitation, wind and solar times.   |
+| Warnings           | Wind, rain, snow/ice, thunderstorm, fog, cold, heat and coastal warnings when available.        |
+
+## Installation
+
+Install the integration from the Gladys catalog once its Docker image has been published. If you install the repository manually, first build an image compatible with your server architecture, then reference that image in the integration manifest.
+
+The project is based on Gladys’ official integration template. If you publish your own copy, replace `your-github-username` in both `docker_image` and `cover_image` of `gladys-assistant-integration.json`. The supplied release workflow builds a multi-architecture image for every version.[3]
+
+## Configuration
+
+No personal information is needed. The optional **Cache duration** setting defaults to 600 seconds. It controls how long a downloaded forecast can be reused for the same location and unit system. Set it to `0` to disable the cache; doing so increases calls to the IRM/KMI service.
+
+|          Value | Recommended use                                                                   |
+| -------------: | --------------------------------------------------------------------------------- |
+|            `0` | Occasional troubleshooting or an exceptional need to force every network request. |
+| `300` to `900` | Normal use; reduces calls without making forecasts stale.                         |
+|         `3600` | Only for installations that request the same location very frequently.            |
+
+## How it works and units
+
+Gladys sends a request with latitude, longitude, language and the user’s preferred units. The integration rounds the coordinates, queries the IRM/KMI API and returns the result in Gladys’ standard weather format. Source data is metric; it is converted to Fahrenheit, miles per hour and inches whenever Gladys requests US units.[4]
+
+Warning messages are selected in the requested language where available. IRM/KMI warning levels 1, 2 and 3 are represented by `minor`, `moderate` and `severe` severities. Warnings lacking a dependable type or severity are deliberately omitted to avoid ambiguous notifications.
+
+## Limitations
+
+The reference API does not expose humidity or dew-point data, so those values are not displayed. A daily forecast can contain two conditions; only the first is retained. Rain-radar animation and pollen information are outside this version because Gladys’ main weather interface does not convey them in an appropriate form.[1] [2]
+
+## Troubleshooting
+
+If no forecast is displayed, first confirm that the Gladys location falls within the supported Benelux area. Then check the integration logs: an unsuccessful HTTP response, invalid response or timeout is explicitly recorded. A temporary provider outage can be addressed by retrying later; increasing the cache duration can also reduce failures from repeated requests.
+
+## References
+
+[1]: https://github.com/jdejaegh/irm-kmi-ha 'IRM/KMI integration for Home Assistant'
+[2]: https://github.com/jdejaegh/irm-kmi-api 'IRM/KMI Python client'
+[3]: https://github.com/GladysAssistant/integration-template-js 'Official Gladys JavaScript integration template'
+[4]: https://github.com/jdejaegh/irm-kmi-api/blob/main/irm_kmi_api/api.py 'IRM/KMI protocol implementation'
+
+## Configuration settings
+
+These are the settings Météo Bénélux asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| IRM/KMI data | `section` | No | This integration uses the undocumented mobile API of the Royal Meteorological Institute of Belgium. No account or personal key is required. The service covers Belgium, Luxembourg and the Netherlands; its interface may change without notice. |
+| Cache duration (seconds) | `number` | No | How long a forecast for the same location is kept. Set to 0 to disable caching. |
+
+## How to install Météo Bénélux in Gladys
+
+1. In Gladys, open **Integrations**: Météo Bénélux appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/gboulvin/gladys-irm-kmi-v2:1.0.2`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/gboulvin/Gladys-IRM-KMI-V2](https://github.com/gboulvin/Gladys-IRM-KMI-V2).
+
+Météo Bénélux requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+Météo Bénélux is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [gboulvin](https://github.com/gboulvin), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/gboulvin/Gladys-IRM-KMI-V2) — [source of this documentation](https://github.com/gboulvin/Gladys-IRM-KMI-V2/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/meteo-france.mdx
+++ b/docs/integrations/external/meteo-france.mdx
@@ -1,0 +1,148 @@
+---
+title: "Météo France integration for Gladys Assistant"
+sidebar_label: "Météo France"
+description: "French weather forecasts and official vigilance alerts from Météo France. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/William-De71--gladys-meteo-france.jpg"
+keywords:
+  - "météo france"
+  - "gladys météo france"
+  - "météo france gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/William-De71/gladys-meteo-france instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="meteo-france" />
+
+This integration provides Gladys with **weather forecasts** and the **official vigilance alerts** from Météo France, the French national weather service. It feeds the dashboard weather widget, the voice assistant and the weather-alert scene triggers.
+
+## Ready to use
+
+**No configuration is required.** Forecasts and vigilance alerts go through the Météo France public service: install the integration and it works right away.
+
+An optional API key additionally unlocks the national vigilance map (see below).
+
+## What it provides
+
+- **Hourly forecast** for the next 24 hours: temperature, feels-like, humidity, pressure, wind (speed, gusts, direction), rainfall and precipitation probability.
+- **Daily forecast** for up to 8 days: min/max temperatures, conditions, total rainfall, UV index, sunrise and sunset.
+- **Official vigilance alerts**: the nine Météo France phenomena (violent wind, rain-flooding, thunderstorms, floods, snow-ice, heatwave, extreme cold, avalanches, coastal flooding), with the department name and the full official bulletin.
+- **Vigilance map** for today and tomorrow (requires the API key).
+
+## Scenes triggered by vigilance alerts
+
+You can create a scene that runs when a vigilance alert is issued — for example, to receive an SMS on an orange-level alert.
+
+In the scene editor, add a **"Weather alert raised"** or **"Weather alert ended"** trigger, then pick the house and, optionally, the phenomenon type and the minimum severity.
+
+Gladys checks for alerts every 30 minutes. This integration additionally watches the vigilance every 15 minutes and notifies Gladys as soon as it changes, so your scene runs within seconds instead of waiting for the next scheduled check.
+
+## Vigilance map (optional)
+
+Displaying the national vigilance map requires a personal API key, free of charge:
+
+1. Create an account on the [Météo France API portal](https://portail-api.meteofrance.fr/).
+2. Subscribe to the **"Données Publiques de Vigilance"** API (free). It also appears as **"Bulletin Vigilance"**, and as `DPVigilance` in technical URLs — all three are the same API.
+3. On the API configuration screen, pick the **API Key** token type (not OAuth2), enter a long validity **duration**, then generate the key — see the two points below, this is where it usually goes wrong.
+4. In Gladys, open the Météo France integration's **Configuration** screen, paste the key and save.
+
+### An API key, not an OAuth2 token
+
+On the **"Configurer l'API Bulletin Vigilance"** screen, the portal asks for a **token type**:
+
+|                                          | Works here | Lifetime                       |
+| ---------------------------------------- | ---------- | ------------------------------ |
+| **API Key**                              | ✅ **yes** | the duration you enter         |
+| **OAuth2** (the _Generate Token_ button) | ❌ no      | about 1 hour, not renewed here |
+
+So tick **API Key**. An OAuth2 token appears to work at first, then **stops working after roughly an hour**: the map silently disappears. If your map used to show and no longer does, this is almost always why.
+
+### Key validity duration
+
+Once **API Key** is ticked, the portal shows a mandatory **"Durée"** (duration) field, empty by default, to be filled **in seconds**. That is when the key stops working — and the vigilance map with it.
+
+Since the integration uses this key permanently, enter the **longest duration you can**, otherwise you will have to regenerate and re-paste it regularly.
+
+> **Enter `94672800`** (about 3 years). That is the maximum the portal accepts — anything higher is rejected.
+
+For reference, should you prefer a shorter duration:
+
+| Duration | Value to enter           |
+| -------- | ------------------------ |
+| 1 month  | `2592000`                |
+| 6 months | `15552000`               |
+| 1 year   | `31536000`               |
+| ~3 years | `94672800` — **maximum** |
+
+Write the expiry date down somewhere: on that day the map will stop with no warning, exactly like an OAuth2 token. Generating a new key and re-pasting it in Gladys is then all it takes.
+
+Without this key, everything else keeps working normally — only the map is unavailable.
+
+## Cache duration
+
+The dashboard and the chat assistant both ask for the weather, and every request costs two calls to Météo France. The integration therefore reuses a recent answer for the **cache duration**, adjustable in the **Configuration** screen (600 seconds by default, between 0 and 3600).
+
+You normally never need to change it: the 600-second default suits the vast majority of setups.
+
+### Which value to pick
+
+The setting is in **seconds**, between 0 and 3600 (1 hour).
+
+| Value                        | Effect                                      |
+| ---------------------------- | ------------------------------------------- |
+| **0**                        | no cache, every request calls Météo France  |
+| **300** (5 min)              | fresher data, more calls                    |
+| **600** (10 min) — _default_ | good balance, recommended                   |
+| **1800** (30 min)            | fewer calls, very responsive dashboard      |
+| **3600** (1 h)               | maximum, forecasts may be up to an hour old |
+
+Raising the value is not risky: Météo France only refreshes its forecasts a few times an hour, so a 10 to 30 minute cache costs you almost nothing in freshness while making the dashboard faster.
+
+Two things worth knowing:
+
+- a change in the vigilance level is detected independently of the cache: the integration clears the cache and asks Gladys to re-pull immediately, so **your alert scenes fire without waiting for the cache to expire**, even with the cache set to 1 hour;
+- setting it to **0** disables the cache and calls Météo France on every request. Since the forecast endpoint can take up to 20 seconds on a cold cache, the dashboard may then feel much slower. Keep it for one-off troubleshooting rather than permanent use.
+
+## Coverage
+
+Météo France covers **mainland France and its overseas departments**. For a house outside that area, the integration returns no data and Gladys automatically falls back to another weather service if you have one configured.
+
+## Precedence over OpenWeather
+
+If you already had OpenWeather configured, installing Météo France automatically takes over with no setting to change. If you stop or uninstall the integration, Gladys falls back to OpenWeather just as automatically.
+
+## Configuration settings
+
+These are the settings Météo France asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| Ready to use | `section` | No | Forecasts and vigilance alerts work with no configuration at all. The optional API key below only unlocks the national vigilance map image. |
+| Météo France API key (optional) | `secret` | No | Only needed to display the national vigilance map. Create a free account on the Météo France API portal and subscribe to the "Données Publiques de Vigilance" API. Pick the "API Key" token type, NOT OAuth2 (which expires after about an hour), and set the mandatory "Durée" field to 94672800 seconds — about 3 years, the maximum the portal accepts. The map stops loading once that duration runs out. |
+| Cache duration (s) | `number` | No | In seconds, between 0 and 3600. How long a weather answer is reused before calling Météo France again. The forecast endpoint can take up to 20 seconds on a cold cache, so reusing a recent answer keeps the dashboard responsive. The default of 600 (10 min) suits most setups; raising it to 1800 costs almost no freshness, as Météo France only refreshes a few times an hour. Set to 0 to always call the API (slower dashboard). A vigilance change always refreshes immediately, whatever this value. |
+
+## How to install Météo France in Gladys
+
+1. In Gladys, open **Integrations**: Météo France appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/william-de71/gladys-meteo-france:1.0.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/William-De71/gladys-meteo-france](https://github.com/William-De71/gladys-meteo-france).
+
+Météo France requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+Météo France is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [William-De71](https://github.com/William-De71), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/William-De71/gladys-meteo-france) — [source of this documentation](https://github.com/William-De71/gladys-meteo-france/blob/HEAD/docs/en.md)

--- a/docs/integrations/external/netatmo.mdx
+++ b/docs/integrations/external/netatmo.mdx
@@ -122,6 +122,64 @@ When the Security family is enabled, each camera is created with:
 
 ---
 
+## Gladys Plus webhooks (real time) — optional
+
+By default Gladys polls Netatmo **every 2 minutes**. With webhooks, Netatmo
+**tells** Gladys as soon as something happens: values are then refreshed in
+**2-3 seconds** instead of waiting for the next cycle — without increasing the
+number of Netatmo API calls.
+
+Since a local Gladys is not reachable from the Internet, **Gladys Plus** relays
+the events, so an active Gladys Plus subscription is required.
+
+### Setup (a single step)
+
+1. On the integration **Configuration** screen, find the **"Gladys Plus
+   webhooks"** block (shown automatically).
+2. Paste your Gladys Plus **Open API key** there. That's it.
+
+**Nothing to paste on the Netatmo website:** the integration registers the URL
+at Netatmo itself, and re-registers it on every reconnection. To check, open the
+integration **Logs**: you should see
+
+```
+Netatmo webhook registered — events will trigger an immediate refresh
+```
+
+Without a key (or without Gladys Plus), the integration behaves exactly as
+before, polling every 2 minutes.
+
+### What it brings
+
+- **Values land almost instantly** — for example a thermostat setpoint changed
+  from the Netatmo app, or a camera monitoring state.
+- **Detections you can use in your scenes** (see below).
+
+### Real-time detections (scene triggers)
+
+Some events are **momentary**: they exist only in the event stream, no API poll
+can report them. They are published as dedicated features, usable as **scene
+triggers**:
+
+| Device                     | Feature              | Fired by                       |
+| -------------------------- | -------------------- | ------------------------------ |
+| Indoor and outdoor cameras | **Motion**           | motion detected                |
+| Indoor and outdoor cameras | **Person detected**  | a person detected / recognized |
+| Outdoor camera (Presence)  | **Animal detected**  | an animal detected             |
+| Outdoor camera (Presence)  | **Vehicle detected** | a vehicle detected             |
+| Smoke alarm                | **Smoke**            | a smoke detection              |
+
+Each detection goes to **Yes** and returns to **No** by itself after one minute
+(Netatmo sends no "detection over" event). In a scene, use the "value becomes
+Yes" trigger.
+
+> ⚠️ **If your cameras already existed in Gladys**, these new features do not
+> appear on their own: go to the **Discovery** screen and click **Update** on
+> each camera (or smoke alarm) to add them. Without webhooks configured, these
+> features simply stay at "No".
+
+---
+
 ## Security accessories (camera-bridged)
 
 When the Security family is enabled, the accessories linked to your cameras are
@@ -130,9 +188,9 @@ discovered too:
 - **Door / window tag** (`NACamDoorTag`) — an opening sensor (open/closed), plus
   battery and RF signal.
 - **Indoor siren** (`NIS`) — a read-only sounding sensor, plus battery and RF.
-- **Smoke alarm** (`NSD`) — discovered with its battery and signal. Its **smoke
-  state** is delivered by webhooks (real-time events), which arrive in a later
-  milestone; polling alone cannot report it.
+- **Smoke alarm** (`NSD`) — discovered with its battery and signal, plus a
+  **Smoke** feature fed by the webhooks (see the section above): polling alone
+  cannot report that state.
 
 ---
 
@@ -187,7 +245,7 @@ These are the settings Netatmo asks for in its configuration screen in Gladys.
 ## How to install Netatmo in Gladys
 
 1. In Gladys, open **Integrations**: Netatmo appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/terdious/gladys-netatmo:1.1.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/terdious/gladys-netatmo:1.2.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/Terdious/gladys-netatmo](https://github.com/Terdious/gladys-netatmo).
 

--- a/docs/integrations/external/openweather.mdx
+++ b/docs/integrations/external/openweather.mdx
@@ -78,12 +78,13 @@ this integration follows.
 
 ## Troubleshooting
 
-| What you see                                                               | What it means                                                                                                                   |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| "OpenWeather rejected the API key (HTTP 401)"                              | The key is wrong, or it is not active yet (wait up to a couple of hours after creating it).                                     |
-| "OpenWeather does not serve /data/3.0/onecall for this account (HTTP 404)" | You selected One Call 3.0 without the matching subscription. Subscribe on the OpenWeather site, or switch back to the free API. |
-| "OpenWeather quota exceeded (HTTP 429)"                                    | Too many calls. Raise the cache duration, or upgrade your OpenWeather plan.                                                     |
-| The widget shows the weather but no alerts                                 | Weather alerts only exist on One Call 3.0, and only where a meteorological office has issued one.                               |
+| What you see                                                               | What it means                                                                                                                                                                                                                    |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "OpenWeather rejected the API key (HTTP 401)"                              | The key is wrong, or it is not active yet (wait up to a couple of hours after creating it).                                                                                                                                      |
+| "OpenWeather does not serve /data/3.0/onecall for this account (HTTP 404)" | You selected One Call 3.0 without the matching subscription. Subscribe on the OpenWeather site, or switch back to the free API.                                                                                                  |
+| "OpenWeather quota exceeded (HTTP 429)"                                    | Too many calls. Raise the cache duration, or upgrade your OpenWeather plan.                                                                                                                                                      |
+| The widget shows the weather but no alerts                                 | Weather alerts only exist on One Call 3.0, and only where a meteorological office has issued one.                                                                                                                                |
+| The text of an alert is in English                                         | OpenWeather serves the alert bulletins in English whatever the requested language — an API limitation. The alert label itself is translated by Gladys as soon as the phenomenon is recognized (wind, rain, thunderstorm, snow…). |
 
 The integration logs every request it makes: open the integration logs from the
 Gladys UI (or `docker logs` on the host). Set `LOG_LEVEL=debug` for the full
@@ -103,7 +104,7 @@ These are the settings OpenWeather asks for in its configuration screen in Glady
 ## How to install OpenWeather in Gladys
 
 1. In Gladys, open **Integrations**: OpenWeather appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/gladysassistant/gladys-openweather:1.0.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/gladysassistant/gladys-openweather:1.0.2`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/GladysAssistant/gladys-openweather](https://github.com/GladysAssistant/gladys-openweather).
 

--- a/docs/integrations/external/overkiz.mdx
+++ b/docs/integrations/external/overkiz.mdx
@@ -72,7 +72,7 @@ These are the settings Overkiz asks for in its configuration screen in Gladys.
 ## How to install Overkiz in Gladys
 
 1. In Gladys, open **Integrations**: Overkiz appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/cicoub13/gladys-overkiz:1.1.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/cicoub13/gladys-overkiz:1.1.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/cicoub13/gladys-overkiz](https://github.com/cicoub13/gladys-overkiz).
 

--- a/docs/integrations/external/pollens.mdx
+++ b/docs/integrations/external/pollens.mdx
@@ -22,7 +22,8 @@ import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationH
 
 This integration exposes the **pollen risk** of the locations you choose as
 Gladys devices: one device per location, with a 0-to-5 risk level for each pollen
-type.
+type. You add your **Gladys houses in one click**, or a location by typing its
+**town**.
 
 No account to create, no API key to paste.
 
@@ -45,6 +46,30 @@ there is no country to pick anywhere in this integration.
 > France, but its API requires an account and an authentication token that every
 > user would have to create before the integration works at all. CAMS was chosen
 > because it is official _and_ usable with zero setup.
+
+## Adding your Gladys houses, in one click
+
+You have already told Gladys where you live: that is the map in **Settings >
+Houses**. The **"Add my Gladys houses"** button reads those houses and creates a
+location for each one that is not watched yet — no town to type.
+
+Four things worth knowing:
+
+- **The access is a permission.** Where you live is personal data: Gladys only
+  shares it if you accepted the request on the integration's install screen. If
+  the button answers that the access is refused, remove and re-install the
+  integration, accepting the request shown there.
+- **A house you never placed on the map has no coordinates.** It is named in the
+  answer; locate it in Settings > Houses and click the button again.
+- **A house outside the CAMS European domain** is named too, and left out: no
+  pollen forecast covers it (see "Geographic coverage" below).
+- **This is not a sync.** The houses are read at the moment you click. What comes
+  out is an ordinary location, which you rename and remove like any other, and a
+  house moved in Gladys afterwards does not move its location.
+
+Clicking again is safe: a house already watched is reported, not added twice.
+
+Reading the houses requires **Gladys 4.85.0 or newer**.
 
 ## Adding a location
 
@@ -97,19 +122,20 @@ second one.
 
 ## What the device measures
 
-Each device exposes nine measurements:
+Each device exposes ten measurements:
 
-| Measurement                | Description                                 |
-| -------------------------- | ------------------------------------------- |
-| Overall pollen risk        | The highest of the six risks below (0 to 5) |
-| Overall pollen risk (text) | The same level, spelled out                 |
-| Dominant pollen            | The name of the pollen driving that risk    |
-| Alder pollen risk          | Risk from 0 to 5                            |
-| Birch pollen risk          | Risk from 0 to 5                            |
-| Grass pollen risk          | Risk from 0 to 5                            |
-| Mugwort pollen risk        | Risk from 0 to 5                            |
-| Olive pollen risk          | Risk from 0 to 5                            |
-| Ragweed pollen risk        | Risk from 0 to 5                            |
+| Measurement                | Description                                     |
+| -------------------------- | ----------------------------------------------- |
+| Overall pollen risk        | The highest of the six risks below (0 to 5)     |
+| Overall pollen risk (text) | The same level, spelled out                     |
+| Dominant pollen            | The name of the pollen driving that risk        |
+| Last data update           | The date and hour the displayed forecast is for |
+| Alder pollen risk          | Risk from 0 to 5                                |
+| Birch pollen risk          | Risk from 0 to 5                                |
+| Grass pollen risk          | Risk from 0 to 5                                |
+| Mugwort pollen risk        | Risk from 0 to 5                                |
+| Olive pollen risk          | Risk from 0 to 5                                |
+| Ragweed pollen risk        | Risk from 0 to 5                                |
 
 > These are the names with the **Language of the device names** setting on
 > English. It defaults to **French** (`Risque pollinique — Bouleau`) — see
@@ -137,6 +163,26 @@ of your town.
 
 When the model has no value for a species at that position, **nothing is
 published** for that species — a missing measurement is not a zero risk.
+
+### How old are these numbers?
+
+The **Last data update** measurement answers that. It shows the date and hour
+the displayed forecast is for, as `2026-08-06 13:00`.
+
+It is the date of the **data**, not of the last request: CAMS publishes its
+forecast once a day and Open-Meteo interpolates it hour by hour, so a successful
+refresh usually re-reads exactly the same numbers. What you want to know is how
+old those numbers are, not when they were last fetched.
+
+The hour shown is the **location's own**: a forecast is read against the clock of
+the town it covers. For a location in your timezone that is simply your time; for
+one further away it is the local time over there. It is also why this measurement
+sits **on every device** rather than on a single one shared by the whole
+integration: two locations do not necessarily carry the same.
+
+If the date stays stuck in the past, the refresh is failing: the **Test the
+pollen provider** button shows the same date for every location, and says what
+is going wrong if anything is.
 
 > On a dashboard, the "device in a room" box labels a risk value with the names
 > Gladys knows, which stop at 3: levels 4 and 5 show up as "Unknown" there. The
@@ -188,8 +234,10 @@ a value.
 ## Troubleshooting
 
 - **"Test the pollen provider" button**: it queries the source live for _every_
-  location and prints one line per location, numbered like the listing. The
-  quickest way to tell a network problem from a configuration one.
+  location and prints one line per location, numbered like the listing. Each
+  line ends with the date of the data it read, so a source stuck in the past
+  shows up here too. The quickest way to tell a network problem from a
+  configuration one.
 - **The logs**: read the integration logs from the Gladys UI, or with
   `docker logs`. Set `LOG_LEVEL` to `debug` to see the URLs being queried and
   the exact device payload sent to Gladys.
@@ -209,16 +257,16 @@ These are the settings Pollens asks for in its configuration screen in Gladys.
 | General settings | `section` | No | These settings apply to every configured location. |
 | Language of the device names | `select` | No | The language the pollen names are written in: "Bouleau" or "Birch". Everything else this integration displays already follows your Gladys language, but the name of a device and of its features is stored as it is published, so it has to be chosen here. A device already added to Gladys keeps the names it was created with: delete it and add it again from the Discovery tab to rename it. |
 | Refresh interval (s) | `number` | No | How often each location is refreshed, in seconds. The forecast is updated once a day and interpolated hourly, so there is nothing to gain below one hour. |
-| Your locations | `section` | No | Use the buttons below to add, list and remove your locations. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list. |
+| Your locations | `section` | No | Use the buttons below to add, list and remove your locations. "Add my Gladys houses" turns the houses you already placed on the map in Gladys into locations, in one click. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list. |
 
 ## How to install Pollens in Gladys
 
 1. In Gladys, open **Integrations**: Pollens appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-pollen:1.0.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-pollen:1.0.3`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/prohand/gladys-pollen](https://github.com/prohand/gladys-pollen).
 
-Pollens requires Gladys `>=4.62.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+Pollens requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
 
 Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
 

--- a/docs/integrations/external/prix-carburants.mdx
+++ b/docs/integrations/external/prix-carburants.mdx
@@ -40,12 +40,35 @@ For **every station you add**, a device with two read-only features:
 
 - **Price** — the price per litre of the chosen fuel, in euros. History is
   kept, so Gladys charts the price over time.
-- **Last price update** — when the station declared that price (the national
-  feed refreshes about every 10 minutes, but a given station does not change
-  its prices every day).
+- **Last price update** — when the station declared that price, shown as
+  `06/08/2026 à 07:12` in the station's own local time. The national feed
+  refreshes about every 10 minutes, but a given station does not change its
+  prices every day: this date tells you how old the price above really is.
+  It is read per station **and** per fuel, so the diesel and the SP98 of the
+  same station each carry their own date.
 
 The address, the brand, the GPS coordinates and the distance to the postal
 code are stored in the device parameters.
+
+### The "Prix carburants - Mise à jour des données" device
+
+Besides the stations, the Discovery tab offers **one single device, shared by
+the whole integration**, with one feature:
+
+- **Dernière lecture des données** — the date and time, as
+  `08/08/2026 à 21:00`, of the last **successful** read of the open data feed
+  by the integration. The device and its feature are named in French, like the
+  data source they report on.
+
+This is not the same information as a station's "Last price update": that one
+tells you when the station moved its prices (a week ago is perfectly normal),
+this one tells you whether the integration can still reach the national API. A
+date that starts ageing while your refresh interval is one hour means the data
+source stopped answering.
+
+The device is optional: leave it out and the integration behaves exactly the
+same. Added, it is updated at the end of every refresh pass, and stays empty
+until a first read has succeeded.
 
 A device is named after the brand of the station and its city, e.g.
 `Total Access - Oullins-Pierre-Bénite - SP98`. The national price feed does not
@@ -60,7 +83,9 @@ built from its street.
 3. Fill in your **postal code** (5 digits in France, e.g. `35000`). Stations
    are searched around it.
 4. Set the **search radius**: `0` keeps only the stations of the postal code
-   itself, `10` km widens the search to the neighbouring towns.
+   itself, `10` km widens the search to the neighbouring towns. A postal code
+   with no petrol station of its own is fine: the search is centred on your
+   town anyway, so the pumps of the next one show up.
 5. Tick the **fuel type(s)** you care about: Diesel, SP95, SP98, E10, E85,
    LPG.
 6. Save.
@@ -125,13 +150,23 @@ integration keeps the last known value instead of leaving a hole in the chart.
 bounds the discovery list (20 by default, 50 max). In a dense city, lower it
 and shrink the radius.
 
+**One particular station is missing.** The list keeps the NEAREST stations, up
+to that maximum: in a city, twenty of them fit in a couple of kilometres, so a
+station 5 km away is left out even with a 10 km radius. Raise **Maximum number
+of stations** rather than the radius. A station that declares no price for the
+fuel you ticked is not offered either, since the device would have nothing to
+publish.
+
 ## Data and licence
 
 The French data is published by the Ministry of the Economy under the
 [Etalab open licence](https://www.etalab.gouv.fr/licence-ouverte-open-licence).
 The integration queries the
 ["flux instantané" dataset](https://data.economie.gouv.fr/explore/dataset/prix-des-carburants-en-france-flux-instantane-v2/)
-and only fetches the stations around your postal code.
+and only fetches the stations around your postal code. When that dataset knows
+no station in your postal code, the position of your town is read from the
+[Base Adresse Nationale](https://adresse.data.gouv.fr/), the official French
+address service — the postal code is the only thing sent to it.
 
 ## Configuration settings
 
@@ -150,7 +185,7 @@ These are the settings Prix carburants asks for in its configuration screen in G
 ## How to install Prix carburants in Gladys
 
 1. In Gladys, open **Integrations**: Prix carburants appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-prixcarburants:1.0.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-prixcarburants:1.0.3`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/prohand/gladys-prixcarburants](https://github.com/prohand/gladys-prixcarburants).
 

--- a/docs/integrations/external/qualite-de-l-air.mdx
+++ b/docs/integrations/external/qualite-de-l-air.mdx
@@ -21,11 +21,34 @@ import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationH
 <ExternalIntegrationHeader slug="qualite-de-l-air" />
 
 Follow the air quality index of the places you choose in Gladys, with one device
-per location. You add a location by typing the name of its **town**, **anywhere
-in the world**.
+per location. You add your **Gladys houses in one click**, or a location by
+typing the name of its **town**, **anywhere in the world**.
 
 No account to create, no API key to paste: both sources this integration uses
 are open and public.
+
+## Adding your Gladys houses, in one click
+
+You have already told Gladys where you live: that is the map in **Settings >
+Houses**. The **"Add my Gladys houses"** button reads those houses and creates a
+location for each one that is not watched yet — no town to type.
+
+Three things to know:
+
+- **The access is a permission.** Where you live is personal data: Gladys only
+  shares it if you accepted the request on the integration's install screen. If
+  the button answers that the access is refused, remove and re-install the
+  integration, accepting the request it shows.
+- **A house you never placed on the map has no coordinates.** It is named in the
+  answer; locate it in Settings > Houses and run the action again.
+- **This is not a sync.** The houses are read at the moment you click. What comes
+  out is an ordinary location, renamed and removed like the others, and a house
+  moved in Gladys afterwards does not move its location.
+
+Clicking again is safe: a house that is already watched is reported, not added a
+second time. A location that came from a house carries no address label: the
+listing shows its name and its point, because the geocoder cannot name the town
+a point sits in.
 
 ## Adding a location
 
@@ -103,6 +126,7 @@ Each device exposes:
 | **Dominant pollutant**                      | the pollutant that set the index                      |
 | **PM2.5 / PM10 / NO₂ / O₃ / SO₂ sub-index** | 1 to 6, pollutant by pollutant                        |
 | **PM2.5** and **PM10**                      | the concentration, in µg/m³                           |
+| **Last data update**                        | the hour of the data, in the local time of the place  |
 
 The six classes of the index:
 
@@ -122,6 +146,12 @@ enough to degrade the air.
 Only PM2.5 and PM10 also get a concentration feature: they are the only
 pollutants Gladys has a dedicated category for. NO₂, O₃ and SO₂ are carried by
 their sub-index.
+
+The **last data update** is the hour of the CAMS analysis for that place, not
+the hour the integration last ran: the model runs hourly, so refreshing more
+often does not move it. It is shown in the **local time of the place** (followed
+by its zone, `CEST`, `GMT+9`…), which is why every device carries its own: two
+locations can legitimately show two different hours.
 
 A pollutant the source has **no value** for publishes nothing at all. A missing
 measurement is not clean air: writing 1 would corrupt the history and could fire
@@ -210,16 +240,16 @@ These are the settings Qualité de l'air asks for in its configuration screen in
 | General settings | `section` | No | These settings apply to every configured location. |
 | Language of the device names | `select` | No | The language the device and feature names are written in: "Dominant pollutant" or "Polluant dominant", "Nitrogen dioxide (NO₂)" or "Dioxyde d'azote (NO₂)". Everything else this integration displays already follows your Gladys language, but the name of a device and of its features is stored as it is published, so it has to be chosen here. A device already added to Gladys keeps the names it was created with: delete it and add it again from the Discovery tab to rename it. |
 | Refresh interval (s) | `number` | No | How often each location is refreshed, in seconds. The CAMS analysis is produced once an hour, so there is nothing to gain below one hour. |
-| Your locations | `section` | No | Use the buttons below to add, list and remove your locations. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list. |
+| Your locations | `section` | No | Use the buttons below to add, list and remove your locations. "Add my Gladys houses" adds them all in one click, from the houses you already placed on the map in Gladys. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list. |
 
 ## How to install Qualité de l'air in Gladys
 
 1. In Gladys, open **Integrations**: Qualité de l'air appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-airquality:1.0.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-airquality:1.0.3`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/prohand/gladys-airquality](https://github.com/prohand/gladys-airquality).
 
-Qualité de l'air requires Gladys `>=4.62.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+Qualité de l'air requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
 
 Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
 

--- a/docs/integrations/external/reolink.mdx
+++ b/docs/integrations/external/reolink.mdx
@@ -157,7 +157,7 @@ These are the settings Reolink asks for in its configuration screen in Gladys.
 ## How to install Reolink in Gladys
 
 1. In Gladys, open **Integrations**: Reolink appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/william-de71/gladys-reolink:1.0.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/william-de71/gladys-reolink:1.0.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/William-De71/gladys-reolink](https://github.com/William-De71/gladys-reolink).
 

--- a/docs/integrations/external/roborock.mdx
+++ b/docs/integrations/external/roborock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Roborock integration for Gladys Assistant"
 sidebar_label: "Roborock"
-description: "Robot vacuums paired in the Roborock app: state, start/stop, fan power, dock, battery. Free, open source, installable in one click."
+description: "Robot vacuums paired in the Roborock app: state, start/stop, fan power, dock, battery and routines. Free, open source, installable in one click."
 image: "https://integration-store-storage.gladysassistant.com/covers/callemand--gladys-roborock.jpg"
 keywords:
   - "roborock"
@@ -40,6 +40,9 @@ For every robot of your account:
 - **Clean mode** — the suction level (silent, balanced, turbo, max, gentle).
 - **Dock** — send the robot back to its charging dock.
 - **Battery** — the current battery level, in percent.
+- **Routines** — one button per routine saved in the Roborock app. Pressing it
+  preserves its full configuration: rooms, zones, order, cleaning mode and
+  number of passes.
 
 ## Configuration
 
@@ -93,7 +96,7 @@ These are the settings Roborock asks for in its configuration screen in Gladys.
 ## How to install Roborock in Gladys
 
 1. In Gladys, open **Integrations**: Roborock appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/callemand/gladys-roborock:2.1.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/callemand/gladys-roborock:2.2.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/callemand/gladys-roborock](https://github.com/callemand/gladys-roborock).
 

--- a/docs/integrations/external/saunier-duval.mdx
+++ b/docs/integrations/external/saunier-duval.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Saunier Duval integration for Gladys Assistant"
 sidebar_label: "Saunier Duval"
-description: "Control your Saunier Duval heating (MiGo): temperatures, humidity, boiler state and setpoint. Free, open source, installable in one click."
+description: "Control your Saunier Duval boiler through your MiGo / MiGo Link account. Free, open source, installable in one click."
 image: "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-Vaillant-SaunierDuval.png"
 keywords:
   - "saunier duval"
@@ -20,119 +20,187 @@ import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationH
 
 <ExternalIntegrationHeader slug="saunier-duval" />
 
-This integration connects Gladys Assistant to your Saunier Duval heating system
-through the Vaillant Group cloud — the same service the **MiGo** app on your
-phone uses.
+This integration connects your **Saunier Duval** boiler to Gladys Assistant:
+temperatures, setpoints, heating modes and domestic hot water become Gladys
+devices, usable in your scenes and your charts.
 
-It lets you:
+It goes through the **Saunier Duval cloud**, the one behind the **MiGo** /
+**MiGo Link** mobile application. These boilers have no local API: everything
+travels over the Internet, so your gateway has to be online.
 
-- read the room temperature measured by the thermostat;
-- read the humidity measured by the thermostat (model dependent);
-- read the outdoor temperature;
-- read the boiler state (heating, or idle);
-- read the target temperature;
-- **change** the target temperature;
-- **change** the boiler state (turn heating on or off).
+## What you need
 
-## Supported hardware
+- A Saunier Duval boiler connected through a **MiGo** or **MiGo Link** gateway
+  (or a MiPro Sense / Exacontrol connected control behind a gateway).
+- The **account** you already use in the mobile application: same email
+  address, same password.
+- The **country** the account was created in.
 
-Any Saunier Duval installation already driven from the MiGo app:
+Nothing to install on the boiler, no API key to request.
 
-- a **MiGo** or **MiGo Link** gateway paired with a boiler (ThemaPlus Condens,
-  Isotwin, Duomax…);
-- controllers based on a **VRC700** (MiPro, MiPro Sense).
+## Setup
 
-One installation can hold several heating zones: Gladys then creates one
-thermostat per zone.
+1. In Gladys, open **Integrations → Install an integration** and install
+   **Saunier Duval**.
+2. Open the integration configuration screen and fill in:
+   - **Email**: the address of your MiGo / MiGo Link account;
+   - **Password**: of the same account. Gladys stores it encrypted and never
+     sends it back to the browser;
+   - **Country of the account**: the country the account was created in. This
+     matters: an account created in France cannot log in through another
+     country, and the login would be refused without further explanation;
+   - **Refresh interval**: how often, in seconds, the boiler is read. 300 s
+     (5 minutes) is a good setting — a boiler is a slow system, and the
+     Saunier Duval platform limits the number of calls;
+   - **Default override duration**: the duration every zone starts from. You
+     then set it per zone, see "Changing a temperature" below.
+3. Click **Test the connection**. The message tells you how many installations
+   were found on your account.
+4. Open the **Devices** tab of the integration: your devices are already
+   listed. Pick the ones you want to create in Gladys.
 
-> **Bulex** accounts (Belgium) use the same backend but a different country list
-> than the one offered here. This integration targets Saunier Duval accounts.
+## The devices created
 
-## Requirements
+For each installation, the integration creates:
 
-1. A MiGo gateway already installed and **paired in the MiGo app**. This
-   integration reads the account, it does not set it up.
-2. The email address and the password of that MiGo account.
-3. The **country** the account was registered in. This is the most common cause
-   of failure: a wrong country makes the login fail even with a valid password.
+| Device                                  | What it exposes                                                                                                                                                |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Boiler**                              | Outdoor temperature (current and 24 h average), heating water pressure, current activity (heating, hot water, standby), number of fault codes and their detail |
+| **Zone** (one per heating zone)         | Room temperature, humidity (if your thermostat measures it), target temperature, mode, override duration, and whether it is heating right now                  |
+| **Circuit** (one per hydraulic circuit) | Flow temperature actually produced, flow setpoint computed by the heating curve, circuit state                                                                 |
+| **Hot water**                           | Water temperature, setpoint, mode, a **Boost** button, and whether the boiler is heating the water                                                             |
 
-## Configuration
+Zones carry the name you gave them in the boiler ("Living room", "Upstairs"…).
+A zone declared inactive in the boiler is skipped: it reports nothing.
 
-Open the integration configuration in Gladys and fill in:
+**Water pressure** is the value worth watching: below ~1 bar the installation
+needs a top-up. A Gladys scene can warn you.
 
-| Field                  | Description                                                                              |
-| ---------------------- | ---------------------------------------------------------------------------------------- |
-| **Email address**      | The login of your MiGo account.                                                          |
-| **Password**           | The account password. Gladys stores it encrypted and never sends it back to the browser. |
-| **Country**            | The country the account was registered in (France by default).                           |
-| **When heating is on** | The mode a zone returns to when you switch heating back on.                              |
-| **Temporary override** | How long a target temperature lasts when the zone follows its schedule.                  |
-| **Refresh interval**   | How often the readings are fetched, in seconds.                                          |
+## Changing a temperature
 
-Then click **Test the connection**: the button lists the installations found on
-the account with their current temperatures. If that test passes, everything
-else will work.
+The value shown in the "Target temperature" field is the one you edit: the
+**manual temperature**, the one the Saunier Duval application displays — or the
+temporary override temperature while an override is running.
 
-## Devices created
+Deliberately not the boiler's "demand of the moment": that one drops to 0 as
+soon as the heating has nothing to do (a scheduled zone outside its slots,
+summer mode), and an input box pre-filled with 0 would be of no use.
 
-For each installation, Gladys creates two devices.
+The boiler has no single setpoint register: what gets written depends on the
+mode the zone runs in.
 
-**The thermostat** (one per heating zone):
+- **Zone on a schedule** ("Auto"): changing the temperature starts a
+  **temporary override**. The new setpoint applies for the duration you chose,
+  then the schedule takes over again. This is exactly what the mobile
+  application does when you turn the dial on a scheduled zone: your schedule is
+  never overwritten.
+- **Zone in manual mode**: the setpoint is written for good, until you change
+  it again.
+- **Zone switched off**: the command is refused with a clear message. Change
+  the mode of the zone first.
 
-| Feature            | Read / write |
-| ------------------ | ------------ |
-| Temperature        | Read         |
-| Humidity           | Read         |
-| Target temperature | Read + write |
-| Heating (on / off) | Read + write |
+### Override duration
 
-**The boiler** (one per installation):
+Every zone carries an **"Override duration"** control, adjustable from
+**30 minutes to 24 hours**, like the application. Set it before changing the
+temperature: that is the duration the next override will use.
 
-| Feature             | Read / write |
-| ------------------- | ------------ |
-| Outdoor temperature | Read         |
-| Boiler state        | Read         |
-| Water pressure      | Read         |
+It is expressed in **minutes** rather than hours, for a precise reason: the
+Gladys slider steps by one unit, so hours would put every half-hour out of
+reach. In minutes, every value of the application stays reachable. A value that
+does not fall on a step is brought back to the nearest half-hour (100 minutes →
+1 h 30), exactly as the boiler does.
 
-Humidity and water pressure are only created when your installation actually
-reports them.
+This control does not talk to the boiler: the platform only accepts the
+duration when the override starts, alongside the temperature. It is therefore a
+setting of the integration, which Gladys stores and which is read back after a
+restart. A zone starts from the value of the configuration screen.
 
-## How the target temperature is applied
+### Mode mapping
 
-The behaviour depends on the mode the zone currently runs in, so that the value
-you pick in Gladys is the one the controller aims for:
+| Gladys mode | Heating zone                                     | Hot water      |
+| ----------- | ------------------------------------------------ | -------------- |
+| Off         | Off                                              | Off            |
+| Heating     | Manual (or "Day" on MiPro / Exacontrol controls) | Manual / "Day" |
+| Auto        | Scheduled                                        | Scheduled      |
 
-- **The zone follows its weekly schedule** → a temporary override is applied,
-  exactly like turning the dial on the thermostat. It lasts the configured
-  number of hours, then the schedule takes over again.
-- **The zone runs in manual mode** → the manual setpoint itself is changed,
-  permanently.
-- **The zone is switched off** → heating is turned back on in manual mode at the
-  requested temperature: asking for a temperature means asking for heat.
+These are the **only three** modes offered, on the heating zone as on the hot
+water: the same ones the Saunier Duval application shows, in the same order.
+Gladys knows other values — "Cooling" for a thermostat, "Eco", "Away", "Boost"
+for a water heater — but the integration declares to it the modes your boiler
+actually accepts, so those buttons do not appear.
 
-The **Heating** switch turns the zone off (`OFF` mode) or back on in the mode
-chosen in the configuration (weekly schedule by default).
+The **wording differs between the two**, though, and that is not up to the
+integration: each category has its own vocabulary in Gladys. They are the same
+three notions.
 
-## Known limitations
+| Saunier Duval application | Heating zone (Gladys) | Hot water (Gladys) |
+| ------------------------- | --------------------- | ------------------ |
+| Manual                    | Heating               | Manual             |
+| Schedule                  | Auto                  | Schedule           |
+| Heating off               | Off                   | Off                |
 
-- **The gateway is slow.** It only pushes its readings to the cloud every few
-  minutes: lowering the refresh interval below 300 seconds gains nothing and
-  multiplies the calls.
-- **Changes take a moment to show up.** After a command, the cloud can take one
-  to two minutes to reflect the new value.
-- **Unofficial API.** Saunier Duval does not document this API: it is the one
-  its mobile app uses. It can change without notice.
-- **One account at a time.** The integration reads every installation of an
-  account, but only one account can be configured.
+On older controls the "Set back" mode (permanent heating at the reduced
+temperature) reads as "Heating" too — Gladys has no value that matches it
+exactly.
+
+## Hot water boost
+
+The **Boost** asks the boiler to heat the tank right now, outside of the
+schedule. The boiler clears it by itself once the tank is hot: Gladys will show
+it back as off at the next refresh.
+
+> On Gladys versions older than the
+> [#2815](https://github.com/GladysAssistant/Gladys/pull/2815) fix, the greyed
+> button of the pair shows the opposite of the real state ("Boost active" while
+> the boost is off). The clickable one is correct. This is a display bug of the
+> Gladys core, not of the integration: updating Gladys fixes it.
+
+## Things to know
+
+- **Display delay.** After a command, Gladys shows the requested value right
+  away, then replaces it with the one the boiler confirms on the next cycle.
+  Needing one or two refreshes to see the real effect is normal.
+- **Rate limiting.** The Saunier Duval platform limits the number of requests,
+  and you share it with the mobile application. A refresh cycle costs **one
+  single request per installation**: every published value comes from the same
+  answer. The list of installations, the gateway state and the fault codes are
+  read separately, every 30 minutes only — which is why a gateway that just
+  went offline can take up to half an hour to be reported as such. Do not lower
+  the interval without a reason: 60 seconds is the allowed minimum, 300 seconds
+  the recommended setting.
+- **One account.** The integration reads every installation attached to the
+  account. If you have several, each one produces its own set of devices,
+  prefixed with its name.
+- **Unofficial API.** Saunier Duval neither documents nor supports this API:
+  it is the one its mobile application uses, and it can change without notice.
+  This integration is not affiliated with, nor endorsed by, Saunier Duval or
+  the Vaillant Group.
+
+## After an update of the integration
+
+An already-created device does not change by itself. The **Discovery** tab
+shows an **Update** button on the devices whose structure moved, and that
+button is what re-applies everything: new features, units, and the list of
+offered modes.
+
+One case to know about: Gladys detects a "changed structure" by comparing the
+features, their units and their bounds — **not the list of modes**. If an
+update of the integration only changes the offered modes, no **Update** button
+appears and the device keeps its old list. Delete the device and create it
+again from the Discovery tab: there is no other way.
 
 ## Troubleshooting
 
-- **"Login refused"**: check the email address, the password and above all the
-  **country**. Try signing in from the MiGo app to confirm the account works.
-- **No device appears**: run **Test the connection**. If no installation is
-  found, the gateway is not attached to this account.
-- **Values stopped updating**: check the logs of the integration container
-  (`LOG_LEVEL=debug` shows every API call).
+- **"Login refused"**: check the email, the password and above all the
+  **country** of the account. Check as well that these credentials work in the
+  mobile application.
+- **No installation found**: the account has no boiler attached, or the
+  gateway was paired with another account.
+- **Frozen values**: the gateway is probably offline. Check it in the mobile
+  application; the integration can only read what the platform knows.
+- **Detailed diagnosis**: set the `LOG_LEVEL` environment variable of the
+  integration to `debug` to see every call in the container logs.
 
 ## Configuration settings
 
@@ -140,22 +208,21 @@ These are the settings Saunier Duval asks for in its configuration screen in Gla
 
 | Setting | Type | Required | Description |
 | --- | --- | --- | --- |
-| Connect your MiGo account | `section` | No | This integration talks to the Saunier Duval cloud, the same service the MiGo app uses. Sign in with the email address and the password of that app, and pick the country your account was created in. Your gateway (MiGo, MiGo Link) must already be paired in the app. |
-| Email address | `string` | Yes | The email address of your MiGo / Saunier Duval account. |
-| Password | `secret` | Yes | The password of your MiGo account. It is stored encrypted by Gladys and never sent back to the browser. |
-| Country | `select` | Yes | The country your account was registered in. A wrong country makes the login fail. |
-| When heating is turned on | `select` | No | Which mode the zone goes back to when you switch heating on: its weekly schedule, or a fixed manual temperature. |
-| Temporary override duration (h) | `number` | No | When the zone follows its schedule, changing the target temperature applies a temporary override. This is how long it lasts, in hours. |
-| Refresh interval (s) | `number` | No | How often the temperatures are read from the cloud, in seconds. The gateway itself only reports every few minutes, so there is little value in going below 300. |
+| Getting started | `section` | No | Use the email and password of the MiGo or MiGo Link account you already use in the mobile application. Your boiler must be connected through a MiGo or MiGo Link gateway: everything goes through the Saunier Duval cloud, there is no local access. |
+| Email | `string` | Yes | Email address of your MiGo / MiGo Link account. |
+| Password | `secret` | Yes | Password of your MiGo / MiGo Link account. Stored encrypted by Gladys and never sent back to the browser. |
+| Country of the account | `select` | Yes | The country you registered your account in. An account created in France cannot log in through another country. |
+| Refresh interval (s) | `number` | No | How often the boiler is read, in seconds. The Saunier Duval platform is rate limited: keep a comfortable interval, a boiler is a slow system. |
+| Default override duration (h) | `number` | No | When a zone follows its schedule, changing its temperature starts a temporary override, after which the schedule takes over again. This is the duration a zone starts from: each zone then carries its own "Override duration" control, from 30 minutes to 24 hours in 30-minute steps. Half-hours only. |
 
 ## How to install Saunier Duval in Gladys
 
 1. In Gladys, open **Integrations**: Saunier Duval appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/philippema/gladys-vaillant-saunierduval:2.0.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/philippema/gladys-vaillant-saunierduval:1.0.1`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/PhilippeMA/gladys-Vaillant-SaunierDuval](https://github.com/PhilippeMA/gladys-Vaillant-SaunierDuval).
 
-Saunier Duval requires Gladys `>=4.62.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+Saunier Duval requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
 
 Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
 

--- a/docs/integrations/external/vigieau.mdx
+++ b/docs/integrations/external/vigieau.mdx
@@ -31,17 +31,30 @@ The VigiEau API is free and public: **no account, no API key**. It covers
 ## What you get
 
 **One device per watched location**, named "Vigilance sécheresse — _your
-location_", each carrying five sensors. You can watch up to **ten locations**: a
+location_", each carrying seven sensors. You can watch up to **ten locations**: a
 house, a second home and an allotment garden are rarely under the same
 prefectoral decree.
 
-| Sensor                   | Value                                        |
-| ------------------------ | -------------------------------------------- |
-| **Drought alert level**  | 0 to 3 — the worst of the three water types  |
-| **Level (text)**         | "Alerte renforcée", "Crise"…                 |
-| **Surface water level**  | 0 to 3 — rivers and lakes (`SUP` zones)      |
-| **Groundwater level**    | 0 to 3 — aquifers (`SOU` zones)              |
-| **Drinking water level** | 0 to 3 — the tap water network (`AEP` zones) |
+| Sensor                       | Value                                                                   |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| **Drought alert level**      | 0 to 3 — the worst of the three water types                             |
+| **Level (text)**             | "Alerte renforcée", "Crise"…                                            |
+| **Surface water level**      | 0 to 3 — rivers and lakes (`SUP` zones)                                 |
+| **Groundwater level**        | 0 to 3 — aquifers (`SOU` zones)                                         |
+| **Drinking water level**     | 0 to 3 — the tap water network (`AEP` zones)                            |
+| **Dernière mise à jour**     | "15/06/2026 09:26" — the last successful VigiEau read for this location |
+| **Arrêté en vigueur depuis** | "15/06/2026" — the day the decree setting this level came into force    |
+
+> **The two dates do not say the same thing.** VigiEau publishes no timestamp of
+> its own data: nothing in the API says "this information dates from…". So
+> **Dernière mise à jour** is the moment _the integration_ last queried VigiEau
+> successfully for this location — what tells a frozen sensor from a level that
+> simply has not changed. It only moves on a successful read: after an outage it
+> stays on its previous value, alongside the level. **Arrêté en vigueur depuis**
+> is a date from the source: the day the applicable prefectoral decree came into
+> force. When nothing is in force, the sensor reads "Aucun arrêté en vigueur"
+> rather than keeping the date of a decree that has been lifted. Both are shown
+> in Paris time, whatever the server's timezone.
 
 The numeric scale follows the prefectoral decrees, folded onto the four values
 Gladys knows how to name:
@@ -72,7 +85,9 @@ separately, in addition to the overall level.
    **Discovery** tab, ready to be added. If you already know the point, fill the
    optional **Latitude** and **Longitude** fields in instead: they are used as
    they are, with no geocoding.
-3. Repeat for every location you want to watch, up to ten.
+3. Repeat for every location you want to watch, up to ten. If the locations you
+   want are your **Gladys houses**, the **"Add my Gladys houses"** button spares
+   you all typing: see "Adding your Gladys houses in one click" below.
 4. In **"General settings"**, pick your **user profile**: household, company, local authority or farm.
    Restrictions differ per profile, and VigiEau returns the ones that apply to
    yours. This setting applies to **every location**.
@@ -83,6 +98,31 @@ separately, in addition to the overall level.
 
 > Until one location has a usable point, no device is offered. That is
 > deliberate: no device beats a device pinned to an empty location.
+
+### Adding your Gladys houses in one click
+
+You have already told Gladys where you live: that is the map in
+**Settings > Houses**. The **"Add my Gladys houses"** button reads those houses
+and creates a location for each one that is not watched yet — no address to
+type, no risk of geocoding the wrong town. The location takes the name the house
+has in Gladys, and the address shown in the listing is looked up for you from
+the point.
+
+A few rules, which the message under the button repeats every time:
+
+- **Reading your houses' coordinates is an authorization.** Where you live is
+  personal data: the integration asks for it in its manifest, and Gladys shows
+  you that request when you install it. If the button answers that Gladys
+  refuses to share those coordinates, the installed version never asked for it:
+  update the integration, or remove and re-install it and accept the request.
+- **A house you never placed on the map has no coordinates.** It is named in the
+  answer and nothing is watched in its place: locate it in
+  **Settings > Houses**, then click again.
+- **A house already watched is not added twice.** Click as often as you like:
+  the message tells you which location already watches it.
+- **It is not a sync.** The houses are read once, when you click. A location
+  created this way is an ordinary one: move the house in Gladys afterwards and
+  the location stays where it was — delete it and click again.
 
 ### Viewing your locations
 
@@ -201,6 +241,9 @@ point read off a map.
 - **Add a location (search for an address)** — geocodes the address and creates
   the location, or creates it straight on the latitude and longitude you type
   (both optional). See "Why an address and not a postal code" above.
+- **Add my Gladys houses** — reads the houses configured in Gladys and adds a
+  location for each one that is not watched yet, with nothing to type. Requires
+  Gladys 4.85.0 or newer, and the authorization accepted at install time.
 - **Show the locations** — lists every configured location, numbered, with its
   name, address and coordinates. Those numbers are the ones the deletion offers.
 - **Test the VigiEau connection (all locations)** — runs a live request and
@@ -267,9 +310,11 @@ point read off a map.
   connection** action: it queries the API live and shows any error.
 - **Every feature is called "Risk level"** — that is how Gladys displays them:
   the "Features" list on the device page shows the generic category label, not
-  the name published by the integration. In order they are: overall level,
-  text, surface water, groundwater, drinking water. On a dashboard or in a
-  scene, the four levels do show their real names.
+  the name published by the integration. The three text sensors — level (text),
+  last update, decree in force since — share the same fate and carry an
+  identical generic label. In order they are: overall level, text, surface
+  water, groundwater, drinking water, last update, decree in force since. On a
+  dashboard or in a scene, they all do show their real names.
 - **"VigiEau cannot tell which zone applies here"** — the configured point does
   not fall inside a single zone. The message names the location: add it again
   with a more precise address (number and street rather than just the town
@@ -313,11 +358,11 @@ These are the settings VigiEau asks for in its configuration screen in Gladys.
 ## How to install VigiEau in Gladys
 
 1. In Gladys, open **Integrations**: VigiEau appears in the catalog, next to the native integrations, with a community badge.
-2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-vigieau:2.0.0`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-vigieau:2.0.2`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
 3. Open the **Configuration** screen of the integration, fill in the settings, and save.
 4. You can also install it directly from its repository URL: [https://github.com/prohand/gladys-vigieau](https://github.com/prohand/gladys-vigieau).
 
-VigiEau requires Gladys `>=4.62.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+VigiEau requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
 
 Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
 

--- a/docs/integrations/external/z2m-devices-monitor.mdx
+++ b/docs/integrations/external/z2m-devices-monitor.mdx
@@ -1,0 +1,358 @@
+---
+title: "Z2M Devices Monitor integration for Gladys Assistant"
+sidebar_label: "Z2M Devices Monitor"
+description: "Alerts you when a Zigbee2MQTT device stops giving signs of life. Free, open source, installable in one click."
+image: "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-z2m-devices-monitor.jpg"
+keywords:
+  - "z2m devices monitor"
+  - "gladys z2m devices monitor"
+  - "z2m devices monitor gladys assistant"
+  - "external integration"
+  - "open source home automation"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/en.md in
+https://github.com/prohand/gladys-z2m-devices-monitor instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="z2m-devices-monitor" />
+
+This integration watches your Zigbee2MQTT devices and alerts you when one of them
+**stops giving signs of life**.
+
+## Why not the battery level
+
+The battery percentage a Zigbee device reports is a coarse, rarely refreshed and
+often plainly wrong estimate: a CR2032 sensor commonly reads 100% right up to the
+day it stops answering. More importantly, the battery says nothing about the
+other ways a device dies: unplugged, dropped off the network, route lost, or
+parent router down.
+
+A Zigbee device that is alive **talks**. Sensors send their readings, routers
+answer, everything reports at least periodically. So the only reliable fact is
+_when did I last hear from this device?_ — and the only useful question is _has
+it been silent for longer than it should?_
+
+That is exactly what this integration does.
+
+## What it does
+
+It subscribes to everything Zigbee2MQTT publishes on your MQTT broker
+(`zigbee2mqtt/#`), remembers when each device last spoke, and continuously
+re-evaluates their silence.
+
+It **never** publishes anything to your Zigbee network: it only listens. It also
+tells apart:
+
+- a message published **by** the device → proof it is alive;
+- a message replayed by the broker (the _retained_ flag, on every reconnection) →
+  it may be days old, it proves nothing;
+- a `set`/`get` command sent **to** the device by Gladys, Home Assistant or a
+  scene → that is not the device talking. Without that distinction, a dead sensor
+  would look alive for as long as something keeps talking to it.
+
+If you enabled the `advanced.last_seen` option in Zigbee2MQTT, the integration
+uses the timestamp devices attach to their reports: the most reliable source
+there is, and the one that even makes retained messages usable. It is not
+required.
+
+## Setup
+
+### 1. Requirements
+
+- Zigbee2MQTT running and publishing to an MQTT broker;
+- that broker reachable from Gladys (same local network).
+
+### 2. Configuration
+
+| Field                   | What to fill in                                                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Broker URL**          | The address of your MQTT broker, e.g. `mqtt://192.168.1.10:1883`. The `mqtts://`, `ws://` and `wss://` schemes are supported too. |
+| **Username / Password** | Leave empty if your broker allows anonymous connections.                                                                          |
+| **Base topic**          | The `mqtt.base_topic` configured in Zigbee2MQTT. `zigbee2mqtt` in almost every case.                                              |
+
+Then click **Test the MQTT connection**: the button reports whether it is
+connected, how many devices it sees and how many messages it received. It is the
+fastest way to catch the classic mistake — right broker, wrong base topic, and
+nothing happens at all.
+
+#### Where to find those three values
+
+**They have to be typed in by hand: the integration cannot read them from Gladys
+on its own.** An external integration runs in its own container and Gladys only
+ever hands it its _own_ configuration; the API Gladys exposes to it gives no
+access to the settings or variables of another integration. That is a deliberate
+property of the sandbox, not an oversight: without it, any integration from the
+store could read the credentials of your other services.
+
+The copy/paste is short though:
+
+- **if Gladys installed Zigbee2MQTT for you** ("Installation from Gladys" mode),
+  the broker is the Mosquitto container Gladys manages. Open the **Zigbee2MQTT**
+  integration → **Setup** tab → **"External tools connection"** block: Gladys
+  displays the URL, the username and the password there, with a copy button. The
+  password is generated randomly on the first activation, so there is no
+  "default" value to guess. That broker listens on port **1884**, and the URL
+  shown points at `localhost`: **replace `localhost` with the IP address of your
+  Gladys machine**, otherwise `localhost` would mean this integration's own
+  container. The base topic is `zigbee2mqtt`;
+- **if you run your own broker** (standalone Zigbee2MQTT, Mosquitto, Home
+  Assistant…), just reuse the URL and credentials Zigbee2MQTT itself uses — the
+  `mqtt:` block of its `configuration.yaml`.
+
+### 3. Add the devices
+
+Go to **Devices → Discover**, then create the devices you want to watch. You will
+find:
+
+- one device **per Zigbee device** known to Zigbee2MQTT;
+- one **Zigbee2MQTT monitor** device summarizing the whole network.
+
+Watched devices carry their Zigbee2MQTT name **followed by a suffix**,
+`(monitor)` by default: `office plug (monitor)`. Without it they would be
+impossible to tell apart from the devices Gladys already exposes under the very
+same name through its own Zigbee2MQTT integration — a scene picker would show
+"office plug" twice. Change it (or empty it) under **Device naming**. It only
+applies to the devices you create afterwards: Gladys never renames a device you
+already added, rename it yourself on its page.
+
+### What happens when the Zigbee network changes?
+
+The integration keeps re-reading the Zigbee2MQTT inventory, so the **Discover**
+screen updates on its own:
+
+- **a device you just paired** shows up in the list within seconds, with no
+  restart and nothing to click. Creating it in Gladys stays **manual** though —
+  what enters your installation is your call. That is also why the scene worth
+  building is the one on the **Zigbee2MQTT monitor** device: its counters cover
+  every device Zigbee2MQTT knows about, including the ones you never created in
+  Gladys, so a newly paired device is covered by the alert from the moment it
+  joins;
+- **a device removed from Zigbee2MQTT** disappears from the **Discover** screen
+  and stops being counted and publishing values. If you had already created it in
+  Gladys, its device is **not deleted automatically**: it stays, frozen on its
+  last value. An integration is not allowed to delete your devices — remove it
+  from **Devices** whenever you want.
+
+## Silence thresholds
+
+A device is declared dead once it has been silent for longer than its threshold.
+Two defaults:
+
+- **mains-powered devices** (plugs, bulbs, routers): 120 minutes, they report
+  often;
+- **battery devices** (sensors): 1440 minutes, i.e. 24 hours — they sleep most of
+  the time.
+
+You can refine device by device in the **Per-device thresholds** field, one
+`device=minutes` pair per line or separated by commas:
+
+```
+mailbox sensor=4320
+garage motion=180
+0x00158d0001abcdef=60
+```
+
+The device is designated by its Zigbee2MQTT friendly name or its IEEE address.
+
+**Start generous.** A tight threshold produces false alerts, and an alert nobody
+believes anymore is worthless. Let it run for a few days, look at the "Silence"
+value on each device screen (Gladys labels it _Duration (integer)_), then
+tighten.
+
+## What each device exposes
+
+Every watched device exposes **2 features**:
+
+| Feature     | Name displayed by Gladys | Description                                                                                                                                                     |
+| ----------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Alive**   | _State of input_         | On = the device is giving signs of life, Off = it has been silent for longer than its threshold. This is the feature to build an alert on. Its history is kept. |
+| **Silence** | _Duration (integer)_     | How many minutes the device has been quiet. Useful to size the thresholds.                                                                                      |
+
+If you added your devices with version 1.0.1 or earlier, their **Alive** feature
+was published in another category, which the Gladys screens draw as an empty tag
+— it looks as if the device only carries **Silence**. The Discovery screen offers
+an **Update** button on each of those devices: click it and the feature comes
+back, history included.
+
+The **Zigbee2MQTT monitor** device exposes **5 features**:
+
+| Feature                       | Name displayed by Gladys | Description                                                                                                                         |
+| ----------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| **Silent devices**            | _Silent devices_         | How many devices are currently silent. This is the alert trigger.                                                                   |
+| **Silent device names**       | _Text_                   | Their names, so a notification can quote them. Reads "No silent device" while the whole network is answering (editable, see below). |
+| **Devices alive**             | _Devices alive_          | How many devices are answering.                                                                                                     |
+| **Devices monitored**         | _Devices monitored_      | How many devices are watched.                                                                                                       |
+| **Zigbee2MQTT bridge online** | _State of input_         | The state of the Zigbee2MQTT bridge itself.                                                                                         |
+
+### Why some names change on screen
+
+Gladys does not always show the name the integration gave a feature. When a
+feature is **the only one of its type on its device**, the UI shows the standard
+label of its category instead — hence _Text_ for "Silent device names", _State
+of input_ for "Alive" and for "Zigbee2MQTT bridge online", or _Counter (integer)_
+on the device edit screen. The three monitor counters share the same type, so
+they keep their names.
+
+This is Gladys behaviour, not a setting of this integration. Two practical
+consequences:
+
+- in a scene picker, look for the displayed name ("Zigbee2MQTT monitor (Text)" =
+  the names of the silent devices);
+- you can rename a feature from the device page if the standard label does not
+  speak to you.
+
+### The text shown when all is well
+
+"Silent device names" is a text feature, and it spends most of its life naming
+nobody — which is good news. It then shows an explicit sentence rather than a
+dash: **No silent device** by default. The **Text shown when no device is
+silent** field (_Zigbee2MQTT monitor device_ section) lets you translate it.
+Empty the field to restore the default: this text can never be empty, Gladys does
+not store an empty text state.
+
+### What about the signal strength?
+
+It is **not** published by this integration: the Gladys Zigbee2MQTT integration
+already reports the LQI of every device, and a second copy of the same number
+would only clutter the device lists and the scene pickers.
+
+## Getting alerted: the scene
+
+The integration raises the flag, Gladys sends the alert. The most useful scene is
+the one built on the **Zigbee2MQTT monitor** device: it covers the whole network,
+including the devices you will pair six months from now.
+
+1. **Scenes → New scene**;
+2. trigger: **A device value changes** → device _Zigbee2MQTT monitor_, feature
+   **Silent devices**, condition _greater than_ `0`;
+3. first action: **Get device value** → under _Select a device_, pick
+   **Zigbee2MQTT monitor (Text)**, i.e. the **Silent device names** feature.
+
+   This is the step everyone forgets: in Gladys a message can only insert values
+   fetched by an action placed **before** it. Without this box the message's
+   variable picker is empty, and the alert cannot name the sensors involved;
+
+4. second action: **Send a message** (mobile notification, Telegram…) with
+   something like:
+
+   > Zigbee device(s) with no sign of life: _Device last value_
+
+   To insert that variable, type `{{` where you want it in the message: Gladys
+   then offers the value fetched in step 3, shown as "1.1. Device last value"
+   (the number is the position of the _Get device value_ action in the scene).
+   Always go through that picker rather than typing the variable by hand: the
+   message will name the sensors involved instead of just saying something is
+   wrong.
+
+For one particularly critical sensor (smoke detector, alarm, freezer), add a
+dedicated scene on its **Alive** feature turning to Off (in the picker: _device
+name (State of input)_).
+
+Tip: add a time condition to the scene if you would rather not be woken up at
+night — a silent sensor can almost always wait until morning.
+
+## The buttons on the Configuration screen
+
+- **Test the MQTT connection** — the live connection state, how many devices are
+  watched, how many messages were received, and the precise reason on failure.
+- **List the silent devices** — who is quiet, and for how long.
+- **Refresh the device list** — republishes the list to Gladys, after a pairing
+  or a rename in Zigbee2MQTT.
+
+## Good to know
+
+- **Devices are identified by their IEEE address**, not by their name. Renaming a
+  device in Zigbee2MQTT updates its name in Gladys without losing its history.
+- **Devices disabled in Zigbee2MQTT are not watched** by default: they are
+  supposed to be silent. An option lets you include them.
+- **The coordinator (the USB stick) is not watched**: it is not a device that can
+  fall off on its own. Use the _Zigbee2MQTT bridge online_ feature for that.
+- **The last-seen history is persisted** in the integration's `/data` volume. A
+  container restart therefore does not reset every device — otherwise a sensor
+  that died a month ago would start a fresh threshold and the alert would never
+  fire.
+- **If you are upgrading from a version that published the signal strength**,
+  the devices you already created in Gladys keep that feature: an integration
+  cannot remove a feature from a device you created. It stops receiving values
+  and stays frozen on the last one. To get rid of it, delete the device in Gladys
+  and re-create it from **Discover** (its history is lost then); otherwise just
+  ignore it.
+- **A device never heard from** gets one full threshold from the moment the
+  monitor started before being flagged. A freshly installed integration does not
+  declare the whole network dead on its first minute.
+
+## Troubleshooting
+
+**The test button says it is not connected.** Check the URL (with the port,
+`1883` by default), the credentials, and that the broker accepts connections from
+the Gladys machine.
+
+**It is connected, but sees no device.** The base topic probably does not match
+the one Zigbee2MQTT uses. Compare it with `mqtt.base_topic` in your
+`configuration.yaml`.
+
+**A device is flagged silent while it works fine.** Its threshold is too tight:
+look at its _Silence_ (_Duration (integer)_) feature to learn its real rhythm, then give it a custom
+threshold. Door, leak and button sensors are typically quiet for days when
+nothing happens.
+
+**Every device goes silent at once.** Check _Zigbee2MQTT bridge online_ first: it
+is most likely Zigbee2MQTT itself, the broker or the coordinator that went down,
+not your sensors.
+
+**A device I just added reads "no recent value".** A feature only gets a value
+once the device exists in Gladys, so everything published before you pressed
+_Add_ went nowhere. The integration republishes the states of a device the moment
+Gladys tells it the device was created, so the value lands within a couple of
+seconds. If the badge is still there, **reload the page**: the dashboard computes
+the "no recent value" badge when it loads its data and does not clear it on the
+live updates that follow.
+
+## Configuration settings
+
+These are the settings Z2M Devices Monitor asks for in its configuration screen in Gladys.
+
+| Setting | Type | Required | Description |
+| --- | --- | --- | --- |
+| How it works | `section` | No | A Zigbee device that is alive talks. This integration listens to everything Zigbee2MQTT publishes, remembers when each device last spoke, and flags the ones that have been silent for too long. It never uses the battery level: a Zigbee battery percentage is a coarse estimate that often reads 100% right up to the day the sensor stops answering. |
+| MQTT broker | `section` | No | The same broker Zigbee2MQTT publishes on. The integration only ever subscribes: it never publishes anything to your Zigbee network. These values have to be typed in here: an integration runs in its own sandbox and Gladys never hands it the settings of another integration. If Gladys installed Zigbee2MQTT for you, copy them from the Zigbee2MQTT integration, Setup tab, "External tools connection" block — and replace localhost in the URL with the IP address of your Gladys machine. |
+| Broker URL | `string` | Yes | Address of the MQTT broker, e.g. mqtt://192.168.1.10:1883 (mqtts:// and ws:// are supported too). |
+| Username | `string` | No | Leave empty if your broker allows anonymous connections. |
+| Password | `secret` | No |  |
+| Base topic | `string` | Yes | The base topic configured in Zigbee2MQTT (mqtt.base_topic). |
+| Silence thresholds | `section` | No | A device is declared dead once it has been silent for longer than its threshold. Battery sensors report far less often than mains-powered devices, hence two separate defaults. Start generous: it is better to be alerted a few hours late than to be woken up by a false alarm. |
+| Threshold for mains-powered devices (min) | `number` | No | Applies to plugs, bulbs and routers, which report often. |
+| Threshold for battery devices (min) | `number` | No | Applies to battery sensors, which sleep most of the time. 1440 minutes is 24 hours. |
+| Per-device thresholds | `string` | No | One device=minutes pair per line or separated by commas. The device is designated by its Zigbee2MQTT friendly name or its IEEE address. Example: mailbox sensor=4320, 0x00158d0001abcdef=60 |
+| Device naming | `section` | No | Gladys most likely already knows these devices under their Zigbee2MQTT name, through its own Zigbee2MQTT integration. Without a suffix, a scene picker shows the same name twice with no way to tell which is which. |
+| Suffix added to device names | `string` | No | Appended to the Zigbee2MQTT name of each watched device, e.g. "office plug (monitor)". Leave empty to keep the raw name. Only affects the devices you create afterwards: Gladys never renames a device you already added. |
+| Zigbee2MQTT monitor device | `section` | No | The single device summarizing the whole network: how many devices are watched, how many are silent, and the names of the silent ones — the text a scene notification quotes. It is the one to build your alert on: its counters cover every device Zigbee2MQTT knows about, including the ones you pair later. |
+| Text shown when no device is silent | `string` | No | What the "Silent device names" feature reads while the whole network is answering. Write it in your own language; empty restores the default. |
+| Advanced | `section` | No |  |
+| Devices to ignore | `string` | No | Friendly names or IEEE addresses, separated by commas. Ignored devices are not published to Gladys and never raise an alert. |
+| Also watch devices disabled in Zigbee2MQTT | `boolean` | No | Off by default: a device you disabled on purpose is expected to be silent. |
+| Check interval (s) | `number` | No | How often the silence of every device is re-evaluated. |
+
+## How to install Z2M Devices Monitor in Gladys
+
+1. In Gladys, open **Integrations**: Z2M Devices Monitor appears in the catalog, next to the native integrations, with a community badge.
+2. Click **Install**. Gladys pulls the Docker image (`ghcr.io/prohand/gladys-z2m-devices-monitor:1.0.3`), starts it in a sandbox isolated from the core, and generates the integration's interface (devices, discovery and configuration).
+3. Open the **Configuration** screen of the integration, fill in the settings, and save.
+4. You can also install it directly from its repository URL: [https://github.com/prohand/gladys-z2m-devices-monitor](https://github.com/prohand/gladys-z2m-devices-monitor).
+
+Z2M Devices Monitor requires Gladys `>=4.85.0`. The catalog inside Gladys refreshes every hour, so a new version becomes available at most one hour after its release.
+
+Not running Gladys yet? It is free and open source: [follow the installation guide](/docs/) to get started.
+
+## About external integrations
+
+Z2M Devices Monitor is an **external integration**: a community integration packaged as a Docker container and published on GitHub, that Gladys installs in one click and runs in a sandbox isolated from its core. It is published and maintained by [prohand](https://github.com/prohand), not by the Gladys core team.
+
+- [Browse all external integrations](/docs/integrations/external/)
+- [Discover the native integrations](/docs/integrations/) built into Gladys
+- [Build and publish your own external integration](/docs/dev/external-integrations/)
+- [Source code on GitHub](https://github.com/prohand/gladys-z2m-devices-monitor) — [source of this documentation](https://github.com/prohand/gladys-z2m-devices-monitor/blob/HEAD/docs/en.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/apple-tv.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/apple-tv.mdx
@@ -1,0 +1,240 @@
+---
+title: "Intégration Apple TV pour Gladys Assistant"
+sidebar_label: "Apple TV"
+description: "Contrôlez votre Apple TV : alimentation, télécommande, lecture, volume et applications. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/valentinhttr--gladys-apple-tv.jpg"
+keywords:
+  - "apple tv"
+  - "gladys apple tv"
+  - "apple tv gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/valentinhttr/gladys-apple-tv instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="apple-tv" />
+
+Contrôlez votre Apple TV depuis Gladys Assistant : alimentation, télécommande,
+lecture, volume et applications. L'intégration parle directement à votre Apple TV
+sur votre réseau local, avec [pyatv](https://pyatv.dev) — l'implémentation de
+référence des protocoles AirPlay et Companion d'Apple, celle qu'utilise aussi
+Home Assistant. Rien ne passe par les serveurs d'Apple, aucun identifiant Apple
+n'est nécessaire.
+
+## Prérequis
+
+- Une Apple TV (HD, 4K, toute génération sous tvOS 15 ou plus récent).
+- Gladys 4.85.0 ou plus récent.
+- L'Apple TV et votre serveur Gladys sur le **même réseau**. S'ils sont sur des
+  VLAN ou sous-réseaux différents, voir « Réseaux séparés » plus bas.
+- Un accès physique au téléviseur pendant l'appairage : Apple affiche un code à
+  l'écran, que vous devez lire et saisir dans Gladys.
+
+## Mise en route
+
+Trois étapes, dans cet ordre. Une Apple TV doit être **ajoutée** puis
+**appairée** avant que la moindre commande fonctionne : l'ajouter seulement vous
+donne un appareil qui n'obéit à rien.
+
+### 1. Trouver votre Apple TV
+
+Ouvrez l'onglet **Découverte** de l'intégration et cliquez sur **Scanner**.
+Gladys écoute les annonces AirPlay de votre réseau, et l'intégration vérifie
+chaque adresse candidate directement avec pyatv. Votre Apple TV apparaît avec
+son nom et son modèle.
+
+Cliquez sur **Ajouter à Gladys** pour créer l'appareil. Une Apple TV porte
+généralement le nom de la pièce où elle se trouve (« Séjour ») : l'appareil est
+donc créé sous le nom « Apple TV Séjour » — lisible dans une liste d'appareils,
+et c'est aussi ce qui rend son sélecteur lisible dans les scènes. Vous pouvez le
+renommer ensuite dans l'onglet Appareils.
+
+### 2. L'appairer
+
+L'appairage autorise Gladys à contrôler l'appareil. Il se fait dans l'onglet
+**Configuration**, avec les deux premiers boutons :
+
+1. **1. Appairer une Apple TV** — choisissez votre Apple TV dans la liste
+   déroulante et cliquez sur **Exécuter**. La liste contient les Apple TV
+   ajoutées à l'étape 1 : aucune adresse IP à chercher. Un code s'affiche sur
+   votre téléviseur.
+2. **2. Saisir le code** — tapez le code affiché à l'écran, puis cliquez sur
+   **Exécuter**.
+
+Apple demande un code **par protocole** : une fois le premier code accepté, un
+second s'affiche sur le téléviseur. Deux codes, c'est normal.
+
+Le second code se saisit **dans le même champ que le premier**. Le formulaire
+conserve ce que vous avez tapé : il faut donc **effacer le champ et saisir le
+nouveau code à la place**, puis relancer le bouton. Relancer sans effacer ne
+sert à rien — l'intégration reconnaît l'ancien code et vous le dit, plutôt que
+de gâcher le nouveau.
+
+Les codes expirent vite, et la connexion qui les porte se ferme d'elle-même au
+bout d'un moment. Si cela arrive, l'intégration vous le dit et affiche
+immédiatement un **nouveau code** sur votre téléviseur : lisez le message,
+effacez le champ, saisissez le nouveau code, et continuez. Inutile de repartir
+de l'étape 1.
+
+Une fois l'appairage terminé, relancez une recherche (ou acceptez la **mise à
+jour** que Gladys propose dans l'onglet Découverte) : l'intégration connaît
+maintenant les capacités réelles de votre Apple TV et ajoute le contrôle du
+volume et les raccourcis d'applications.
+
+### 3. L'utiliser
+
+L'appareil expose :
+
+- **Alimentation** — allumé/éteint. « Éteint » signifie veille, au sens d'Apple :
+  le boîtier reste sur le réseau, l'écran et la sortie HDMI s'éteignent.
+- **Télécommande** — croix directionnelle, OK, Retour, Accueil, Centre de
+  contrôle.
+- **Lecture** — lecture, pause, stop, précédent, suivant, retour et avance
+  rapide.
+- **Volume** — un curseur, ainsi que des boutons volume +/−. Le curseur
+  n'apparaît que si votre installation expose un niveau de volume lisible. Une
+  Apple TV qui pilote une barre de son en HDMI-CEC ne gère généralement que les
+  boutons +/−.
+- **Lecture en cours** et **Application** — capteurs texte indiquant ce qui est
+  à l'écran.
+- **Raccourcis d'applications** — un bouton par application installée, pour
+  qu'une scène ouvre Netflix ou Disney+ directement. Désactivables, ou limitables
+  en nombre, dans la configuration.
+
+### Sur un tableau de bord
+
+Deux boîtes, deux façons d'utiliser la même Apple TV :
+
+- **Appareils d'une pièce** — chaque touche de la télécommande est un vrai
+  bouton cliquable : croix directionnelle, OK, Retour, Accueil, Centre de
+  contrôle, lecture, pause, touches de transport, curseur de volume et
+  raccourcis d'applications. C'est la télécommande.
+- **Boîte Musique** — la barre de transport d'un lecteur multimédia. Ajoutez-y
+  l'Apple TV et pilotez-la comme un Sonos.
+
+La liste des fonctionnalités contient les deux jeux, d'où certaines touches en
+double : celles préfixées « Media » servent à la boîte Musique, les autres sont
+les boutons de la télécommande. Chaque boîte ne propose que ce qu'elle sait
+utiliser, vous n'avez donc jamais à choisir.
+
+## Configuration
+
+| Réglage                        | Effet                                                                                                                                |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Durée de la recherche          | Durée d'écoute des annonces AirPlay. À augmenter sur un réseau chargé ou lent.                                                       |
+| Adresses IPv4 manuelles        | Utile uniquement si les annonces n'arrivent pas jusqu'à Gladys (réseaux routés, VLAN). S'ajoutent à la découverte automatique.       |
+| Intervalle de rafraîchissement | Fréquence de réconciliation de ce que l'Apple TV ne pousse pas d'elle-même, généralement l'état d'alimentation sur certains modèles. |
+| Raccourcis d'applications      | Exposer ou non un bouton par application installée.                                                                                  |
+| Nombre maximum de raccourcis   | Une Apple TV peut compter une centaine d'applications ; cette limite garde l'appareil lisible.                                       |
+
+## Autres actions
+
+Chacune agit sur une Apple TV choisie dans une liste déroulante — la même que
+celle des boutons d'appairage, remplie avec les appareils ajoutés depuis
+l'onglet Découverte.
+
+- **Reconnecter et actualiser** — rouvre la session et relit l'appareil. La
+  première chose à essayer quand un état semble figé.
+- **Lister les applications installées** — affiche l'identifiant de chaque
+  application, celui qu'attend « Lancer une application ».
+- **Lancer une application** — ouvre une application par son identifiant, par
+  exemple `com.netflix.Netflix`.
+- **Lire une URL** — envoie une URL vidéo ou un lien profond à l'Apple TV via
+  AirPlay.
+- **Supprimer l'appairage** — oublie les identifiants enregistrés. À utiliser
+  lorsque l'appairage doit être refait, par exemple après une réinitialisation de
+  l'Apple TV.
+
+## Dépannage
+
+**La recherche ne trouve rien.** Gladys capte les annonces AirPlay depuis le
+réseau de l'hôte. Vérifiez que votre Apple TV est allumée, qu'AirPlay est activé
+(Réglages → AirPlay et HomeKit) et que Gladys est sur le même réseau. Si votre
+serveur Gladys est sur un autre sous-réseau, renseignez l'adresse IPv4 manuelle.
+
+Le journal de l'intégration nomme ce qu'il a vu : s'il signale des annonces
+« sans adresse IPv4 », votre Apple TV _a bien_ été annoncée mais son adresse
+n'est jamais arrivée jusqu'à Gladys — passez directement par l'adresse manuelle.
+
+**Vous faites tourner Gladys dans Docker sur un Mac ou sous Windows.** La
+découverte automatique ne peut pas fonctionner là, et ce n'est pas une erreur de
+configuration de votre part. Docker Desktop, OrbStack et Colima exécutent les
+conteneurs dans une machine virtuelle Linux : `network_mode: host` désigne donc
+le réseau _de la machine virtuelle_, pas votre wifi. Le multicast émis par votre
+Apple TV n'atteint jamais Gladys. L'unicast, lui, passe : renseignez l'adresse IP
+de votre Apple TV dans « Adresses IPv4 manuelles » et l'intégration la découvre,
+l'appaire et la pilote normalement. Un Gladys installé sur Linux (Raspberry Pi,
+NAS, serveur) est réellement sur le réseau et n'a pas besoin de cela.
+
+**Toutes les commandes échouent avec « pas encore appairée ».** L'appareil a été
+ajouté mais jamais appairé. Lancez les deux boutons d'appairage dans l'onglet
+Configuration.
+
+**La liste déroulante de l'appairage est vide.** Elle ne contient que les Apple
+TV déjà ajoutées à Gladys : l'étape 1 n'a donc pas été faite. Allez dans l'onglet
+Découverte, cliquez sur **Scanner**, puis sur **Ajouter à Gladys**.
+
+**L'appairage échoue ou le code est refusé.** Le code expire vite — relancez
+l'étape 1 et saisissez-le immédiatement. Si l'échec persiste, retirez Gladys de
+l'Apple TV (Réglages → Général → AirPlay et HomeKit → Autoriser l'accès), lancez
+« Supprimer l'appairage » dans Gladys, puis recommencez.
+
+**L'appareil est indiqué injoignable.** Vérifiez que l'Apple TV est allumée et
+qu'elle a toujours la même adresse IP. Une recherche met à jour l'adresse
+utilisée par l'intégration ; un bail statique sur votre routeur évite le problème.
+
+**Il n'y a pas de curseur de volume.** Votre installation n'expose pas de niveau
+de volume lisible — cas fréquent en HDMI-CEC. Utilisez les boutons volume +/−.
+
+**Réseaux séparés.** Les annonces mDNS ne traversent pas les sous-réseaux.
+Renseignez l'adresse IPv4 de chaque Apple TV dans « Adresses IPv4 manuelles » :
+l'intégration les interroge directement, ce qui fonctionne tant que le trafic est
+routé.
+
+## Confidentialité et stockage
+
+Les identifiants d'appairage sont stockés dans le volume dédié de l'intégration
+(`/data/pyatv.json`), jamais dans la configuration de Gladys, et ne quittent
+jamais votre réseau. Supprimer l'intégration les supprime avec elle.
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par Apple TV dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Configurer votre Apple TV, étape par étape | `section` | Non | Une Apple TV doit être ajoutée ET appairée avant que la moindre commande fonctionne. Trois étapes, dans cet ordre. 1) Onglet Découverte : cliquez sur « Scanner », patientez, puis sur « Ajouter à Gladys » sur votre Apple TV. Elle existe alors dans Gladys, mais n'obéit encore à rien. 2) De retour sur cette page, tout en bas : lancez « 1. Appairer une Apple TV » et choisissez-la dans la liste — aucune adresse IP à chercher. Un code s'affiche sur votre téléviseur ; saisissez-le dans « 2. Saisir le code ». Apple demande un code par protocole, un second code suit donc : effacez le champ et saisissez le nouveau à la place. 3) Onglet Découverte à nouveau : cliquez sur « Mettre à jour » sur votre Apple TV pour récupérer le volume et les raccourcis d'applications révélés par l'appairage. |
+| Trouver votre Apple TV | `section` | Non | Ces deux réglages ne concernent que le scan de l'onglet Découverte. Les valeurs par défaut conviennent à un réseau domestique classique : n'y touchez que si un scan ne trouve rien. |
+| Durée de la recherche (secondes) | `number` | Non | Durée d'écoute des annonces AirPlay. À augmenter sur un réseau chargé ou lent. |
+| Adresses IPv4 manuelles | `string` | Non | Facultatif, séparées par des virgules. Utile uniquement si Gladys et votre Apple TV sont sur des sous-réseaux ou VLAN différents, où les annonces mDNS ne circulent pas. Elles s'ajoutent à la découverte automatique : l'Apple TV apparaît alors dans l'onglet Découverte comme les autres. |
+| Ce que l'appareil expose | `section` | Non | Ces réglages façonnent l'appareil Gladys lui-même. Une modification prend effet au prochain « Mettre à jour » accepté dans l'onglet Découverte. |
+| Intervalle de rafraîchissement | `select` | Non | L'Apple TV pousse en temps réel ce qu'elle peut. Cet intervalle réconcilie ce qu'elle ne pousse pas, généralement l'état d'alimentation sur certains modèles. |
+| Raccourcis d'applications | `boolean` | Non | Ajoute un bouton par application installée sur l'appareil, pour ouvrir Netflix ou Disney+ directement depuis une scène. Lu sur l'Apple TV après l'appairage. |
+| Nombre maximum de raccourcis | `number` | Non | Une Apple TV peut compter une centaine d'applications. Cette limite garde l'appareil lisible. |
+| Appairage et outils, avec les boutons ci-dessous | `section` | Non | Tout ce qui suit agit sur une Apple TV déjà ajoutée depuis l'onglet Découverte : choisissez-la dans la liste, puis cliquez sur « Exécuter ». Les deux premiers boutons forment l'appairage et vont ensemble — commencez par « 1. Appairer une Apple TV ». Les autres sont des outils de dépannage dont vous n'aurez presque jamais besoin. |
+
+## Comment installer Apple TV dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : Apple TV apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/valentinhttr/gladys-apple-tv:1.0.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/valentinhttr/gladys-apple-tv](https://github.com/valentinhttr/gladys-apple-tv).
+
+Apple TV nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+Apple TV est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [valentinhttr](https://github.com/valentinhttr), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/valentinhttr/gladys-apple-tv) — [source de cette documentation](https://github.com/valentinhttr/gladys-apple-tv/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/charger-station.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/charger-station.mdx
@@ -1,0 +1,227 @@
+---
+title: "Intégration Charger Station pour Gladys Assistant"
+sidebar_label: "Charger Station"
+description: "Suivez vos bornes de recharge dans Gladys, en direct, grâce au protocole OCPP. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/sescandell--gladys-ocpp-integration.png"
+keywords:
+  - "charger station"
+  - "gladys charger station"
+  - "charger station gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/sescandell/gladys-ocpp-integration instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="charger-station" />
+
+**Supervision en lecture seule.** Cette intégration observe un
+nombre quelconque de bornes de recharge OCPP 1.6 et affiche leur état dans
+Gladys (statut du connecteur, état de charge, puissance, courant, tension,
+énergie totale) — il n'est pas encore possible de démarrer, arrêter ou
+limiter une charge depuis Gladys.
+
+## Fonctionnement
+
+```mermaid
+flowchart LR
+    Borne(["Borne de recharge"]) <-->|OCPP, WebSocket| Relais["Relais OCPP"]
+    Relais <-->|OCPP, relayé| Cloud[("Cloud du fabricant")]
+    Relais <-.->|état et configuration, HTTP| Gladys[("Gladys")]
+```
+
+L'intégration embarque son propre relais OCPP. Chaque borne se connecte à la
+**même** URL — le relais les distingue grâce à l'identity que chacune
+annonce à la connexion. Dès qu'une borne pointe vers cette URL (voir
+Installation ci-dessous), le relais la supervise **automatiquement**, sans
+qu'il soit besoin de la déclarer dans Gladys au préalable : il lui répond
+normalement, donc la charge elle-même continue de fonctionner. Mais tant que
+vous ne lui avez pas associé **son propre** cloud d'origine, ce dernier est
+totalement hors circuit — rien de ce qui passe par l'application du
+fabricant (pilotage à distance, statut en direct, historique) ne fonctionne
+pendant cette période, puisque son cloud n'a plus aucune connexion à la
+borne. Associer le cloud d'origine change cela : le relais se met alors
+aussi à relayer le trafic de la borne vers ce cloud, et l'application du
+fabricant refonctionne exactement comme avant. Le relais se contente
+d'_observer_ ce qui transite pour construire l'état affiché dans Gladys ; il
+n'invente ni ne retient jamais rien sur le fil, dans aucun des deux modes.
+
+## Prérequis
+
+**Gladys 4.85.0 ou ultérieur.** L'état des bornes est publié via les
+fonctionnalités « borne de recharge » de Gladys, que les versions
+antérieures ne connaissent pas (elles refuseraient de créer l'appareil).
+
+L'application ou le portail de chaque borne doit permettre de consulter et
+de modifier l'URL du serveur OCPP auquel elle se connecte. Tous les
+fabricants ne proposent pas cette option — si le vôtre ne le fait pas, cette
+intégration ne peut pas être utilisée pour cette borne.
+
+**Avant de changer quoi que ce soit, notez l'URL du serveur OCPP actuellement
+affichée par l'application du fabricant.** C'est le seul moyen de revenir au
+cloud d'origine pour cette borne si vous souhaitez un jour arrêter d'utiliser
+cette intégration.
+
+## Installation
+
+Cinq étapes, une fois par borne. Rien n'est perdu au passage : la borne
+conserve sa propre connexion au cloud du fabricant, Gladys se place
+simplement au milieu et observe.
+
+1. **Notez l'URL du serveur OCPP** actuellement utilisée par votre borne,
+   dans l'application du fabricant. C'est votre seul chemin de retour vers
+   le cloud du fabricant — gardez-la précieusement.
+2. **Pointez la borne vers Gladys** : dans cette même application, remplacez
+   l'URL par celle affichée dans le guide de l'écran **Configuration** de
+   l'intégration — elle est déjà complétée pour vous, adresse et port
+   inclus. La même URL fonctionne pour **toutes** les bornes.
+3. **Ajoutez-la à Gladys** : elle se connecte immédiatement et apparaît dans
+   l'onglet **Découverte**, déjà supervisée. Ajoutez-la depuis là.
+4. **Rendez-lui son cloud** : sur l'écran Configuration, lancez l'action
+   **"Ajouter une borne"**, choisissez-la dans la liste, et collez l'URL de
+   l'étape 1 — exactement telle que l'application l'affichait, y compris une
+   éventuelle chaîne de requête finale que certains fabricants utilisent
+   (ex. se terminant par `?sn=`).
+5. **C'est tout.** La borne se reconnecte toute seule en quelques secondes et
+   continue de dialoguer avec le cloud du fabricant exactement comme avant,
+   en passant par Gladys — qui la suit désormais en direct.
+
+Répétez pour chaque autre borne : même URL Gladys, sa propre URL fabricant,
+même d'un fabricant différent.
+
+Pour corriger une erreur ou changer l'URL du cloud d'origine d'une borne,
+relancez l'action pour cette même borne avec l'URL corrigée (vérifiez
+d'abord son URL actuelle sur sa fiche appareil). Pour détacher une borne de
+son cloud et la remettre en supervision locale uniquement, relancez
+l'action pour elle avec une URL **vide** — prend effet à la prochaine
+reconnexion de cette borne (elle continue d'être relayée via sa connexion
+en cours jusque-là).
+
+Si vous **supprimez** de Gladys l'appareil d'une borne encore associée à un
+cloud d'origine, elle disparaît de la liste déroulante et l'action ne peut
+plus la modifier — le relais continue d'utiliser ce cloud. Ré-ajoutez
+l'appareil depuis Découverte pour reprendre la main.
+
+## Repartir de zéro
+
+Désinstaller l'intégration supprime tout ce qu'elle a créé : ses appareils,
+sa configuration stockée, ainsi que le conteneur et les données du relais.
+Rien n'est laissé derrière, une réinstallation repart donc vraiment de zéro.
+
+Pour revenir directement au cloud de votre fabricant, remettez l'URL notée à
+l'étape 1 dans l'application de la borne — elle cesse de passer par Gladys à
+sa prochaine reconnexion.
+
+## Ce que vous voyez sur une borne
+
+Chaque connecteur remonte deux fonctionnalités d'état, en plus de ses
+mesures (puissance, courant, tension, énergie totale) :
+
+- **Statut** — ce que fait le connecteur lui-même : _Disponible_, _Occupé_,
+  _Réservé_, _Indisponible_, _En défaut_.
+- **État de charge** — ce que fait la session : _En charge_, _Véhicule
+  connecté_, _En pause (véhicule)_, _En pause (borne)_, _Inactif_.
+
+Les bornes OCPP 1.6 rapportent un statut unique, plus détaillé, qui est
+réparti entre ces deux fonctionnalités : `Preparing` et `Finishing`
+deviennent tous les deux « Occupé / Véhicule connecté » (un véhicule est
+physiquement branché dans les deux cas), `Charging` devient « Occupé / En
+charge », et `SuspendedEV`/`SuspendedEVSE` deviennent « Occupé / En pause
+(véhicule) »/« Occupé / En pause (borne) ». Quand aucune session n'est en
+cours, l'état de charge affiche _Inactif_. Les deux fonctionnalités restent
+vides tant que la borne n'a pas rapporté son statut au moins une fois.
+
+Les valeurs se mettent à jour **au fil de l'eau**, en quelques secondes : le
+relais signale à l'intégration chaque changement qu'il observe, au lieu d'être
+interrogé à intervalles réguliers. Une borne qui se connecte pour la première
+fois apparaît elle aussi toute seule dans Découverte, sans attendre un
+rafraîchissement.
+
+## Connecteurs multiples
+
+Une borne est un seul appareil dans Gladys, quel que soit son nombre de
+connecteurs physiques. Elle démarre avec les fonctionnalités d'un seul
+connecteur (statut, état de charge, puissance, courant, tension,
+énergie) ; si elle possède plusieurs connecteurs physiques, les
+supplémentaires apparaissent comme fonctionnalités additionnelles
+("Connecteur 2 - ...", etc.) une fois que le relais les a réellement vus
+rapporter leur statut au moins une fois. Si vous avez déjà créé l'appareil,
+Gladys affiche un bouton **Mettre à jour** dès que de nouveaux connecteurs
+sont détectés — rien n'est ajouté silencieusement à un appareil déjà créé.
+Si un connecteur n'apparaît pas encore, essayez **Relancer un scan** depuis
+l'onglet Découverte après avoir utilisé ce connecteur.
+
+## Note de sécurité
+
+Exposer le port OCPP du relais le rend joignable par tout appareil de votre
+réseau local, sans authentification — c'est inhérent à la façon dont les
+bornes OCPP se connectent à un serveur. Le relais se contente d'_observer_ ce
+qui transite et ne prend jamais de décision de lui-même (il n'invente jamais
+de transaction, n'autorise jamais une charge) : au pire, un appareil
+malveillant de votre réseau local pourrait injecter des données trompeuses
+dans la vue de cette intégration, mais il ne peut pas affecter une borne
+réelle, qui garde sa propre connexion indépendante au cloud de son fabricant
+via le relais. Gardez cela à l'esprit sur un réseau partagé ou non fiable.
+
+## Limitations connues (cette version)
+
+- **L'état du relais est réinitialisé à chaque redémarrage** (redémarrage de
+  l'hôte, plantage) : il ne se souvient que de ce qu'il a vu depuis son
+  dernier démarrage, y compris quelles bornes sont configurées — l'intégration
+  renvoie l'ensemble complet des bornes configurées dès qu'elle se reconnecte
+  à Gladys, donc ça se répare tout seul en quelques secondes, sans avoir à
+  relancer l'action. Juste après un redémarrage, des bornes déjà connues
+  disparaissent brièvement jusqu'à leur reconnexion (généralement quelques
+  secondes) ; cela ne supprime jamais un appareil déjà créé dans Gladys.
+- **Démarrer une charge pendant qu'une borne est encore supervisée
+  localement (pas de cloud d'origine associé), puis associer un cloud en
+  cours de session :** la borne peut continuer de référencer la session
+  démarrée localement une fois reconnectée en mode relais, que le vrai cloud
+  d'origine n'a jamais vue. Un chevauchement rare en pratique (associer un
+  cloud se fait généralement une seule fois, juste après la première
+  connexion) — si cela arrive, les données de cette session peuvent ne pas
+  remonter correctement au cloud d'origine ; la session suivante n'est pas
+  affectée.
+- **Aucun pilotage depuis Gladys.** Démarrer, arrêter ou limiter une charge
+  n'est pas possible dans cette version.
+
+## Dépannage
+
+Consultez les logs de l'intégration depuis l'interface Gladys (bloc de
+supervision → sélecteur de conteneur), pour le conteneur principal et,
+séparément, pour le sous-conteneur `gateway` — c'est là que le relais OCPP
+lui-même journalise chaque connexion, déconnexion et message relayé (payload
+complet, dans les deux sens) pour chaque borne.
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par Charger Station dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Raccorder une borne | `section` | Non | Dans l'application de votre borne, notez son URL OCPP actuelle et conservez toutes les informations de configuration qui s'y trouvent : c'est ce qui vous permettra de revenir à un fonctionnement normal en cas de problème. Remplacez cette URL par ws://\{\{gladys_host\}\}:\{\{port:ocpp\}\}/ - la même pour toutes vos bornes. Votre borne s'y reconnecte aussitôt et apparaît dans l'onglet Découverte : ajoutez-la à Gladys. Revenez ensuite ici, dans la zone Action ci-dessous, sélectionnez votre borne et saisissez l'URL OCPP notée à la première étape - c'est elle qui permet à votre borne de continuer à dialoguer avec le cloud de son fabricant, désormais relayé par Gladys. |
+
+## Comment installer Charger Station dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : Charger Station apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/sescandell/gladys-ocpp-integration:1.0.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/sescandell/gladys-ocpp-integration](https://github.com/sescandell/gladys-ocpp-integration).
+
+Charger Station nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+Charger Station est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [sescandell](https://github.com/sescandell), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/sescandell/gladys-ocpp-integration) — [source de cette documentation](https://github.com/sescandell/gladys-ocpp-integration/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/daikin-cloud.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/daikin-cloud.mdx
@@ -31,23 +31,25 @@ télécommande de plus.
 Pour chaque climatiseur de votre compte Daikin, Gladys crée un appareil avec les
 fonctionnalités que votre modèle prend réellement en charge :
 
-| Fonctionnalité          | Rôle                                                                            |
-| ----------------------- | ------------------------------------------------------------------------------- |
-| Marche/Arrêt            | Allumer et éteindre l'unité                                                     |
-| Mode                    | Auto, Froid, Chaud, Déshumidification, Ventilation seule                        |
-| Température de consigne | La consigne du mode actuellement actif                                          |
-| Vitesse (niveau)        | La vitesse de ventilation, sur l'échelle déclarée par votre unité (souvent 1-5) |
-| Balayage horizontal     | Le sens du flux d'air gauche/droite                                             |
-| Balayage vertical       | Le sens du flux d'air haut/bas                                                  |
-| Mode puissant           | Le mode « Puissant » de Daikin (interrupteur)                                   |
-| Mode Econo              | Le mode « Econo » de Daikin (interrupteur)                                      |
-| Mode Streamer           | Le mode « Streamer » de purification d'air (interrupteur)                       |
-| Garder au sec           | La fonction avancée « Garder au sec » de l'unité intérieure                     |
-| Température intérieure  | La température mesurée par l'unité (capteur, historisé)                         |
-| Température extérieure  | La température mesurée par le groupe extérieur (capteur, historisé)             |
-| Énergie aujourd'hui     | Consommation électrique du jour, en kWh (capteur, historisé)                    |
-| Énergie ce mois-ci      | Consommation électrique du mois en cours, en kWh                                |
-| Énergie cette année     | Consommation électrique de l'année en cours, en kWh                             |
+| Fonctionnalité                     | Rôle                                                                            |
+| ---------------------------------- | ------------------------------------------------------------------------------- |
+| Marche/Arrêt                       | Allumer et éteindre l'unité                                                     |
+| Mode                               | Auto, Froid, Chaud, Déshumidification, Ventilation seule                        |
+| Température de consigne            | La consigne du mode actuellement actif                                          |
+| Vitesse (niveau)                   | La vitesse de ventilation, sur l'échelle déclarée par votre unité (souvent 1-5) |
+| Balayage horizontal                | Le sens du flux d'air gauche/droite                                             |
+| Balayage vertical                  | Le sens du flux d'air haut/bas                                                  |
+| Mode puissant                      | Le mode « Puissant » de Daikin (interrupteur)                                   |
+| Mode Econo                         | Le mode « Econo » de Daikin (interrupteur)                                      |
+| Mode Streamer                      | Le mode « Streamer » de purification d'air (interrupteur)                       |
+| Garder au sec                      | La fonction avancée « Garder au sec » de l'unité intérieure                     |
+| Température intérieure             | La température mesurée par l'unité (capteur, historisé)                         |
+| Température extérieure             | La température mesurée par le groupe extérieur (capteur, historisé)             |
+| Énergie aujourd'hui                | Consommation électrique du jour, en kWh (capteur, historisé)                    |
+| Énergie ce mois-ci                 | Consommation électrique du mois en cours, en kWh                                |
+| Énergie cette année                | Consommation électrique de l'année en cours, en kWh                             |
+| Énergie aujourd'hui (consommation) | Ce que l'unité a consommé sur les 30 dernières minutes, rempli par Gladys       |
+| Énergie aujourd'hui (coût)         | Ce que ces 30 minutes ont coûté, selon votre contrat d'énergie                  |
 
 Un modèle sans volets n'obtient pas de sens du flux d'air, un modèle sans
 ventilateur n'obtient pas de vitesse, un modèle sans fonction Streamer n'obtient
@@ -82,6 +84,25 @@ qui attend un index. Daikin ventile ces compteurs par mode (chaud, froid…) :
 l'intégration les additionne, parce que ce qui intéresse un tableau de bord
 c'est ce que l'unité a consommé, pas comment ça se répartit.
 
+Leur finesse est celle de Daikin, pas celle de l'intervalle de rafraîchissement :
+Daikin ventile la journée en tranches de deux heures, et le compteur du jour —
+leur total — avance **par pas de 0,1 kWh**, dès que ce dixième de kWh de plus a
+été consommé. « Énergie aujourd'hui » reste donc plate un moment, puis fait un
+bond : rafraîchir plus souvent ne lisse rien, ça ne fait que consommer votre
+quota d'appels plus vite. Ce compteur du jour est le plus fin que l'API
+fournit, et c'est ce qui en fait le bon candidat pour alimenter le suivi de
+l'énergie de Gladys : sa remise à zéro de minuit ne coûte quasiment rien (la
+première valeur après minuit vaut 0, et Gladys ignore le pas négatif d'un
+compteur qui repart à zéro).
+
+En fonctionnement, un climatiseur franchit ces 0,1 kWh toutes les quelques
+dizaines de minutes : chaque fenêtre de 30 minutes reçoit alors sa valeur, et la
+vue **Jour** du suivi de l'énergie ressemble à une vraie courbe de consommation,
+qui recoupe l'application Onecta. Le pas ne se voit qu'à très faible puissance :
+quelques fenêtres restent à zéro, puis une autre rattrape le tout. C'est un
+décalage de quelques dizaines de minutes au pire, et les totaux du jour, du mois
+et de l'année restent justes.
+
 Certaines fonctions sont signalées en lecture seule par Daikin selon le modèle
 et le firmware — c'est presque toujours le cas de « Garder au sec ». Elles sont
 alors publiées comme capteurs, sans interrupteur qui serait de toute façon
@@ -97,6 +118,82 @@ Les pompes à chaleur (Altherma…) sont partiellement prises en charge : leur
 marche/arrêt, leur mode et leur température extérieure fonctionnent, mais leur
 consigne de température d'eau n'est pas exposée — cette intégration vise les
 climatiseurs.
+
+## Suivi de l'énergie
+
+Votre climatiseur peut prendre sa place dans le
+[suivi de l'énergie](https://gladysassistant.com/fr/docs/integrations/energy-monitoring/)
+de Gladys, aux côtés de votre compteur électrique et de vos prises connectées :
+le tableau de bord Énergie montre alors, par tranches de trente minutes, ce que
+le climatiseur a consommé et ce que ça vous a coûté.
+
+### Ce que l'intégration branche toute seule
+
+L'intégration publie les deux fonctionnalités qui rendent ce calcul possible —
+**Énergie aujourd'hui (consommation)** et **Énergie aujourd'hui (coût)** — et
+les enchaîne elle-même : le coût pointe sur la consommation, qui pointe sur
+« Énergie aujourd'hui ». C'est Gladys qui les remplit, toutes les trente
+minutes, à partir de l'écart entre deux lectures du compteur du jour et du prix
+du kWh de votre contrat : rien n'est écrit ici, et il n'y a rien à régler sur
+ces deux lignes. Si vous leur choisissez un autre parent dans l'écran Énergie,
+l'intégration remettra le sien à la publication suivante.
+
+### La seule étape à votre charge
+
+Dans **Réglages → Énergie**, choisissez le parent d'**Énergie aujourd'hui** : la
+fonctionnalité de votre compteur principal (la consommation quotidienne remontée
+par Enedis, une pince sur l'arrivée générale…). C'est ce qui indique à Gladys que
+le climatiseur est une _part_ de ce que le compteur mesure déjà, et non une
+consommation qui s'ajouterait par-dessus.
+
+L'écran ressemble alors à ceci :
+
+```
+Enedis — Consommation quotidienne                          niveau 0
+└── Climatiseur — Énergie aujourd'hui                      niveau 1   ← la seule ligne à régler
+    └── Climatiseur — Énergie aujourd'hui (consommation)   niveau 2   ← posé par l'intégration
+        └── Climatiseur — Énergie aujourd'hui (coût)       niveau 3   ← posé par l'intégration
+
+Climatiseur — Énergie ce mois-ci                           niveau 0   ← normal, rien à faire
+Climatiseur — Énergie cette année                          niveau 0   ← normal, rien à faire
+```
+
+Le niveau affiché devant chaque ligne n'est rien d'autre que sa profondeur dans
+cet arbre : niveau 0 = racine, c'est-à-dire une fonctionnalité qui n'est la part
+de rien d'autre. Votre compteur principal y est parce que rien ne le contient ;
+le climatiseur est en dessous parce que ses kWh font partie de ceux du compteur.
+
+Ce choix est le vôtre et il le reste : l'intégration n'envoie jamais le parent
+d'« Énergie aujourd'hui », pas même à vide, précisément pour ne pas défaire votre
+réglage à chaque publication.
+
+### Pourquoi « Énergie ce mois-ci » et « Énergie cette année » restent au niveau 0
+
+C'est voulu : ces deux lignes n'ont pas de parent, et il n'y a rien à corriger.
+
+- **Ce sont les mêmes kWh.** L'arbre est une décomposition, pas une liste :
+  chaque enfant déclare « ma consommation fait partie de celle de mon parent ».
+  Les compteurs du mois et de l'année mesurent exactement la même électricité que
+  celui du jour, sur une fenêtre plus large. Les accrocher au compteur principal
+  ferait apparaître les mêmes kWh deux fois de plus dans la répartition.
+- **Elles n'alimenteraient rien de plus.** Seul le compteur du jour porte le
+  couple 30 minutes, parce que c'est le plus fin que l'API Daikin fournit. Un
+  couple accroché au compteur mensuel ferait doublon, et le compteur annuel ne
+  bougeant qu'une fois par jour, il ne délivrerait qu'un bloc quotidien : le
+  tableau de bord n'y gagnerait rien.
+- **Elles ne sont pas non plus des enfants d'« Énergie aujourd'hui ».** Un parent
+  est un tout, un enfant en est une part : le mois n'est pas une part de la
+  journée.
+- **Elles restent utiles ailleurs** : tuile de tableau de bord, graphique
+  d'historique, condition de scénario. Elles sont là pour être lues, elles
+  n'entrent pas dans le calcul du suivi de l'énergie.
+
+Autrement dit, un suivi correctement configuré laisse bien deux fonctionnalités
+du climatiseur au niveau 0, à côté du compteur principal.
+
+> **Le suivi de l'énergie nécessite Gladys 4.66 ou plus récent.** Sur une version
+> antérieure, les deux fonctionnalités ne sont simplement pas publiées et le
+> reste de l'intégration n'est pas affecté.
 
 ## Avant de commencer : créez votre application Daikin
 
@@ -241,6 +338,14 @@ dépend du modèle et du firmware, donc vérifiez plutôt que de supposer : lanc
 publiées ni dans les caractéristiques ignorées est un nom que l'API n'expose pas
 pour votre unité.
 
+**Les lignes « Énergie aujourd'hui (consommation) » et « (coût) » n'apparaissent
+pas dans Réglages → Énergie.**
+Elles nécessitent Gladys 4.66 ou plus récent. Si votre version convient, c'est
+que l'appareil a été créé avant leur ajout : lancez _Tester la connexion_, qui
+republie la découverte et complète les appareils déjà existants. Elles arrivent
+déjà rattachées l'une à l'autre ; il ne vous reste qu'à donner un parent à
+« Énergie aujourd'hui ».
+
 **Rien n'apparaît dans l'onglet Découverte.**
 Vérifiez que les unités sont bien visibles dans l'application Onecta avec le même
 compte, puis lancez _Tester la connexion_ : le message indique combien d'unités
@@ -266,7 +371,7 @@ Voici les paramètres demandés par Daikin Cloud dans son écran de configuratio
 ## Comment installer Daikin Cloud dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Daikin Cloud apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-daikin-cloud:1.0.7`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-daikin-cloud:1.0.10`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/prohand/gladys-daikin-cloud](https://github.com/prohand/gladys-daikin-cloud).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/gardena-smart-system.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/gardena-smart-system.mdx
@@ -1,0 +1,227 @@
+---
+title: "Intégration GARDENA smart system pour Gladys Assistant"
+sidebar_label: "GARDENA smart system"
+description: "Pilotez vos tondeuses, vannes, prises et capteurs GARDENA depuis Gladys. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/Nagromdark--gladys-gardena.png"
+keywords:
+  - "gardena smart system"
+  - "gladys gardena smart system"
+  - "gardena smart system gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/Nagromdark/gladys-gardena instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="gardena-smart-system" />
+
+Pilotez votre jardin GARDENA depuis Gladys : tondeuses robots, vannes
+d'arrosage, prises d'extérieur et capteurs de sol. L'intégration utilise l'**API
+publique officielle GARDENA smart system**, celle qu'utilise l'application
+GARDENA elle-même : tout reste synchronisé dans les deux sens.
+
+## Ce dont vous avez besoin
+
+- une **passerelle GARDENA smart gateway** déjà installée, avec vos appareils
+  appairés et fonctionnels dans l'application GARDENA ;
+- un compte gratuit sur le **portail développeur Husqvarna** (GARDENA appartient
+  au groupe Husqvarna) — l'API est gratuite pour un usage personnel.
+
+L'intégration ne parle jamais directement à vos appareils : les appareils
+GARDENA utilisent une radio propriétaire vers la passerelle, et la passerelle ne
+parle qu'au cloud GARDENA. Une connexion Internet est donc nécessaire.
+
+## Étape 1 — Créer votre application d'API
+
+1. Rendez-vous sur [https://developer.husqvarnagroup.cloud/](https://developer.husqvarnagroup.cloud/) et cliquez sur
+   **Sign in**.
+2. Connectez-vous avec **votre compte GARDENA habituel** (celui de
+   l'application GARDENA). Aucun compte séparé n'est à créer.
+3. Ouvrez **My applications** puis cliquez sur **New application**. Donnez-lui
+   le nom que vous voulez, par exemple `Gladys`. L'URL de redirection n'est pas
+   utilisée par cette intégration : laissez-la vide ou mettez
+   `http://localhost`.
+4. Sur la page de l'application, cliquez sur **Connect new API** et connectez
+   l'**API GARDENA smart system**. Cette étape est facile à oublier, et sans
+   elle l'API répond `403 Forbidden` à toutes les requêtes.
+5. Copiez la **Application key** (clé) et l'**Application secret** (secret)
+   affichés sur cette page.
+
+> Laissez également l'API d'authentification connectée — elle est ajoutée
+> automatiquement dans la plupart des cas, et c'est elle qui délivre le jeton.
+
+## Étape 2 — Configurer l'intégration dans Gladys
+
+1. Collez la **clé d'application** et le **secret d'application** dans l'écran
+   de configuration, puis enregistrez.
+2. Cliquez sur **Tester la connexion** : l'intégration s'authentifie et liste
+   les emplacements (jardins) de votre compte.
+3. Allez dans l'onglet **Découvrir** : tous les appareils GARDENA de votre
+   compte apparaissent. Créez ceux que vous souhaitez utiliser dans Gladys.
+
+Réglages optionnels :
+
+| Réglage                        | Rôle                                                                                                                                                                                                                                     |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Identifiant d'emplacement**  | Limiter l'intégration à un seul jardin. Laissez vide pour tous les utiliser.                                                                                                                                                             |
+| **Relecture de l'API GARDENA** | Délai minimum entre deux relectures complètes de l'API GARDENA, le filet de sécurité derrière le flux temps réel. C'est ce réglage qui consomme votre quota hebdomadaire de requêtes — voir le tableau plus bas. Par défaut : une heure. |
+| **Durée par défaut**           | Durée d'arrosage d'une vanne, ou d'allumage d'une prise, quand vous l'activez depuis Gladys.                                                                                                                                             |
+| **Allumage des prises**        | Éteindre automatiquement après la durée par défaut, ou rester allumée jusqu'à extinction.                                                                                                                                                |
+| **Démarrage de la tondeuse**   | Démarrer la tondeuse peut suivre son propre calendrier, ou le forcer pendant une durée fixe.                                                                                                                                             |
+| **Arrêt de la tondeuse**       | Arrêter la tondeuse peut la garer jusqu'à sa prochaine tâche planifiée, ou annuler le calendrier jusqu'à nouvel ordre.                                                                                                                   |
+
+## Ce que vous obtenez dans Gladys
+
+| Appareil GARDENA                 | Fonctionnalités créées                                                                             |
+| -------------------------------- | -------------------------------------------------------------------------------------------------- |
+| smart Mower (SILENO...)          | Tonte (marche/arrêt), activité, état, dernière erreur, heures de fonctionnement, batterie, signal  |
+| smart Water Control              | Arrosage (marche/arrêt), activité, temps d'arrosage restant, batterie, signal                      |
+| smart Irrigation Control         | Un interrupteur d'arrosage, une activité et un temps restant **par voie**, nommés comme dans l'app |
+| smart Power (prise d'extérieur)  | Marche/Arrêt, activité, temps restant, signal                                                      |
+| smart Sensor / smart Soil Sensor | Humidité du sol, température du sol, température ambiante, luminosité, batterie, signal            |
+
+Activer une vanne lance un **arrosage manuel de la durée configurée** : l'API
+GARDENA ne propose pas de commande « ouvrir indéfiniment » sur une vanne, ce qui
+est exactement ce que l'on veut d'un système domotique branché sur un robinet.
+
+L'état marche/arrêt d'une tondeuse, d'une vanne ou d'une prise reflète toujours
+ce que GARDENA rapporte, et non ce que Gladys a demandé : une tondeuse rentrée à
+cause de la pluie, ou une vanne ouverte depuis l'application GARDENA, s'affiche
+correctement dans Gladys.
+
+## Temps réel
+
+L'intégration maintient un websocket ouvert vers GARDENA pour chaque
+emplacement, la méthode supportée pour suivre un jardin : un changement fait sur
+l'appareil, dans l'application GARDENA ou par une programmation arrive dans
+Gladys en une à deux secondes. Le rafraîchissement périodique n'est qu'un filet
+de sécurité en cas de message manqué.
+
+GARDENA ferme ce websocket toutes les deux heures environ, volontairement :
+l'intégration se reconnecte seule et se resynchronise à chaque fois.
+
+Gladys interroge ses appareils toutes les minutes (son intervalle le plus court
+disponible), mais cette interrogation **n'appelle pas** GARDENA : l'intégration
+répond depuis l'image qu'elle a déjà en mémoire, et ne relit l'API GARDENA que
+lorsque cette image dépasse l'âge du réglage **Relecture de l'API GARDENA**.
+Quel que soit le nombre d'appareils du jardin, une relecture coûte un appel.
+
+## Rester dans le quota de requêtes GARDENA
+
+GARDENA accorde un **nombre limité de requêtes API par semaine** à une
+application personnelle gratuite. L'intégration est construite autour de cette
+contrainte : le websocket temps réel ne coûte rien par événement, si bien que
+les requêtes consommées sont presque uniquement celles de la relecture
+périodique de sécurité.
+
+Ce que coûte une semaine, quel que soit le nombre d'appareils du jardin (une
+relecture lit tout l'emplacement en un seul appel) :
+
+| Relecture de l'API GARDENA | Relectures | URL websocket | Jetons | **Total / semaine** |
+| -------------------------- | ---------- | ------------- | ------ | ------------------- |
+| 15 minutes                 | 672        | 84            | 7      | **763**             |
+| 30 minutes                 | 336        | 84            | 7      | **427**             |
+| **1 heure (par défaut)**   | **168**    | **84**        | **7**  | **259**             |
+| 2 heures                   | 84         | 84            | 7      | **175**             |
+| 6 heures                   | 28         | 84            | 7      | **119**             |
+
+Les deux coûts fixes sont incompressibles : GARDENA ferme le flux temps réel
+toutes les deux heures environ et il faut redemander une URL (~84 par semaine),
+et le jeton d'accès est renouvelé chaque jour (7 par semaine, sur l'API
+d'authentification, distincte).
+
+Les commandes ajoutent une requête chacune — ouvrir une vanne, allumer une
+prise, démarrer la tondeuse. Cent commandes par semaine, cent requêtes : avec la
+relecture par défaut, la marge reste large.
+
+Deux réflexes suffisent :
+
+- **ne descendez pas la relecture sous une heure** sans savoir que votre quota
+  le permet. Le flux temps réel apporte déjà tous les changements en quelques
+  secondes ; la relecture ne rattrape que ce qu'un websocket coupé aurait pu
+  manquer ;
+- **évitez de redémarrer l'intégration en boucle** : chaque démarrage coûte un
+  listing des emplacements plus une relecture complète.
+
+Si GARDENA répond malgré tout « trop de requêtes », l'intégration **suspend
+d'elle-même ses relectures REST pendant une heure** et continue de fonctionner
+sur le flux temps réel, au lieu d'insister et d'aggraver la situation.
+
+## Actions
+
+- **Tester la connexion** — s'authentifie et liste les emplacements du compte.
+  À utiliser en premier lorsque quelque chose ne va pas.
+- **Rafraîchir les appareils** — relit le compte, par exemple après avoir ajouté
+  un appareil dans l'application GARDENA.
+- **Arrêter tout l'arrosage** — ferme toutes les vannes de l'appareil choisi
+  jusqu'à sa prochaine tâche planifiée. Pratique dans une scène, ou avant
+  d'aller marcher dans le jardin.
+
+## En cas de problème
+
+**« GARDENA a refusé les identifiants »** — la clé ou le secret est incorrect,
+ou bien l'**API GARDENA smart system n'est pas connectée à votre application**
+sur le portail développeur (étape 1.4). C'est de loin la cause la plus
+fréquente.
+
+**Un appareil affiche un badge orange « injoignable »** — la passerelle GARDENA
+ne le voit plus (liaison radio hors ligne) : l'appareil est hors de portée,
+éteint, ou ses piles sont vides. Gladys conserve les dernières valeurs connues
+au lieu de faire croire qu'elles sont à jour.
+
+**« GARDENA limite le débit de l'intégration »** — l'API applique sa limitation.
+L'intégration espace ses appels et réessaie, mais si vous avez beaucoup augmenté
+la fréquence de rafraîchissement, remettez une valeur plus élevée : le flux
+temps réel vous donne déjà les changements.
+
+**Aucun appareil dans l'onglet Découvrir** — vérifiez que vos appareils
+apparaissent bien dans l'application GARDENA, et que le filtre d'emplacement (si
+vous en avez mis un) correspond au bon jardin.
+
+---
+
+_GARDENA est une marque déposée du groupe Husqvarna. Cette intégration
+communautaire est indépendante : elle n'est ni affiliée à GARDENA ou au groupe
+Husqvarna, ni approuvée ou supportée par eux._
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par GARDENA smart system dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Connectez votre compte GARDENA | `section` | Non | Cette intégration utilise l'API publique officielle GARDENA smart system. Créez un compte gratuit sur le portail développeur Husqvarna, connectez-vous avec votre compte GARDENA (Husqvarna), créez une application, connectez-lui l'API « GARDENA smart system API », puis copiez sa clé et son secret d'application ci-dessous. |
+| Clé d'application | `string` | Oui | La clé d'application de votre application sur le portail développeur Husqvarna. |
+| Secret d'application | `secret` | Oui | Le secret d'application de cette même application. Il est stocké chiffré et n'est jamais renvoyé au navigateur. |
+| Identifiant d'emplacement (optionnel) | `string` | Non | Limiter l'intégration à un seul emplacement GARDENA (jardin). Laissez vide pour utiliser tous les emplacements du compte. |
+| Relecture de l'API GARDENA (s) | `number` | Non | Délai minimum entre deux relectures complètes de l'API GARDENA, le filet de sécurité derrière le flux temps réel. GARDENA compte un quota hebdomadaire de requêtes et c'est ce réglage qui le consomme : une heure coûte environ 170 appels par semaine, quinze minutes en coûteraient environ 670. Les changements arrivent déjà en temps réel, gardez une valeur élevée. |
+| Durée par défaut (min) | `number` | Non | Durée d'arrosage d'une vanne, ou d'allumage d'une prise, lorsque vous l'activez depuis Gladys. |
+| Allumage des prises | `select` | Non | Ce qui se passe lorsqu'une prise GARDENA est allumée depuis Gladys. |
+| Démarrage de la tondeuse | `select` | Non | Ce que signifie démarrer la tondeuse depuis Gladys : la laisser suivre son calendrier, ou le forcer pendant une durée fixe. |
+| Durée de tonte (min) | `number` | Non | Utilisée lorsque le mode de démarrage force le calendrier. |
+| Arrêt de la tondeuse | `select` | Non | Ce que signifie arrêter la tondeuse depuis Gladys : la garer jusqu'à la prochaine tâche planifiée, ou annuler le calendrier. |
+
+## Comment installer GARDENA smart system dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : GARDENA smart system apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/nagromdark/gladys-gardena:1.0.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/Nagromdark/gladys-gardena](https://github.com/Nagromdark/gladys-gardena).
+
+GARDENA smart system nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+GARDENA smart system est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [Nagromdark](https://github.com/Nagromdark), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/Nagromdark/gladys-gardena) — [source de cette documentation](https://github.com/Nagromdark/gladys-gardena/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/grdf-gazpar.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/grdf-gazpar.mdx
@@ -1,0 +1,172 @@
+---
+title: "Intégration GRDF Gazpar pour Gladys Assistant"
+sidebar_label: "GRDF Gazpar"
+description: "Lit la consommation de gaz quotidienne de votre compteur Gazpar depuis votre compte GRDF. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-grdf.png"
+keywords:
+  - "grdf gazpar"
+  - "gladys grdf gazpar"
+  - "grdf gazpar gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/PhilippeMA/gladys-grdf instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="grdf-gazpar" />
+
+Cette intégration lit la consommation de gaz mesurée par votre compteur
+**Gazpar** et la transforme en appareils Gladys : votre gaz apparaît alors à côté
+du reste des données de votre maison — courbes quotidiennes, scènes et écran
+énergie.
+
+GRDF ne propose pas d'API publique pour les particuliers. L'intégration se
+connecte donc à votre compte client comme le ferait un navigateur, sur
+[monespace.grdf.fr](https://monespace.grdf.fr), et lit exactement les relevés
+quotidiens que le site vous affiche.
+
+## Ce qu'il vous faut
+
+- un compte client GRDF (celui de monespace.grdf.fr), avec votre compteur déjà
+  rattaché ;
+- un compteur communicant **Gazpar** : les relevés quotidiens n'existent que
+  pour ceux-là. Avec un ancien compteur relevé deux fois par an par un
+  technicien, GRDF ne publie qu'un relevé global par période, et c'est tout ce
+  que l'intégration pourra afficher ;
+- un compte qui ne demande **pas** d'étape de vérification supplémentaire à la
+  connexion (code à usage unique par SMS ou e-mail, captcha) : l'intégration ne
+  sait répondre qu'à l'étape du mot de passe.
+
+## Configuration
+
+1. Ouvrez l'onglet **Configuration** de l'intégration.
+2. Saisissez l'**e-mail** et le **mot de passe** de votre compte GRDF. Le mot de
+   passe est stocké chiffré par Gladys et n'est transmis qu'à GRDF.
+3. Laissez **PCE à suivre** vide pour suivre tous les compteurs du compte. Si
+   votre compte comporte plusieurs points de comptage et que vous n'en voulez
+   qu'une partie, listez leurs numéros de PCE à 14 chiffres, séparés par des
+   virgules. Un PCE figure sur votre facture de gaz et dans Mon Espace GRDF.
+4. Choisissez l'**historique à importer** : le nombre de jours passés récupérés
+   lors de la première synchronisation. GRDF conserve environ trois ans, vous
+   pouvez donc importer plusieurs mois d'un coup pour obtenir des courbes qui
+   ont déjà un passé. Cela ne concerne que la première synchronisation ; ensuite,
+   l'intégration ne récupère que les nouveautés. Importer un long historique
+   prend quelques minutes : Gladys n'accepte qu'un nombre limité de mesures par
+   minute, l'intégration les injecte donc en douceur — comptez environ une
+   minute par deux mois importés.
+5. Cliquez sur **Tester la connexion GRDF** : elle se connecte et liste les
+   points de comptage trouvés. C'est le moyen le plus rapide de vérifier vos
+   identifiants.
+6. Enregistrez, puis ouvrez l'onglet **Découverte** et **ajoutez votre compteur
+   à votre maison**. C'est cette étape qui déclenche la collecte : tant qu'un
+   compteur n'est pas ajouté, ce n'est qu'une proposition, et Gladys n'a nulle
+   part où ranger ses mesures. L'historique est importé dès que vous l'ajoutez.
+
+## Les appareils obtenus
+
+Un appareil par point de comptage, nommé d'après l'alias que vous lui avez donné
+dans Mon Espace, portant quatre capteurs en lecture seule :
+
+| Capteur                        | Unité | Ce que c'est                                             |
+| ------------------------------ | ----- | -------------------------------------------------------- |
+| Consommation quotidienne       | kWh   | Énergie consommée pendant la journée gazière (facturée)  |
+| Volume quotidien               | m³    | Volume brut de gaz consommé pendant la journée gazière   |
+| Index compteur                 | m³    | Index du compteur à la fin de la journée gazière         |
+| Température extérieure moyenne | °C    | Température extérieure moyenne associée au jour par GRDF |
+
+Chaque valeur est enregistrée à la date du jour qu'elle concerne, et non à la
+date de son téléchargement : vos courbes restent justes malgré le retard de
+publication.
+
+## Quand arrivent les données
+
+GRDF publie un relevé avec **un à deux jours de retard**, généralement dans la
+journée qui suit la mesure. Rien n'est temps réel ici : la consommation du lundi
+arrive typiquement le mardi ou le mercredi. C'est une limite du réseau Gazpar
+lui-même (le compteur n'émet qu'une fois par jour), pas de l'intégration.
+
+L'intégration interroge GRDF selon son propre calendrier — toutes les six heures
+par défaut, ce qui est largement suffisant pour une valeur quotidienne. L'action
+**Rafraîchir les données maintenant** force une récupération immédiate si vous
+ne voulez pas attendre.
+
+## En cas de problème
+
+**« Tester la connexion GRDF » échoue.** Essayez de vous connecter sur
+[monespace.grdf.fr](https://monespace.grdf.fr) avec les mêmes identifiants dans
+une fenêtre de navigation privée. Si GRDF vous y demande un code ou un captcha,
+l'intégration ne passera pas non plus.
+
+**Les capteurs existent mais restent vides.** Vérifiez que le compteur est bien
+**ajouté à votre maison**, et pas seulement listé dans l'onglet **Découverte** :
+Gladys ne conserve les mesures que des appareils que vous avez ajoutés. Une fois
+ajouté, l'historique est importé en quelques secondes, et au pire dans la minute
+— ou utilisez **Rafraîchir les données maintenant**. Un long historique met
+quelques minutes à s'afficher entièrement : il est injecté en douceur (voir
+ci-dessus), du jour le plus ancien au plus récent.
+
+**« GRDF served its HTML app shell » ou « the session was not accepted ».** GRDF
+a répondu par une page web au lieu de données. Son site fait cela quand il
+n'accepte pas la session, mais aussi quand il traverse simplement un mauvais
+moment — il ne dit jamais lequel des deux. L'intégration se reconnecte et
+réessaie seule plusieurs fois ; si cela échoue encore, patientez quelques
+minutes puis utilisez **Rafraîchir les données maintenant**. Si cela persiste,
+vérifiez que monespace.grdf.fr fonctionne dans votre navigateur : GRDF freine
+parfois un compte qui s'est connecté de nombreuses fois d'affilée.
+
+**Aucune donnée nouvelle depuis plusieurs jours.** Vérifiez sur le site GRDF que
+les relevés sont bien publiés pour votre compteur : un Gazpar qui a perdu sa
+liaison radio n'alimente plus GRDF, et l'intégration ne peut montrer que ce que
+GRDF possède.
+
+**Les valeurs semblent fausses ou dupliquées.** L'intégration mémorise le dernier
+jour publié pour chaque compteur : elle ne réimporte jamais deux fois le même
+jour. Si vous supprimez un appareil puis le recréez, son historique repart de la
+fenêtre d'import configurée.
+
+Pour le détail de ce qui se passe, consultez les logs de l'intégration depuis
+l'interface Gladys (ou `docker logs` sur l'hôte) ; passez `LOG_LEVEL=debug` pour
+la version bavarde.
+
+## Vie privée
+
+Vos identifiants GRDF et vos données de consommation restent entre votre serveur
+Gladys et GRDF. Rien n'est envoyé ailleurs, aucun service tiers n'intervient.
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par GRDF Gazpar dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Avant de commencer | `section` | Non | Cette intégration se connecte à votre compte client GRDF, celui de monespace.grdf.fr, et lit les relevés quotidiens de votre compteur Gazpar. GRDF les publie avec un à deux jours de retard : rien n'arrive en temps réel. Votre compte ne doit pas demander d'étape de vérification supplémentaire à la connexion. |
+| E-mail du compte GRDF | `string` | Oui | L'adresse e-mail utilisée pour vous connecter sur monespace.grdf.fr. |
+| Mot de passe du compte GRDF | `secret` | Oui | Stocké chiffré par Gladys et transmis uniquement à GRDF. |
+| PCE à suivre | `string` | Non | Facultatif. Identifiants de point de comptage à 14 chiffres, séparés par des virgules. Laissez vide pour suivre tous les compteurs du compte. |
+| Historique à importer (jours) | `number` | Non | Nombre de jours de consommation passée importés à la première synchronisation. GRDF conserve environ trois ans. |
+| Intervalle de rafraîchissement (s) | `number` | Non | Fréquence d'interrogation de GRDF, en secondes. Un nouveau relevé n'arrive qu'une fois par jour : inutile de descendre en dessous de quelques heures. |
+
+## Comment installer GRDF Gazpar dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : GRDF Gazpar apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/philippema/gladys-grdf:1.1.4`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/PhilippeMA/gladys-grdf](https://github.com/PhilippeMA/gladys-grdf).
+
+GRDF Gazpar nécessite Gladys `>=4.62.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+GRDF Gazpar est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [PhilippeMA](https://github.com/PhilippeMA), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/PhilippeMA/gladys-grdf) — [source de cette documentation](https://github.com/PhilippeMA/gladys-grdf/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/home-connect.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/home-connect.mdx
@@ -1,0 +1,220 @@
+---
+title: "Intégration Home Connect pour Gladys Assistant"
+sidebar_label: "Home Connect"
+description: "Pilotez et suivez vos appareils Bosch, Siemens, Neff et Gaggenau via Home Connect. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-homeconnect.png"
+keywords:
+  - "home connect"
+  - "gladys home connect"
+  - "home connect gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/prohand/gladys-homeconnect instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="home-connect" />
+
+Cette intégration relie Gladys à **Home Connect**, la plateforme cloud des
+appareils électroménagers Bosch, Siemens, Neff, Gaggenau, Balay, Constructa,
+Profilo et Thermador.
+
+Tout appareil visible dans l'application Home Connect apparaît dans Gladys :
+lave-vaisselle, lave-linge, sèche-linge, lavante-séchante, fours, micro-ondes,
+tiroirs chauffants, tables de cuisson, hottes, réfrigérateurs, congélateurs,
+caves à vin, machines à café, robots aspirateurs et robots culinaires.
+
+> **Il n'y a pas de mode local.** Les appareils Home Connect dialoguent avec le
+> cloud BSH, et uniquement avec lui. Sans connexion Internet, cette intégration
+> ne fonctionne pas. C'est une propriété des appareils, pas de l'intégration.
+
+## 1. Créer une application développeur Home Connect
+
+L'API Home Connect est gratuite, mais chaque instance Gladys a besoin de **ses
+propres** identifiants : BSH les délivre par développeur, pas par produit.
+
+1. Créez un compte gratuit sur le
+   [portail développeur Home Connect](https://developer.home-connect.com/) et
+   connectez-vous. Utilisez **la même adresse e-mail que votre compte de
+   l'application Home Connect** : le portail relie les deux, et c'est à cette
+   condition que vous verrez vos propres appareils.
+2. Allez dans **Applications → Register Application** et renseignez :
+   - **Application ID** : ce que vous voulez, par exemple `gladys`.
+   - **OAuth Flow** : **Authorization Code Grant Flow**.
+   - **Home Connect User Account for Testing** : l'adresse e-mail de votre
+     compte Home Connect.
+   - **Redirect URI** : voir l'étape 2 ci-dessous, Gladys doit d'abord vous la
+     donner.
+   - **Success Redirect URI** : laissez vide.
+3. Une fois l'application enregistrée, le portail affiche vos **Client ID** et
+   **Client Secret**.
+
+## 2. Configurer l'intégration dans Gladys
+
+1. Installez l'intégration, puis ouvrez son onglet **Configuration**.
+2. Collez le **Client ID** et le **Client Secret**.
+3. Cliquez sur **Enregistrer**, puis sur **Connecter** au niveau du champ
+   _Compte Home Connect_. Gladys ouvre la page de connexion Home Connect.
+
+Si Home Connect répond « redirect_uri mismatch », c'est que l'URL utilisée par
+Gladys n'est pas celle déclarée dans le portail. Cliquez une fois sur le bouton
+**Tester la connexion** : il affiche l'URL de redirection exacte utilisée par
+Gladys. Collez-la dans le champ **Redirect URI** de votre application
+développeur, enregistrez sur le portail, puis cliquez de nouveau sur
+**Connecter**.
+
+4. Connectez-vous avec votre compte Home Connect et autorisez les permissions
+   demandées.
+5. De retour dans Gladys, ouvrez l'onglet **Découverte** : vos appareils sont
+   listés, prêts à être ajoutés.
+
+## 3. Ce que vous obtenez par appareil
+
+Les fonctionnalités sont construites à partir de ce que chaque appareil déclare
+réellement : deux appareils n'obtiennent donc jamais la même liste. En général :
+
+| Fonctionnalité                                         | Type        | Appareils                     |
+| ------------------------------------------------------ | ----------- | ----------------------------- |
+| Alimentation                                           | on/off      | la plupart                    |
+| Programme en cours                                     | on/off      | appareils à programmes        |
+| Programme actif / sélectionné                          | texte       | appareils à programmes        |
+| État de fonctionnement (`Run`, `Ready`, `Finished`…)   | texte       | tous                          |
+| Temps restant, temps écoulé, progression               | capteur     | appareils à programmes        |
+| Porte                                                  | ouverture   | la plupart                    |
+| Démarrage à distance, commande à distance, usage local | capteur     | la plupart                    |
+| Consignes réfrigérateur / congélateur                  | thermostat  | froid                         |
+| Super mode, mode éco, mode vacances                    | on/off      | froid                         |
+| Température du four                                    | température | fours                         |
+| Éclairage, éclairage d'ambiance, luminosité            | lumière     | hottes, fours, réfrigérateurs |
+| Sécurité enfant                                        | verrou      | appareils compatibles         |
+| Compteurs de boissons                                  | compteur    | machines à café               |
+| Alertes (sel, réservoir d'eau, filtre…)                | binaire     | selon la famille d'appareil   |
+| Connecté                                               | binaire     | tous                          |
+
+**Porte** suit la convention Gladys des détecteurs d'ouverture : la
+fonctionnalité affiche _Fermé_ quand la porte est fermée et _Ouvert_ sinon (une
+porte verrouillée compte comme fermée). Les **alertes** affichent _Off_ tant que
+Home Connect ne les a pas déclenchées : un lave-vaisselle qui n'a jamais manqué
+de sel montre une alerte au repos, et non une valeur vide.
+
+### Démarrer un programme
+
+**Programme en cours** démarre le programme **actuellement sélectionné sur
+l'appareil** (ou dans l'application Home Connect) : il n'en choisit pas un à
+votre place. C'est exactement ce que les appareils autorisent — un démarrage à
+distance est un déclencheur, pas un sélecteur de programme.
+
+Pour que cela fonctionne, le **démarrage à distance doit être armé** sur
+l'appareil : sur la plupart des modèles, un appui long sur la touche _Démarrage
+à distance_ jusqu'à confirmation à l'écran. Sans cela, Home Connect refuse la
+commande et Gladys affiche le message de refus.
+
+Repasser **Programme en cours** sur « éteint » interrompt le programme.
+
+## 4. Comment les états restent à jour
+
+L'intégration maintient ouvert un **flux d'événements** permanent vers Home
+Connect : une porte qui s'ouvre ou un programme qui se termine arrive dans
+Gladys en une seconde environ — y compris les actions faites directement sur
+l'appareil.
+
+Le polling (par défaut toutes les 15 minutes) tourne derrière, en filet de
+sécurité, car Home Connect coupe le flux environ une fois par jour. Home Connect
+applique un quota de requêtes : gardez un intervalle élevé sauf raison
+particulière.
+
+Une valeur qui ne change pas est tout de même renvoyée à Gladys **au moins une
+fois par heure**. Gladys considère en effet qu'un état devient « périmé » au
+bout d'un certain délai (48 heures par défaut, réglable dans **Paramètres →
+Système**) et affiche alors « Pas de valeur récente » sur le tableau de bord. Un
+lave-vaisselle qui reste plusieurs jours dans le même état — connecté, réservoir
+de sel plein, aucun programme en cours — doit donc redire régulièrement que rien
+n'a changé. Ces renvois ne consomment aucune requête Home Connect.
+
+## 5. Tester sans appareil
+
+Activez **Utiliser le simulateur Home Connect** dans la configuration.
+L'intégration s'adresse alors à `simulator.home-connect.com`, qui sert la même
+API sur les appareils virtuels de votre compte développeur. Pensez à le
+désactiver ensuite.
+
+## 6. Dépannage
+
+**« Renseignez vos Client ID et Client Secret Home Connect »** — les identifiants
+sont absents ou vides.
+
+**« Cliquez sur Connecter pour lier votre compte Home Connect »** — les
+identifiants sont là, mais le flux OAuth n'a jamais été mené à son terme.
+
+**« L'intégration a refusé la connexion. Réessayez. »** dans la fenêtre de
+retour d'autorisation — l'échange du code d'autorisation a échoué. Ouvrez les
+logs de l'intégration : le message y donne la raison exacte donnée par Home
+Connect (Client Secret manquant, URL de redirection non déclarée dans le portail
+développeur, code déjà utilisé…). Si vous avez redémarré l'intégration ou la
+machine pendant que vous vous connectiez chez Home Connect, relancez simplement
+**Connecter** : une autorisation reste valable quinze minutes.
+
+Après un **Connecter** réussi, la fenêtre se ferme immédiatement et
+l'état de la connexion affiche « Compte connecté, lecture de vos appareils… » :
+la lecture du compte Home Connect se poursuit en arrière-plan et peut prendre
+quelques secondes par appareil.
+
+**« Autorisation Home Connect expirée »** — le refresh token a été refusé. Il
+expire après environ deux mois sans utilisation, et il est également révoqué si
+vous retirez Gladys des applications autorisées de votre compte Home Connect.
+Cliquez de nouveau sur **Connecter**.
+
+**« Quota Home Connect atteint »** — trop de requêtes. L'intégration lève le pied
+d'elle-même ; augmentez l'intervalle de rafraîchissement si cela se répète.
+
+**Un appareil affiche un badge orange « injoignable »** — c'est Home Connect
+lui-même qui ne le joint pas. Vérifiez dans l'application Home Connect qu'il est
+allumé et connecté à votre Wi-Fi.
+
+**Une commande est refusée** — Gladys affiche la raison donnée par Home Connect.
+Les plus fréquentes : _démarrage à distance non activé_, _porte ouverte_ et
+_appareil éteint_.
+
+L'intégration journalise tout ce qu'elle fait : passez `LOG_LEVEL=debug` et
+consultez les logs de l'intégration depuis l'interface Gladys pour le détail
+complet.
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par Home Connect dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Avant de commencer | `section` | Non | Home Connect n'a pas d'API locale : tout passe par le cloud BSH. Créez un compte développeur gratuit, enregistrez une application de type « Home Connect Application » avec le flux Authorization Code Grant, puis collez ses Client ID et Client Secret ci-dessous. L'URL de redirection à déclarer est affichée par l'action « Tester la connexion » une fois la connexion lancée. |
+| Client ID | `string` | Oui | Client ID de votre application Home Connect. |
+| Client Secret | `secret` | Non | Client Secret de votre application Home Connect. Laissez vide uniquement si vous avez enregistré un client public sans secret. |
+| Compte Home Connect | `oauth2` | Oui | Connectez-vous avec le compte Home Connect auquel vos appareils sont associés, puis autorisez Gladys. |
+| Langue | `select` | Non | Langue des noms de fonctionnalités et des noms de programmes renvoyés par Home Connect. |
+| Intervalle de rafraîchissement (s) | `number` | Non | Filet de sécurité derrière le flux d'événements temps réel. Home Connect impose un quota de requêtes quotidien : gardez une valeur élevée sauf raison particulière. |
+| Scopes OAuth | `string` | Non | Scopes Home Connect demandés lors de l'autorisation, séparés par des espaces. Réduisez-les si votre application développeur a été enregistrée avec moins de permissions. |
+| Utiliser le simulateur Home Connect | `boolean` | Non | Utiliser simulator.home-connect.com au lieu de l'API de production, pour tester sans appareil réel. |
+
+## Comment installer Home Connect dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : Home Connect apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-homeconnect:1.0.4`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/prohand/gladys-homeconnect](https://github.com/prohand/gladys-homeconnect).
+
+Home Connect nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+Home Connect est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [prohand](https://github.com/prohand), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/prohand/gladys-homeconnect) — [source de cette documentation](https://github.com/prohand/gladys-homeconnect/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/immich-slideshow.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/immich-slideshow.mdx
@@ -1,0 +1,101 @@
+---
+title: "Intégration Immich Slideshow pour Gladys Assistant"
+sidebar_label: "Immich Slideshow"
+description: "Diffuse un album ou les souvenirs Immich en diaporama caméra sur le dashboard Gladys. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/gboulvin--Gladys-Immich.jpg"
+keywords:
+  - "immich slideshow"
+  - "gladys immich slideshow"
+  - "immich slideshow gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/gboulvin/Gladys-Immich instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="immich-slideshow" />
+
+## Objectif
+
+Cette intégration externe Gladys transforme un **album Immich** ou la collection **Souvenirs — ce jour-là** en caméra virtuelle. Ajoutez cette caméra au dashboard Gladys pour afficher un diaporama de photos qui change automatiquement. Les photos restent sur votre serveur Immich : l’intégration ne demande que les aperçus Immich et ne télécharge jamais les originaux.
+
+L’intégration nécessite Gladys **4.85.0 ou version ultérieure**. Elle s’appuie sur le canal d’images des caméras afin de proposer immédiatement un diaporama fonctionnel sur le dashboard actuel. La sélection des photos est séparée de l’adaptateur caméra et pourra être reliée à la future API de fournisseur du widget Photo annoncée par Gladys.
+
+## Prérequis
+
+Vous avez besoin d’un serveur Immich joignable et d’une clé API créée dans **Immich → Paramètres du compte → Clés API**. Attribuez le minimum de permissions suivant :
+
+| Permission    | Utilité                                                  |
+| ------------- | -------------------------------------------------------- |
+| `album.read`  | Lister les albums et lire l’album sélectionné.           |
+| `asset.view`  | Télécharger l’aperçu de chaque image affichée.           |
+| `memory.read` | Lire la source facultative des souvenirs « ce jour-là ». |
+
+Le conteneur Gladys doit pouvoir atteindre l’URL indiquée dans le formulaire. Pour un serveur local, utilisez son adresse réseau et son port, par exemple `http://192.168.1.20:2283`. N’utilisez pas `localhost` : il désigne le conteneur isolé de l’intégration, et non l’hôte Gladys ou le serveur Immich.
+
+## Configuration
+
+Ouvrez **Intégrations → Immich Slideshow → Configuration**, puis renseignez l’URL et la clé API. Choisissez **Album** ou **Souvenirs — ce jour-là**. Pour un album, copiez son UUID depuis l’URL affichée dans Immich et collez-le dans **UUID de l’album**. Le bouton **Tester la connexion Immich** vérifie que Gladys peut lister les albums avec cette clé.
+
+Réglez l’intervalle entre les photos, la fréquence de mise à jour de la source et le plafond d’images conservées. L’actualisation de la liste est distincte de l’intervalle d’affichage : un grand album n’est interrogé que périodiquement et seuls les aperçus effectivement affichés sont téléchargés. Les vidéos sont ignorées. Par défaut, les images les plus récentes passent en premier ; activez l’ordre aléatoire pour mélanger chaque liste rechargée.
+
+Enregistrez la configuration, ouvrez l’onglet **Découverte** de l’intégration et créez la caméra **Immich slideshow**. Ajoutez ensuite cette caméra à une boîte caméra sur un dashboard Gladys. La première image est publiée immédiatement, puis la caméra est mise à jour selon l’intervalle configuré. Utilisez **Actualiser le diaporama maintenant** après l’ajout de photos ou pour récupérer sans attendre les nouveaux souvenirs du jour.
+
+## Confidentialité et traitement des images
+
+La clé API est déclarée comme un `secret` Gladys : elle est stockée de manière sécurisée et n’est jamais retournée au navigateur du dashboard. Les requêtes vers Immich contiennent l’en-tête `x-api-key` dans le conteneur de l’intégration. Avant publication dans le canal caméra Gladys, les aperçus sont orientés correctement, redimensionnés et compressés en JPEG afin de conserver un dashboard fluide et de respecter la limite de taille du canal.
+
+## Dépannage
+
+Si le test de connexion indique une clé ou des permissions invalides, recréez une clé API Immich avec les trois permissions précédentes. Si le serveur est inaccessible, vérifiez l’URL depuis le réseau de l’hôte Gladys et assurez-vous qu’un pare-feu, un proxy inverse ou la configuration Docker ne bloque pas l’accès du conteneur d’intégration à Immich. Un album vide ou une collection de souvenirs vide est un état normal : ajoutez des photos ou sélectionnez une autre source. Les journaux consultables dans l’onglet Configuration donnent la catégorie de l’erreur HTTP sans afficher la clé API.
+
+## Modèle dashboard actuel et futur widget Photo
+
+Dans Gladys 4.85, le widget **Photo** accepte une liste d’URL gérée manuellement ; il n’expose pas encore d’API de source de photos externe. Ce projet fournit donc aujourd’hui un véritable diaporama sur le dashboard via une caméra virtuelle. La couche indépendante `src/photoProvider.js` résout déjà albums et souvenirs sous forme de métadonnées normalisées, dont les légendes, afin de pouvoir se raccorder au futur contrat de fournisseur du widget Photo sans réécrire le client Immich.
+
+## Références
+
+[1] [Points de terminaison de l’API Immich](https://api.immich.app/endpoints)
+[2] [Intégrations externes Gladys](https://gladysassistant.com/docs/dev/external-integrations/)
+[3] [Annonce du widget Photo Gladys 4.85](https://community.gladysassistant.com/t/gladys-assistant-4-85-0-widget-photo-navigation-dans-les-graphiques-chauffe-eau-homekit/10483)
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par Immich Slideshow dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Connecter Immich | `section` | Non | Créez une clé API Immich avec les permissions album.read, asset.view et memory.read. Gladys stocke cette clé de manière sécurisée ; elle n’est jamais envoyée au navigateur du dashboard. |
+| URL du serveur Immich | `string` | Oui | Par exemple : http://192.168.1.20:2283. Le conteneur d’intégration Gladys doit pouvoir joindre cette adresse. |
+| Clé API Immich | `secret` | Oui |  |
+| Source des photos | `select` | Oui | Choisissez un album précis ou les souvenirs Immich de cette date les années précédentes. |
+| UUID de l’album | `string` | Non | Requis uniquement pour la source Album. Copiez l’UUID dans l’URL de l’album Immich ; laissez vide pour Souvenirs. |
+| Intervalle entre les photos (secondes) | `number` | Oui | Durée d’affichage de chaque image sur la caméra du dashboard. Le minimum respecte les limites du canal caméra Gladys. |
+| Intervalle d’actualisation de la source (secondes) | `number` | Oui | Fréquence à laquelle l’intégration redemande l’album ou les souvenirs du jour à Immich. Les diapositives existantes défilent entre deux actualisations. |
+| Nombre maximal d’images | `number` | Oui | Limite les grands albums pour préserver la réactivité. Les images les plus récentes sont sélectionnées, sauf si l’ordre aléatoire est activé. |
+| Mélanger les images | `boolean` | Non | Lorsqu’il est désactivé, le diaporama commence par l’image la plus récente. |
+
+## Comment installer Immich Slideshow dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : Immich Slideshow apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/gboulvin/gladys-immich:0.1.2`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/gboulvin/Gladys-Immich](https://github.com/gboulvin/Gladys-Immich).
+
+Immich Slideshow nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+Immich Slideshow est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [gboulvin](https://github.com/gboulvin), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/gboulvin/Gladys-Immich) — [source de cette documentation](https://github.com/gboulvin/Gladys-Immich/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/indice-uv.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/indice-uv.mdx
@@ -20,12 +20,34 @@ import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationH
 
 <ExternalIntegrationHeader slug="indice-uv" />
 
-Cette intégration suit l'**indice UV** des lieux de votre choix. Vous ajoutez un
-lieu avec son **code postal**, et un appareil apparaît dans l'onglet
-**Découverte**, prêt à être ajouté à Gladys.
+Cette intégration suit l'**indice UV** des lieux de votre choix. Vous ajoutez vos
+**maisons Gladys en un clic** ou un lieu avec son **code postal**, et un appareil
+apparaît dans l'onglet **Découverte**, prêt à être ajouté à Gladys.
 
 Aucun compte à créer, aucune clé d'API à saisir : les deux sources utilisées sont
 des données ouvertes publiques.
+
+## Ajouter vos maisons Gladys, en un clic
+
+Vous avez déjà dit à Gladys où vous habitez : c'est la carte de **Réglages >
+Maisons**. Le bouton **« Ajouter mes maisons Gladys »** lit ces maisons et crée
+un lieu pour chacune qui n'est pas déjà surveillée — aucun code postal à saisir.
+
+Trois choses à savoir :
+
+- **L'accès est une autorisation.** L'endroit où vous vivez est une donnée
+  personnelle : Gladys ne la partage que si vous l'avez accepté sur l'écran
+  d'installation de l'intégration. Si le bouton répond que l'accès est refusé,
+  supprimez puis réinstallez l'intégration en acceptant la demande affichée.
+- **Une maison sans position sur la carte n'a pas de coordonnées.** Elle est
+  nommée dans la réponse, et il suffit de la placer dans Réglages > Maisons puis
+  de relancer l'action.
+- **Ce n'est pas une synchronisation.** Les maisons sont lues au moment du clic.
+  Le lieu obtenu est un lieu ordinaire, que vous renommez et supprimez comme les
+  autres, et une maison déplacée dans Gladys ensuite ne déplace pas son lieu.
+
+Relancer l'action est sans risque : une maison déjà surveillée est signalée, pas
+ajoutée une deuxième fois.
 
 ## Ajouter un lieu
 
@@ -83,6 +105,7 @@ Deux choses à savoir sur la suppression :
 | Niveau d'exposition UV         | De 0 à 5, les catégories de l'OMS : la fonctionnalité à tester dans un scénario          |
 | Niveau d'exposition UV (texte) | Son libellé : « Faible », « Élevé »…                                                     |
 | Conseil de protection solaire  | La recommandation de l'OMS pour ce niveau                                                |
+| Données mises à jour le        | L'heure de la prévision d'où viennent les valeurs, dans l'heure locale du lieu           |
 
 ### L'échelle
 
@@ -109,6 +132,22 @@ Quand le modèle n'a pas de valeur pour un lieu, **rien n'est publié** pour la
 fonctionnalité concernée : l'appareil garde sa dernière valeur connue. Publier un
 0 ferait croire à un coucher de soleil en plein après-midi et déclencherait les
 scénarios correspondants.
+
+### Les données datent de quand ?
+
+**Données mises à jour le** indique l'heure de la prévision CAMS d'où viennent
+les valeurs de l'appareil, écrite dans l'**heure locale du lieu** — un lieu à
+Sydney et un lieu à Nantes n'affichent jamais la même, et c'est pourquoi cette
+fonctionnalité est portée par chaque station plutôt que par un appareil unique.
+
+Ce n'est pas l'heure de la dernière interrogation. La prévision est horaire :
+la lire trois fois dans l'heure renvoie trois fois le même horodatage, et c'est
+justement l'intérêt — il dit l'âge des chiffres, pas la fréquence des appels.
+Quand un rafraîchissement échoue, rien n'est publié du tout : l'horodatage
+cesse d'avancer et l'ancienneté devient visible sur le tableau de bord.
+
+« Tester le fournisseur UV » termine chaque ligne par ce même horodatage : une
+source qui répond avec l'heure d'hier se voit immédiatement.
 
 ## Réglages généraux
 
@@ -160,16 +199,16 @@ Voici les paramètres demandés par Indice UV dans son écran de configuration d
 | Réglages généraux | `section` | Non | Ces réglages s'appliquent à tous les lieux configurés. |
 | Langue du nom des appareils | `select` | Non | La langue dans laquelle sont écrits les noms des appareils et de leurs fonctionnalités : « Indice UV » ou « UV index ». Tout le reste de ce que l'intégration affiche suit déjà la langue de votre compte Gladys, mais le nom d'un appareil et de ses fonctionnalités est enregistré tel qu'il est publié : il faut donc le choisir ici. Un appareil déjà ajouté à Gladys conserve les noms avec lesquels il a été créé : supprimez-le et rajoutez-le depuis l'onglet Découverte pour le renommer. |
 | Intervalle de rafraîchissement (s) | `number` | Non | Fréquence de rafraîchissement de chaque lieu, en secondes. La prévision est horaire : descendre nettement sous la demi-heure n'apporte rien. |
-| Vos lieux | `section` | Non | Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste. |
+| Vos lieux | `section` | Non | Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. « Ajouter mes maisons Gladys » les ajoute tous en un clic, à partir des maisons que vous avez déjà placées sur la carte dans Gladys. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste. |
 
 ## Comment installer Indice UV dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Indice UV apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-uvindex:1.0.2`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-uvindex:1.0.4`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/prohand/gladys-uvindex](https://github.com/prohand/gladys-uvindex).
 
-Indice UV nécessite Gladys `>=4.62.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+Indice UV nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
 
 Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/ipp-printers.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/ipp-printers.mdx
@@ -130,7 +130,7 @@ Voici les paramètres demandés par IPP Printers dans son écran de configuratio
 ## Comment installer IPP Printers dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : IPP Printers apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/guim31/gladys-ipp:1.0.5`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/guim31/gladys-ipp:1.0.7`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/guim31/gladys-ipp](https://github.com/guim31/gladys-ipp).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/meross.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/meross.mdx
@@ -1,0 +1,224 @@
+---
+title: "Intégration Meross pour Gladys Assistant"
+sidebar_label: "Meross"
+description: "Pilotez vos prises, interrupteurs, lampes et portes de garage Meross. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-Meross.png"
+keywords:
+  - "meross"
+  - "gladys meross"
+  - "meross gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/PhilippeMA/gladys-Meross instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="meross" />
+
+Pilotez vos prises, interrupteurs, lampes et portes de garage Meross depuis Gladys, et
+suivez leur consommation sur votre tableau de bord.
+
+## Ce que vous obtenez
+
+Connectez-vous une fois avec votre compte Meross et tous les appareils compatibles du compte
+apparaissent dans l'onglet **Découverte**, prêts à être ajoutés. Sans réappairage, sans
+matériel supplémentaire.
+
+| Votre appareil                                  | Ce que vous pouvez faire dans Gladys                              |
+| ----------------------------------------------- | ----------------------------------------------------------------- |
+| Prise ou interrupteur (MSS110, MSS210, MSS510…) | L'allumer et l'éteindre                                           |
+| Prise avec mesure (MSS310, MOP320)              | Marche/arrêt, plus puissance, tension, courant et énergie du jour |
+| Multiprise (MSS425…)                            | Chaque prise séparément                                           |
+| Ampoule ou bandeau (MSL120, MSL320, MSL430…)    | Marche/arrêt, luminosité, couleur et température de blanc         |
+| Ouvre-porte de garage (MSG100, MSG200)          | L'ouvrir, la fermer, et voir si elle est réellement ouverte       |
+| Hub (MSH300, MSH400)                            | Tout ce qui lui est appairé — voir ci-dessous                     |
+
+### Appareils reliés à un hub
+
+Un hub est une passerelle : il n'a rien à allumer ou éteindre par lui-même. Le hub
+n'apparaît donc pas dans Gladys — **chaque capteur qui lui est appairé, si**, sous le nom que
+vous lui avez donné dans l'application Meross.
+
+| Appareil appairé                  | Ce que vous obtenez dans Gladys                                       |
+| --------------------------------- | --------------------------------------------------------------------- |
+| Thermomètre (MS100)               | Température, humidité, niveau de batterie                             |
+| Vanne thermostatique (MTS100/150) | Température de consigne, température ambiante, marche/arrêt, batterie |
+| Détecteur de fuite (MS400)        | Fuite détectée, niveau de batterie                                    |
+| Capteur d'ouverture (MS200)       | Ouverture, niveau de batterie                                         |
+| Programmateur d'arrosage (MST100) | Lancer un arrosage, régler sa durée, batterie                         |
+
+Si votre hub semble ne rien faire, vérifiez qu'au moins un capteur lui est **appairé dans
+l'application Meross** : un hub sans capteur n'a rien à afficher. Le bouton **Diagnostiquer
+mes appareils** liste ce que l'intégration a trouvé derrière lui.
+
+Le _mode_ des vannes (confort, éco, programmation) n'est pas encore disponible — seulement la
+température de consigne, qui est l'essentiel pour les automatisations.
+
+#### Programmateurs d'arrosage
+
+Un programmateur MST100 sur un hub MSH400 vous donne un interrupteur **« Watering »**, une
+durée **« Watering duration »** en minutes et son **niveau de batterie**.
+
+Activez **Watering** et le programmateur arrose pendant la durée réglée, puis s'arrête tout
+seul — exactement comme le bouton « arroser maintenant » de l'application Meross. Désactivez-le
+pour arrêter avant la fin. L'interrupteur se remet à zéro quand l'arrosage se termine.
+
+La durée affichée est **celle réglée sur le programmateur lui-même** — la même que dans
+l'application Meross. La modifier depuis Gladys l'écrit sur l'appareil, donc l'application
+verra le changement, et inversement. Il n'y a qu'une seule valeur et elle appartient au
+matériel : Gladys ne lance jamais un arrosage avec une durée de son cru.
+
+Tant que le programmateur n'a rien communiqué, la durée reste vide plutôt qu'affichée avec
+une valeur inventée.
+
+Gladys parle à votre hub en direct sur votre réseau local quand il est joignable, et via les
+serveurs Meross sinon. Si l'arrosage échoue, le message d'erreur nomme les deux canaux et
+l'adresse qui n'a pas répondu ; **Diagnostiquer mes appareils** affiche l'adresse locale de
+chaque appareil et le canal réellement utilisé.
+
+Les **programmations** d'arrosage restent dans l'application Meross : le hub n'en autorise ni
+la lecture ni la modification depuis l'extérieur.
+
+## Configuration
+
+1. Ouvrez l'onglet **Configuration** de l'intégration.
+2. Saisissez l'**e-mail** et le **mot de passe** de votre compte Meross — les mêmes que dans
+   l'application mobile Meross.
+3. Choisissez la **région** de création de votre compte (Europe, Amérique, Asie/Pacifique).
+   C'est la cause la plus fréquente d'un refus de connexion : dans le doute, essayez Europe,
+   puis Global.
+4. Enregistrez. Cliquez sur **Tester la connexion** pour vérifier : le nombre d'appareils
+   trouvés s'affiche sous le bouton.
+5. Vos appareils apparaissent dans l'onglet **Découverte**.
+
+Votre mot de passe est stocké chiffré par Gladys. Il n'est jamais transmis en clair : seule
+une forme hachée quitte l'intégration, et uniquement vers le serveur d'authentification
+Meross.
+
+### Local ou cloud ?
+
+L'interrupteur **Préférer la connexion locale** (activé par défaut) demande à l'intégration
+de parler directement à vos appareils sur votre réseau Wi-Fi, au lieu de passer par les
+serveurs Meross. Le contrôle local est plus rapide et continue de fonctionner même si votre
+connexion Internet est coupée.
+
+Chaque appareil affiche un badge indiquant le canal réellement utilisé :
+
+- **local** — les commandes ne quittent jamais votre réseau ;
+- **cloud** — les commandes passent par Meross ;
+- **cloud avec un point orange** — le local était préféré, mais cet appareil n'a pas répondu
+  sur le réseau ; survolez le badge pour connaître la raison.
+
+Certaines versions de firmware Meross refusent le contrôle local. C'est une limitation de
+l'appareil : l'intégration bascule sur le cloud pour qu'il continue de fonctionner.
+
+Notez que même en mode local, l'intégration se connecte une fois à Meross au démarrage : vos
+appareils n'acceptent que les commandes signées avec la clé de votre compte, et seul Meross
+peut la fournir.
+
+### Intervalle de rafraîchissement
+
+Les prises qui mesurent la consommation et les capteurs derrière un hub sont lus à cet
+intervalle. Choisissez-le dans la liste : **chaque minute** (valeur par défaut, et intervalle
+le plus lent que Gladys accepte) jusqu'à chaque seconde.
+
+Tout le reste — marche/arrêt, couleurs, position de la porte de garage — arrive
+**instantanément**, poussé par l'appareil, y compris lorsque quelqu'un appuie sur un bouton
+physique ou utilise l'application Meross. L'intervalle le plus lent convient donc à la
+plupart des installations ; un intervalle plus rapide ne fait qu'augmenter le nombre de
+requêtes vers Meross.
+
+## Actions
+
+- **Tester la connexion** — se connecte avec les identifiants du formulaire et indique
+  combien d'appareils contient votre compte, et combien sont en ligne.
+- **Rafraîchir la liste des appareils** — relit votre compte. À utiliser après avoir ajouté
+  ou renommé un appareil dans l'application Meross, ou appairé un capteur à un hub.
+- **Diagnostiquer mes appareils** — liste chaque appareil du compte, ses capacités, les
+  capteurs trouvés derrière un hub, et la façon dont l'intégration a traité chacun.
+  Commencez par là quand un appareil manque.
+
+## Dépannage
+
+**« Meross a refusé les identifiants »** — vérifiez les trois champs ensemble : e-mail, mot
+de passe et surtout la **région**. Un compte créé en Europe ne peut pas se connecter sur le
+point d'accès américain.
+
+**Un appareil reste hors ligne** — vérifiez d'abord qu'il est joignable dans l'application
+Meross. Gladys rapporte ce que Meross lui indique : un appareil hors ligne pour Meross l'est
+aussi ici.
+
+**L'application Meross me déconnecte** — Meross limite le nombre de sessions simultanées par
+compte. Reconnectez-vous simplement dans l'application : les deux sessions peuvent
+coexister. L'intégration met sa session en cache et la libère à l'arrêt pour limiter le
+phénomène.
+
+**Un appareil est absent de l'onglet Découverte** — cliquez sur **Diagnostiquer mes
+appareils** : le rapport indique si l'appareil a été vu, ce qu'il annonce, et si
+l'intégration a su le traiter. S'il s'agit d'un capteur censé être derrière un hub, vérifiez
+qu'il est bien appairé à ce hub dans l'application Meross. L'intégration écrit également une
+ligne de log pour chaque appareil ignoré, en précisant ce qu'elle a vu.
+
+**L'adresse locale de mon appareil ne répond pas** — l'intégration bascule sur le cloud et
+le signale dans les logs, avec la raison :
+
+- _no route to the device_ — Gladys n'est pas sur le même réseau que l'appareil. C'est le cas
+  habituel quand Gladys tourne dans Docker sur un autre sous-réseau ou un autre VLAN.
+- _connection refused_ — l'adresse répond mais rien n'écoute : ce n'est probablement plus
+  votre appareil (bail DHCP qui a changé). Utilisez **Rafraîchir la liste des appareils**.
+- _no answer before the timeout_ — un pare-feu bloque les paquets.
+
+Cliquez sur **Diagnostiquer mes appareils** pour un vrai test : il envoie une requête
+correctement signée et rapporte ce que chaque adresse répond. Un `curl` à la main n'apprend
+pas grand-chose ici — un appareil Meross accepte la connexion puis ignore en silence toute
+requête non signée, si bien qu'un appareil en pleine forme ressemble à un appareil mort.
+
+Toute réponse autre qu'une erreur de connexion signifie que l'appareil est joignable. Sinon,
+la correction est côté réseau. La lecture des états et la plupart des commandes continuent
+de fonctionner par le cloud ; **l'arrosage, lui, exige ce canal local** sur les hubs MSH400.
+
+Le bouton **Diagnostiquer mes appareils** teste l'adresse locale port par port et affiche ce
+que chacun répond — c'est plus fiable qu'un `curl` à la main, car un appareil Meross accepte
+la connexion puis ignore en silence toute requête non signée.
+
+**Rien ne fonctionne et je veux savoir pourquoi** — l'intégration journalise tout ce qu'elle
+fait. Ouvrez les logs de l'intégration depuis l'interface Gladys (ou `docker logs` sur
+l'hôte) ; passez `LOG_LEVEL` à `debug` pour le détail complet, y compris chaque message
+échangé avec vos appareils.
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par Meross dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Connectez votre compte Meross | `section` | Non | Utilisez les mêmes identifiants que dans l'application mobile Meross. Vos appareils sont ensuite découverts automatiquement, sans réappairage. Meross limite le nombre de sessions[...] |
+| E-mail Meross | `string` | Oui | L'adresse e-mail de votre compte Meross. |
+| Mot de passe Meross | `secret` | Oui | Stocké chiffré par Gladys et envoyé uniquement, sous forme hachée, au serveur d'authentification Meross. |
+| Région Meross | `select` | Oui | La région de création de votre compte Meross. En cas d'erreur, la connexion est refusée. |
+| Intervalle de rafraîchissement | `select` | Non | Fréquence de lecture des prises avec mesure et des capteurs de hub. Les états on/off arrivent en temps réel : l'intervalle le plus lent convient à la plupart des installations.[...] |
+
+## Comment installer Meross dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : Meross apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/philippema/gladys-meross:1.1.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/PhilippeMA/gladys-Meross](https://github.com/PhilippeMA/gladys-Meross).
+
+Meross nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+Meross est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [PhilippeMA](https://github.com/PhilippeMA), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/PhilippeMA/gladys-Meross) — [source de cette documentation](https://github.com/PhilippeMA/gladys-Meross/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/meteo-benelux.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/meteo-benelux.mdx
@@ -1,0 +1,100 @@
+---
+title: "Intégration Météo Bénélux pour Gladys Assistant"
+sidebar_label: "Météo Bénélux"
+description: "Prévisions, conditions courantes et avertissements météo de l’IRM/KMI pour le Benelux. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/placeholder.png"
+keywords:
+  - "météo bénélux"
+  - "gladys météo bénélux"
+  - "météo bénélux gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/gboulvin/Gladys-IRM-KMI-V2 instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="meteo-benelux" />
+
+## Présentation
+
+Cette intégration ajoute à Gladys les données de l’Institut royal météorologique de Belgique (IRM/KMI) pour les localisations prises en charge en Belgique, au Luxembourg et aux Pays-Bas.[1] Elle utilise la position demandée par Gladys : vous n’avez donc ni ville, ni station, ni clé API à configurer.
+
+> L’IRM/KMI ne publie pas de documentation officielle pour l’API mobile utilisée ici. Le fonctionnement peut évoluer sans préavis ; l’intégration affichera une erreur claire dans ses journaux si le fournisseur devient indisponible.[2]
+
+| Donnée disponible       | Présentation dans Gladys                                                                                                     |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Conditions actuelles    | Température, état du ciel, pression, vent, rafales et indice UV quand le fournisseur les transmet.                           |
+| Prévisions horaires     | Jusqu’à 24 échéances de température, précipitation, probabilité de précipitation, vent et pression.                          |
+| Prévisions quotidiennes | Jusqu’à 8 journées complètes avec températures minimale et maximale, précipitations, vent et heures solaires.                |
+| Avertissements          | Avertissements de vent, pluie, neige/verglas, orage, brouillard, froid, chaleur et submersion selon les données disponibles. |
+
+## Installation
+
+Ajoutez l’intégration depuis le catalogue Gladys une fois que son image Docker a été publiée. Si vous installez le dépôt manuellement, construisez d’abord l’image compatible avec l’architecture de votre serveur puis référencez-la dans le manifeste de l’intégration.
+
+Le projet utilise le template officiel Gladys. Si vous publiez votre propre copie du dépôt, remplacez `your-github-username` dans le champ `docker_image` et dans le champ `cover_image` du fichier `gladys-assistant-integration.json`. Le workflow de publication fourni construit une image multi-architecture à chaque version.[3]
+
+## Configuration
+
+L’intégration ne demande aucune information personnelle. Le réglage **Durée du cache** est facultatif et vaut 600 secondes par défaut. Il détermine combien de temps une prévision déjà téléchargée peut être réutilisée pour une même position et les mêmes unités. Utilisez `0` pour désactiver le cache ; cette option augmente les appels au service IRM/KMI.
+
+|        Valeur | Utilisation recommandée                                                           |
+| ------------: | --------------------------------------------------------------------------------- |
+|           `0` | Diagnostic ponctuel ou besoin exceptionnel de forcer chaque appel réseau.         |
+| `300` à `900` | Usage habituel ; réduit les appels sans rendre la prévision obsolète.             |
+|        `3600` | À réserver aux installations qui demandent très fréquemment la même localisation. |
+
+## Fonctionnement et unités
+
+Gladys adresse une demande incluant la latitude, la longitude, la langue et les unités de l’utilisateur. L’intégration arrondit les coordonnées, interroge l’API IRM/KMI puis renvoie le résultat dans le format météo standard de Gladys. Les données sources sont métriques ; elles sont converties en Fahrenheit, miles par heure et pouces lorsque Gladys demande le système impérial.[4]
+
+Les messages d’avertissement sont sélectionnés dans la langue demandée lorsqu’elle est disponible. Les niveaux IRM/KMI 1, 2 et 3 sont rendus avec les gravités `minor`, `moderate` et `severe`. Les avertissements sans niveau ou sans identifiant fiable sont volontairement omis afin d’éviter toute alerte ambiguë.
+
+## Limites
+
+L’API de référence ne fournit pas d’humidité ni de point de rosée. Ces informations ne sont donc pas affichées. Une prévision quotidienne peut comporter deux conditions ; seule la première est conservée. Le radar de pluie et le pollen ne font pas partie de cette version, car l’interface météo principale de Gladys ne les transporte pas sous une forme suffisante.[1] [2]
+
+## Dépannage
+
+Si aucune prévision ne s’affiche, vérifiez que la localisation Gladys se trouve bien dans la zone Bénélux supportée. Consultez ensuite les journaux de l’intégration : un code HTTP non réussi, une réponse invalide ou un délai dépassé y sont indiqués. Une indisponibilité temporaire du fournisseur peut être contournée en réessayant plus tard ; augmenter le cache peut également limiter les échecs causés par des demandes répétées.
+
+## Références
+
+[1]: https://github.com/jdejaegh/irm-kmi-ha 'Intégration IRM/KMI pour Home Assistant'
+[2]: https://github.com/jdejaegh/irm-kmi-api 'Client Python IRM/KMI'
+[3]: https://github.com/GladysAssistant/integration-template-js 'Template officiel JavaScript pour intégration Gladys'
+[4]: https://github.com/jdejaegh/irm-kmi-api/blob/main/irm_kmi_api/api.py 'Implémentation du protocole IRM/KMI'
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par Météo Bénélux dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Données IRM/KMI | `section` | Non | Cette intégration utilise l’API mobile non documentée de l’Institut royal météorologique de Belgique. Aucun compte ni clé personnelle n’est requis. Le service couvre la Belgique, le Luxembourg et les Pays-Bas ; son interface peut évoluer sans préavis. |
+| Durée du cache (secondes) | `number` | Non | Durée de conservation d’une prévision pour une même position. La valeur 0 désactive le cache. |
+
+## Comment installer Météo Bénélux dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : Météo Bénélux apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/gboulvin/gladys-irm-kmi-v2:1.0.2`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/gboulvin/Gladys-IRM-KMI-V2](https://github.com/gboulvin/Gladys-IRM-KMI-V2).
+
+Météo Bénélux nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+Météo Bénélux est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [gboulvin](https://github.com/gboulvin), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/gboulvin/Gladys-IRM-KMI-V2) — [source de cette documentation](https://github.com/gboulvin/Gladys-IRM-KMI-V2/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/meteo-france.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/meteo-france.mdx
@@ -1,0 +1,148 @@
+---
+title: "Intégration Météo France pour Gladys Assistant"
+sidebar_label: "Météo France"
+description: "Prévisions météo et vigilance officielle Météo France pour la France. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/William-De71--gladys-meteo-france.jpg"
+keywords:
+  - "météo france"
+  - "gladys météo france"
+  - "météo france gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/William-De71/gladys-meteo-france instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="meteo-france" />
+
+Cette intégration fournit à Gladys les **prévisions météo** et la **vigilance officielle** de Météo France. Elle alimente le widget météo du tableau de bord, l'assistant vocal et les scènes déclenchées par une alerte météo.
+
+## Prêt à l'emploi
+
+**Aucune configuration n'est nécessaire.** Les prévisions et la vigilance passent par le service public de Météo France : installez l'intégration, elle fonctionne immédiatement.
+
+Une clé d'API optionnelle permet d'afficher en plus la carte de vigilance nationale (voir plus bas).
+
+## Ce que l'intégration fournit
+
+- **Prévisions heure par heure** sur les 24 prochaines heures : température, ressenti, humidité, pression, vent (vitesse, rafales, direction), pluie et probabilité de précipitations.
+- **Prévisions journalières** sur 8 jours : températures mini/maxi, conditions, cumul de pluie, indice UV, lever et coucher du soleil.
+- **Vigilance officielle** : les neuf phénomènes de Météo France (vent violent, pluie-inondation, orages, crues, neige-verglas, canicule, grand froid, avalanches, vagues-submersion), avec le nom du département et le bulletin complet.
+- **Carte de vigilance** du jour et du lendemain (nécessite la clé d'API).
+
+## Scènes déclenchées par la vigilance
+
+Vous pouvez créer une scène qui se déclenche quand une vigilance est émise, par exemple pour recevoir un SMS en cas de vigilance orange.
+
+Dans l'éditeur de scène, ajoutez un déclencheur **« Alerte météo émise »** ou **« Alerte météo terminée »**, puis choisissez la maison, éventuellement le type de phénomène et le niveau minimum.
+
+Gladys vérifie les alertes toutes les 30 minutes. Cette intégration surveille en plus la vigilance toutes les 15 minutes et prévient Gladys dès qu'elle change : votre scène se déclenche donc en quelques secondes plutôt qu'en attendant la vérification suivante.
+
+## Carte de vigilance (optionnel)
+
+L'affichage de la carte nationale nécessite une clé d'API personnelle, gratuite :
+
+1. Créez un compte sur le [portail API de Météo France](https://portail-api.meteofrance.fr/).
+2. Souscrivez à l'API **« Données Publiques de Vigilance »** (gratuite). Elle apparaît aussi sous le nom **« Bulletin Vigilance »**, et `DPVigilance` dans les adresses techniques : c'est la même API.
+3. Sur l'écran de configuration de l'API, choisissez le type de token **API Key** (et non OAuth2), saisissez une **durée** de validité longue, puis générez la clé — voir les deux points ci-dessous, c'est là que ça se joue.
+4. Dans Gladys, ouvrez l'écran **Configuration** de l'intégration Météo France, collez la clé et enregistrez.
+
+### Clé d'API, et non jeton OAuth2
+
+Sur l'écran **« Configurer l'API Bulletin Vigilance »**, le portail demande un **type de token**. Son guide de démarrage rapide met en avant celui qui ne convient **pas** ici :
+
+|                                               | Utilisable ici | Durée de validité                     |
+| --------------------------------------------- | -------------- | ------------------------------------- |
+| **API Key**                                   | ✅ **oui**     | celle que vous saisissez              |
+| **OAuth2** (jeton du bouton _Generate Token_) | ❌ non         | environ 1 heure, non renouvelable ici |
+
+Cochez donc **API Key**. Un jeton OAuth2 semble fonctionner au début, puis **cesse de marcher au bout d'une heure environ** : la carte disparaît sans message d'erreur particulier. Si votre carte s'affichait et ne s'affiche plus, c'est presque toujours la cause.
+
+### Durée de validité de la clé
+
+Une fois **API Key** coché, le portail affiche un champ **« Durée »** obligatoire, vide par défaut, à renseigner **en secondes**. C'est la durée au bout de laquelle la clé cessera de fonctionner — et donc la carte de vigilance avec elle.
+
+Comme l'intégration utilise cette clé en permanence, saisissez la durée **la plus longue possible**, sans quoi vous devrez la régénérer et la recoller régulièrement.
+
+> **Saisissez `94672800`** (environ 3 ans). C'est la valeur maximale acceptée par le portail : au-delà, il refuse la saisie.
+
+Pour information, si vous préférez une durée plus courte :
+
+| Durée  | Valeur à saisir          |
+| ------ | ------------------------ |
+| 1 mois | `2592000`                |
+| 6 mois | `15552000`               |
+| 1 an   | `31536000`               |
+| ~3 ans | `94672800` — **maximum** |
+
+Notez la date d'expiration quelque part : le jour venu, la carte s'arrêtera sans prévenir, exactement comme avec un jeton OAuth2. Il suffira alors de générer une nouvelle clé et de la recoller dans Gladys.
+
+Sans cette clé, tout le reste continue de fonctionner normalement : seule la carte n'est pas disponible.
+
+## Durée du cache
+
+Le tableau de bord et l'assistant conversationnel demandent tous les deux la météo, et chaque demande représente deux appels à Météo France. L'intégration réutilise donc une réponse récente pendant la **durée du cache**, réglable dans l'écran **Configuration** (600 secondes par défaut, entre 0 et 3600).
+
+Vous n'avez normalement pas à y toucher : les 600 secondes par défaut conviennent à la grande majorité des installations.
+
+### Quelle valeur choisir
+
+Le réglage s'exprime en **secondes**, entre 0 et 3600 (1 heure).
+
+| Valeur                      | Effet                                            |
+| --------------------------- | ------------------------------------------------ |
+| **0**                       | aucun cache, chaque demande appelle Météo France |
+| **300** (5 min)             | données plus fraîches, davantage d'appels        |
+| **600** (10 min) — _défaut_ | bon équilibre, recommandé                        |
+| **1800** (30 min)           | moins d'appels, tableau de bord très réactif     |
+| **3600** (1 h)              | maximum, prévisions pouvant dater d'une heure    |
+
+Augmenter la valeur n'a rien de risqué : Météo France ne met ses prévisions à jour que quelques fois par heure, donc un cache de 10 à 30 minutes ne vous fait pratiquement rien perdre en fraîcheur, tout en accélérant l'affichage.
+
+Deux points à connaître :
+
+- une vigilance qui change est détectée indépendamment du cache : l'intégration vide le cache et demande à Gladys de recharger immédiatement, donc **vos scènes d'alerte se déclenchent sans attendre l'expiration du cache**, même avec un cache réglé à 1 heure ;
+- la valeur **0** désactive le cache et appelle Météo France à chaque demande. L'API de prévisions pouvant mettre jusqu'à 20 secondes à froid, l'affichage du tableau de bord peut alors être nettement plus lent. Réservez-la au diagnostic ponctuel plutôt qu'à un usage permanent.
+
+## Zone couverte
+
+Météo France couvre **la France métropolitaine et les départements d'outre-mer**. Pour une maison située en dehors de cette zone, l'intégration ne renvoie pas de données et Gladys bascule automatiquement sur un autre service météo si vous en avez configuré un.
+
+## Priorité sur OpenWeather
+
+Si vous aviez déjà configuré OpenWeather, l'installation de Météo France prend automatiquement le relais, sans réglage. Si vous arrêtez ou désinstallez l'intégration, Gladys revient tout aussi automatiquement à OpenWeather.
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par Météo France dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Prêt à l'emploi | `section` | Non | Les prévisions et la vigilance fonctionnent sans aucune configuration. La clé d'API optionnelle ci-dessous sert uniquement à afficher la carte de vigilance nationale. |
+| Clé d'API Météo France (optionnelle) | `secret` | Non | Nécessaire uniquement pour afficher la carte de vigilance nationale. Créez un compte gratuit sur le portail API Météo France et souscrivez à l'API « Données Publiques de Vigilance ». Choisissez le type de token « API Key », PAS OAuth2 (qui expire au bout d'une heure environ), et renseignez le champ obligatoire « Durée » avec 94672800 secondes — environ 3 ans, le maximum accepté par le portail. La carte cesse de s'afficher une fois cette durée écoulée. |
+| Durée du cache (s) | `number` | Non | En secondes, entre 0 et 3600. Durée pendant laquelle une réponse est réutilisée avant de rappeler Météo France. L'API de prévisions peut mettre jusqu'à 20 secondes à froid : réutiliser une réponse récente garde le tableau de bord réactif. La valeur par défaut de 600 (10 min) convient à la plupart des installations ; monter à 1800 ne fait presque rien perdre en fraîcheur, Météo France ne mettant à jour que quelques fois par heure. Mettre 0 pour toujours appeler l'API (tableau de bord plus lent). Une vigilance qui change rafraîchit toujours immédiatement, quelle que soit cette valeur. |
+
+## Comment installer Météo France dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : Météo France apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/william-de71/gladys-meteo-france:1.0.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/William-De71/gladys-meteo-france](https://github.com/William-De71/gladys-meteo-france).
+
+Météo France nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+Météo France est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [William-De71](https://github.com/William-De71), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/William-De71/gladys-meteo-france) — [source de cette documentation](https://github.com/William-De71/gladys-meteo-france/blob/HEAD/docs/fr.md)

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/netatmo.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/netatmo.mdx
@@ -128,6 +128,68 @@ Quand la famille Sécurité est activée, chaque caméra est créée avec :
 
 ---
 
+## Webhooks Gladys Plus (temps réel) — optionnel
+
+Par défaut, Gladys interroge Netatmo **toutes les 2 minutes**. Avec les
+webhooks, Netatmo **prévient** Gladys dès qu'il se passe quelque chose : les
+valeurs sont alors rafraîchies en **2-3 secondes** au lieu d'attendre le
+prochain cycle — sans augmenter le nombre d'appels à l'API Netatmo.
+
+Comme une installation Gladys locale n'est pas joignable depuis Internet, c'est
+**Gladys Plus** qui relaie les événements. Il faut donc un abonnement Gladys
+Plus actif.
+
+### Mise en place (une seule étape)
+
+1. Sur l'écran **Configuration** de l'intégration, repérez le bloc
+   **« Webhooks Gladys Plus »** (affiché automatiquement).
+2. Collez-y votre **clé Open API** Gladys Plus. C'est tout.
+
+**Vous n'avez rien à coller sur le site Netatmo :** l'intégration enregistre
+elle-même l'URL auprès de Netatmo, et la ré-enregistre à chaque reconnexion.
+Pour vérifier, ouvrez les **Journaux** de l'intégration : vous devez y voir
+
+```
+Netatmo webhook registered — events will trigger an immediate refresh
+```
+
+Sans clé (ou sans Gladys Plus), l'intégration fonctionne exactement comme avant,
+en interrogation toutes les 2 minutes.
+
+### Ce que ça apporte
+
+- **Les valeurs remontent quasi instantanément** — par exemple une consigne de
+  thermostat changée depuis l'application Netatmo, ou l'état de surveillance
+  d'une caméra.
+- **Des détections utilisables dans vos scènes** (voir ci-dessous).
+
+### Détections en temps réel (déclencheurs de scène)
+
+Certains événements sont **ponctuels** : ils n'existent que dans le flux
+d'événements, aucune interrogation de l'API ne peut les remonter. Ils sont
+publiés comme des fonctionnalités dédiées, utilisables comme **déclencheurs de
+scène** :
+
+| Appareil                        | Fonctionnalité        | Déclenchée par                   |
+| ------------------------------- | --------------------- | -------------------------------- |
+| Caméra intérieure et extérieure | **Mouvement**         | un mouvement détecté             |
+| Caméra intérieure et extérieure | **Personne détectée** | une personne détectée / reconnue |
+| Caméra extérieure (Presence)    | **Animal détecté**    | un animal détecté                |
+| Caméra extérieure (Presence)    | **Véhicule détecté**  | un véhicule détecté              |
+| Détecteur de fumée              | **Fumée**             | une détection de fumée           |
+
+Chaque détection passe à **Oui** puis revient automatiquement à **Non** au bout
+d'une minute (Netatmo n'envoie pas d'événement de « fin de détection »). Dans
+une scène, utilisez donc le déclencheur « la valeur passe à Oui ».
+
+> ⚠️ **Si vos caméras existaient déjà dans Gladys**, ces nouvelles
+> fonctionnalités n'apparaissent pas toutes seules : allez sur l'écran
+> **Découverte** et cliquez sur **Mettre à jour** sur chaque caméra (ou
+> détecteur de fumée) pour les ajouter. Sans webhooks configurés, ces
+> fonctionnalités restent simplement à « Non ».
+
+---
+
 ## Accessoires de sécurité (bridgés par caméra)
 
 Quand la famille Sécurité est activée, les accessoires liés à vos caméras sont
@@ -137,9 +199,9 @@ Quand la famille Sécurité est activée, les accessoires liés à vos caméras 
   (ouvert/fermé), plus la batterie et le signal RF.
 - **Sirène intérieure** (`NIS`) — un capteur sirène en lecture seule, plus la
   batterie et le signal RF.
-- **Détecteur de fumée** (`NSD`) — découvert avec sa batterie et son signal. Son
-  **état de fumée** est délivré par les webhooks (événements temps réel), qui
-  arriveront dans un jalon ultérieur ; le polling seul ne peut pas le remonter.
+- **Détecteur de fumée** (`NSD`) — découvert avec sa batterie et son signal,
+  plus la fonctionnalité **Fumée** alimentée par les webhooks (voir la section
+  ci-dessus) : le polling seul ne peut pas remonter cet état.
 
 ---
 
@@ -197,7 +259,7 @@ Voici les paramètres demandés par Netatmo dans son écran de configuration dan
 ## Comment installer Netatmo dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Netatmo apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/terdious/gladys-netatmo:1.1.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/terdious/gladys-netatmo:1.2.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/Terdious/gladys-netatmo](https://github.com/Terdious/gladys-netatmo).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/openweather.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/openweather.mdx
@@ -81,12 +81,13 @@ maison ou votre préférence d'unité dans Gladys, et cette intégration suit.
 
 ## En cas de problème
 
-| Ce que vous voyez                                                            | Ce que ça veut dire                                                                                                               |
-| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| « OpenWeather rejected the API key (HTTP 401) »                              | La clé est erronée, ou elle n'est pas encore active (attendez jusqu'à quelques heures après sa création).                         |
-| « OpenWeather does not serve /data/3.0/onecall for this account (HTTP 404) » | Vous avez choisi One Call 3.0 sans l'abonnement correspondant. Souscrivez sur le site d'OpenWeather, ou revenez à l'API gratuite. |
-| « OpenWeather quota exceeded (HTTP 429) »                                    | Trop d'appels. Augmentez la durée du cache, ou changez d'offre OpenWeather.                                                       |
-| Le widget affiche la météo mais aucune alerte                                | Les alertes météo n'existent que sur One Call 3.0, et uniquement là où un service météorologique en a émis une.                   |
+| Ce que vous voyez                                                            | Ce que ça veut dire                                                                                                                                                                                                                        |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| « OpenWeather rejected the API key (HTTP 401) »                              | La clé est erronée, ou elle n'est pas encore active (attendez jusqu'à quelques heures après sa création).                                                                                                                                  |
+| « OpenWeather does not serve /data/3.0/onecall for this account (HTTP 404) » | Vous avez choisi One Call 3.0 sans l'abonnement correspondant. Souscrivez sur le site d'OpenWeather, ou revenez à l'API gratuite.                                                                                                          |
+| « OpenWeather quota exceeded (HTTP 429) »                                    | Trop d'appels. Augmentez la durée du cache, ou changez d'offre OpenWeather.                                                                                                                                                                |
+| Le widget affiche la météo mais aucune alerte                                | Les alertes météo n'existent que sur One Call 3.0, et uniquement là où un service météorologique en a émis une.                                                                                                                            |
+| Le texte d'une alerte est en anglais                                         | OpenWeather diffuse les bulletins d'alerte en anglais quelle que soit la langue demandée, c'est une limite de leur API. Le libellé de l'alerte, lui, est traduit par Gladys dès que le phénomène est reconnu (vent, pluie, orage, neige…). |
 
 L'intégration journalise chaque requête qu'elle effectue : consultez les logs de
 l'intégration depuis l'interface de Gladys (ou `docker logs` sur l'hôte).
@@ -107,7 +108,7 @@ Voici les paramètres demandés par OpenWeather dans son écran de configuration
 ## Comment installer OpenWeather dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : OpenWeather apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/gladysassistant/gladys-openweather:1.0.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/gladysassistant/gladys-openweather:1.0.2`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/GladysAssistant/gladys-openweather](https://github.com/GladysAssistant/gladys-openweather).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/overkiz.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/overkiz.mdx
@@ -72,7 +72,7 @@ Voici les paramètres demandés par Overkiz dans son écran de configuration dan
 ## Comment installer Overkiz dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Overkiz apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/cicoub13/gladys-overkiz:1.1.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/cicoub13/gladys-overkiz:1.1.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/cicoub13/gladys-overkiz](https://github.com/cicoub13/gladys-overkiz).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/pollens.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/pollens.mdx
@@ -22,7 +22,8 @@ import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationH
 
 Cette intégration expose le **risque pollinique** des lieux de votre choix sous
 forme d'appareils Gladys : un appareil par lieu, avec un niveau de risque de
-0 à 5 pour chaque type de pollen.
+0 à 5 pour chaque type de pollen. Vous ajoutez vos **maisons Gladys en un clic**,
+ou un lieu en saisissant sa **commune**.
 
 Aucun compte à créer, aucune clé d'API à saisir.
 
@@ -46,6 +47,33 @@ mondiale : il n'y a donc aucun pays à choisir nulle part dans l'intégration.
 > chaque utilisateur devrait créer avant même que l'intégration fonctionne. La
 > source CAMS a été retenue parce qu'elle est officielle _et_ utilisable sans
 > aucune démarche.
+
+## Ajouter vos maisons Gladys, en un clic
+
+Vous avez déjà dit à Gladys où vous habitez : c'est la carte de **Réglages >
+Maisons**. Le bouton **« Ajouter mes maisons Gladys »** lit ces maisons et crée
+un lieu pour chacune qui n'est pas déjà surveillée — aucune commune à saisir.
+
+Quatre choses à savoir :
+
+- **L'accès est une autorisation.** L'endroit où vous vivez est une donnée
+  personnelle : Gladys ne la partage que si vous l'avez accepté sur l'écran
+  d'installation de l'intégration. Si le bouton répond que l'accès est refusé,
+  supprimez puis réinstallez l'intégration en acceptant la demande affichée.
+- **Une maison sans position sur la carte n'a pas de coordonnées.** Elle est
+  nommée dans la réponse, et il suffit de la placer dans Réglages > Maisons puis
+  de relancer l'action.
+- **Une maison hors du domaine européen CAMS** est nommée elle aussi, et laissée
+  de côté : aucune prévision pollinique ne la couvre (voir « Couverture
+  géographique » plus bas).
+- **Ce n'est pas une synchronisation.** Les maisons sont lues au moment du clic.
+  Le lieu obtenu est un lieu ordinaire, que vous renommez et supprimez comme les
+  autres, et une maison déplacée dans Gladys ensuite ne déplace pas son lieu.
+
+Relancer l'action est sans risque : une maison déjà surveillée est signalée, pas
+ajoutée une deuxième fois.
+
+Cette lecture des maisons demande **Gladys 4.85.0 ou plus récent**.
 
 ## Ajouter un lieu
 
@@ -99,19 +127,20 @@ supprimer un deuxième.
 
 ## Ce que mesure l'appareil
 
-Chaque appareil expose neuf mesures :
+Chaque appareil expose dix mesures :
 
-| Mesure                           | Description                                      |
-| -------------------------------- | ------------------------------------------------ |
-| Risque pollinique global         | Le plus élevé des six risques ci-dessous (0 à 5) |
-| Risque pollinique global (texte) | Le même niveau, écrit en toutes lettres          |
-| Pollen dominant                  | Le nom du pollen responsable du risque global    |
-| Risque pollinique — Aulne        | Risque de 0 à 5                                  |
-| Risque pollinique — Bouleau      | Risque de 0 à 5                                  |
-| Risque pollinique — Graminées    | Risque de 0 à 5                                  |
-| Risque pollinique — Armoise      | Risque de 0 à 5                                  |
-| Risque pollinique — Olivier      | Risque de 0 à 5                                  |
-| Risque pollinique — Ambroisie    | Risque de 0 à 5                                  |
+| Mesure                           | Description                                                    |
+| -------------------------------- | -------------------------------------------------------------- |
+| Risque pollinique global         | Le plus élevé des six risques ci-dessous (0 à 5)               |
+| Risque pollinique global (texte) | Le même niveau, écrit en toutes lettres                        |
+| Pollen dominant                  | Le nom du pollen responsable du risque global                  |
+| Dernière mise à jour des données | La date et l'heure auxquelles la prévision affichée correspond |
+| Risque pollinique — Aulne        | Risque de 0 à 5                                                |
+| Risque pollinique — Bouleau      | Risque de 0 à 5                                                |
+| Risque pollinique — Graminées    | Risque de 0 à 5                                                |
+| Risque pollinique — Armoise      | Risque de 0 à 5                                                |
+| Risque pollinique — Olivier      | Risque de 0 à 5                                                |
+| Risque pollinique — Ambroisie    | Risque de 0 à 5                                                |
 
 L'échelle de risque est la suivante :
 
@@ -137,6 +166,29 @@ pollinique de votre commune sur un graphique.
 Lorsque le modèle n'a pas de valeur pour une espèce à cet endroit, **aucune
 valeur n'est publiée** pour cette espèce — une absence de mesure n'est pas un
 risque nul.
+
+### Depuis quand ces chiffres datent-ils ?
+
+La mesure **Dernière mise à jour des données** répond à cette question. Elle
+affiche la date et l'heure auxquelles correspond la prévision affichée, au
+format `06/08/2026 13:00`.
+
+C'est bien la date **des données**, pas celle de la dernière interrogation :
+CAMS publie sa prévision une fois par jour et Open-Meteo l'interpole heure par
+heure, donc un rafraîchissement réussi relit le plus souvent exactement les
+mêmes chiffres. Ce que l'on veut savoir, c'est l'âge de ces chiffres, pas
+l'heure à laquelle on est allé les rechercher.
+
+L'heure affichée est celle **du lieu** : la prévision d'un lieu se lit à
+l'horloge de la commune qu'elle couvre. Pour un lieu dans votre fuseau horaire,
+c'est donc simplement votre heure ; pour un lieu dans un autre fuseau, c'est
+l'heure locale là-bas. C'est aussi pourquoi cette mesure se trouve **sur chaque
+appareil** plutôt que sur un appareil unique commun à toute l'intégration : deux
+lieux n'ont pas forcément la même.
+
+Si la prévision reste bloquée sur une date ancienne, c'est que le
+rafraîchissement échoue : le bouton **Tester le fournisseur de pollens** affiche
+la même date pour chaque lieu, et dit ce qui coince le cas échéant.
 
 > Sur un tableau de bord, la tuile « appareil dans une pièce » traduit une valeur
 > de risque avec les libellés que Gladys connaît, qui s'arrêtent à 3 : les
@@ -191,8 +243,9 @@ de valeur.
 
 - **Bouton « Tester le fournisseur de pollens »** : il interroge la source en
   direct pour _tous_ vos lieux et affiche une ligne par lieu, numérotée comme la
-  liste. C'est le test le plus rapide pour savoir si le problème vient du réseau
-  ou de la configuration.
+  liste. Chaque ligne se termine par la date des données lues : une source
+  bloquée dans le passé se voit donc ici aussi. C'est le test le plus rapide
+  pour savoir si le problème vient du réseau ou de la configuration.
 - **Les journaux** : consultez les logs de l'intégration depuis l'interface
   Gladys, ou avec `docker logs`. Passez `LOG_LEVEL` à `debug` pour voir les URL
   interrogées et le contenu exact envoyé à Gladys.
@@ -213,16 +266,16 @@ Voici les paramètres demandés par Pollens dans son écran de configuration dan
 | Réglages généraux | `section` | Non | Ces réglages s'appliquent à tous les lieux configurés. |
 | Langue du nom des appareils | `select` | Non | La langue dans laquelle sont écrits les noms de pollens : « Bouleau » ou « Birch ». Tout le reste de ce que l'intégration affiche suit déjà la langue de votre compte Gladys, mais le nom d'un appareil et de ses fonctionnalités est enregistré tel qu'il est publié : il faut donc le choisir ici. Un appareil déjà ajouté à Gladys conserve les noms avec lesquels il a été créé : supprimez-le et rajoutez-le depuis l'onglet Découverte pour le renommer. |
 | Intervalle de rafraîchissement (s) | `number` | Non | Fréquence de rafraîchissement de chaque lieu, en secondes. La prévision est mise à jour une fois par jour et interpolée à l'heure : descendre sous une heure n'apporte rien. |
-| Vos lieux | `section` | Non | Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste. |
+| Vos lieux | `section` | Non | Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. « Ajouter mes maisons Gladys » transforme en lieux, en un clic, les maisons que vous avez déjà placées sur la carte dans Gladys. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste. |
 
 ## Comment installer Pollens dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Pollens apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-pollen:1.0.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-pollen:1.0.3`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/prohand/gladys-pollen](https://github.com/prohand/gladys-pollen).
 
-Pollens nécessite Gladys `>=4.62.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+Pollens nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
 
 Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/prix-carburants.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/prix-carburants.mdx
@@ -41,12 +41,37 @@ Pour **chaque station que vous ajoutez**, un appareil avec deux mesures :
 
 - **Prix** — le prix au litre du carburant choisi, en euros. L'historique est
   conservé : Gladys trace la courbe du prix dans le temps.
-- **Dernière mise à jour** — la date à laquelle la station a déclaré ce prix
-  (le flux national est rafraîchi toutes les 10 minutes environ, mais une
-  station donnée ne change pas ses prix tous les jours).
+- **Dernière mise à jour** — la date à laquelle la station a déclaré ce prix,
+  affichée sous la forme `06/08/2026 à 07:12`, à l'heure locale de la station.
+  Le flux national est rafraîchi toutes les 10 minutes environ, mais une
+  station donnée ne change pas ses prix tous les jours : cette date vous dit
+  quel âge a réellement le prix affiché au-dessus. Elle est relevée par station
+  **et** par carburant : le gazole et le SP98 d'une même station ont chacun la
+  leur.
 
 L'adresse, la marque, les coordonnées GPS et la distance au code postal sont
 enregistrées dans les paramètres de l'appareil.
+
+### L'appareil « Prix carburants - Mise à jour des données »
+
+En plus des stations, l'onglet Découverte propose **un appareil unique, commun
+à toute l'intégration**, avec une seule mesure :
+
+- **Dernière lecture des données** — la date et l'heure, au format
+  `08/08/2026 à 21:00`,
+  auxquelles l'intégration a lu le flux open data pour la dernière fois **avec
+  succès**.
+
+C'est une information différente de la « Dernière mise à jour » d'une station :
+celle-ci vous dit quand la station a bougé ses prix (ce qui peut remonter à une
+semaine, tout à fait normalement), celle-là vous dit si l'intégration arrive
+encore à joindre l'API nationale. Si cette date se met à vieillir alors que
+votre intervalle de rafraîchissement est d'une heure, c'est que la source de
+données ne répond plus.
+
+Cet appareil est facultatif : ne l'ajoutez pas et l'intégration fonctionne
+exactement pareil. Ajouté, il est mis à jour à la fin de chaque
+rafraîchissement, et il reste vide tant qu'aucune lecture n'a encore réussi.
 
 L'appareil porte le nom de l'enseigne de la station et de sa commune, par
 exemple `Total Access - Oullins-Pierre-Bénite - SP98`. Le flux national des prix
@@ -61,7 +86,9 @@ garde un nom construit à partir de sa rue.
 3. Renseignez votre **code postal** (5 chiffres en France, par exemple
    `35000`). C'est autour de lui que les stations sont cherchées.
 4. Réglez le **rayon de recherche** : `0` ne garde que les stations du code
-   postal lui-même, `10` km élargit aux communes voisines.
+   postal lui-même, `10` km élargit aux communes voisines. Un code postal sans
+   station-service ne pose pas de problème : la recherche est quand même
+   centrée sur votre commune, les pompes de la commune d'à côté apparaissent.
 5. Cochez le ou les **types de carburant** qui vous intéressent : Gazole,
    SP95, SP98, E10, E85, GPLc.
 6. Enregistrez.
@@ -133,13 +160,24 @@ courbe.
 la liste de découverte (20 par défaut, 50 au maximum). En ville dense,
 baissez-le et réduisez le rayon.
 
+**Une station précise n'apparaît pas.** La liste retient les stations les plus
+PROCHES, dans la limite de ce maximum : en ville, vingt stations tiennent dans
+deux kilomètres, une station à 5 km est donc écartée même avec un rayon de
+10 km. Augmentez le **Nombre maximum de stations** plutôt que le rayon. Une
+station qui ne déclare aucun prix pour le carburant coché n'est pas proposée
+non plus, l'appareil n'aurait rien à publier.
+
 ## Données et licence
 
 Les données sont publiées par le ministère de l'Économie sous
 [licence Etalab](https://www.etalab.gouv.fr/licence-ouverte-open-licence).
 L'intégration interroge le
 [jeu de données « flux instantané »](https://data.economie.gouv.fr/explore/dataset/prix-des-carburants-en-france-flux-instantane-v2/)
-et ne récupère que les stations autour de votre code postal.
+et ne récupère que les stations autour de votre code postal. Quand ce jeu de
+données ne connaît aucune station dans votre code postal, la position de votre
+commune est lue dans la
+[Base Adresse Nationale](https://adresse.data.gouv.fr/), le service d'adresses
+officiel — seul le code postal lui est transmis.
 
 ## Paramètres de configuration
 
@@ -158,7 +196,7 @@ Voici les paramètres demandés par Prix carburants dans son écran de configura
 ## Comment installer Prix carburants dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Prix carburants apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-prixcarburants:1.0.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-prixcarburants:1.0.3`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/prohand/gladys-prixcarburants](https://github.com/prohand/gladys-prixcarburants).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/qualite-de-l-air.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/qualite-de-l-air.mdx
@@ -21,11 +21,36 @@ import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationH
 <ExternalIntegrationHeader slug="qualite-de-l-air" />
 
 Suivez l'indice de qualité de l'air des lieux de votre choix dans Gladys, avec
-un appareil par lieu. Vous ajoutez un lieu en saisissant simplement le nom de sa
-**commune**, **n'importe où dans le monde**.
+un appareil par lieu. Vous ajoutez vos **maisons Gladys en un clic**, ou un lieu
+en saisissant simplement le nom de sa **commune**, **n'importe où dans le
+monde**.
 
 Aucun compte à créer, aucune clé d'API à saisir : les deux sources utilisées
 sont ouvertes et publiques.
+
+## Ajouter vos maisons Gladys, en un clic
+
+Vous avez déjà dit à Gladys où vous habitez : c'est la carte de **Réglages >
+Maisons**. Le bouton **« Ajouter mes maisons Gladys »** lit ces maisons et crée
+un lieu pour chacune qui n'est pas déjà surveillée — aucune commune à saisir.
+
+Trois choses à savoir :
+
+- **L'accès est une autorisation.** L'endroit où vous vivez est une donnée
+  personnelle : Gladys ne la partage que si vous l'avez accepté sur l'écran
+  d'installation de l'intégration. Si le bouton répond que l'accès est refusé,
+  supprimez puis réinstallez l'intégration en acceptant la demande affichée.
+- **Une maison sans position sur la carte n'a pas de coordonnées.** Elle est
+  nommée dans la réponse, et il suffit de la placer dans Réglages > Maisons puis
+  de relancer l'action.
+- **Ce n'est pas une synchronisation.** Les maisons sont lues au moment du clic.
+  Le lieu obtenu est un lieu ordinaire, que vous renommez et supprimez comme les
+  autres, et une maison déplacée dans Gladys ensuite ne déplace pas son lieu.
+
+Relancer l'action est sans risque : une maison déjà surveillée est signalée, pas
+ajoutée une deuxième fois. Un lieu venu d'une maison n'a pas de libellé
+d'adresse : la liste affiche son nom et son point, car le géocodeur ne sait pas
+nommer la commune qui contient un point.
 
 ## Ajouter un lieu
 
@@ -105,6 +130,7 @@ Chaque appareil expose :
 | **Polluant dominant**                         | le polluant qui a déterminé l'indice                            |
 | **Sous-indice PM2,5 / PM10 / NO₂ / O₃ / SO₂** | de 1 à 6, polluant par polluant                                 |
 | **PM2,5** et **PM10**                         | la concentration, en µg/m³                                      |
+| **Dernière mise à jour des données**          | l'heure de la donnée, en heure locale du lieu                   |
 
 Les six classes de l'indice :
 
@@ -124,6 +150,13 @@ suffit à dégrader l'air.
 Seuls PM2,5 et PM10 ont en plus une fonctionnalité de concentration : ce sont
 les seuls polluants pour lesquels Gladys dispose d'une catégorie dédiée. Le
 NO₂, l'O₃ et le SO₂ sont portés par leur sous-indice.
+
+La **dernière mise à jour des données** est l'heure de l'analyse CAMS pour ce
+lieu, pas celle du dernier passage de l'intégration : le modèle tourne toutes
+les heures, donc rafraîchir plus souvent ne change pas cette heure. Elle est
+affichée en **heure locale du lieu** (suivie de son fuseau, `CEST`, `GMT+9`…),
+et c'est pourquoi elle est portée par chaque appareil : deux lieux peuvent
+légitimement afficher deux heures différentes.
 
 Un polluant pour lequel la source n'a **aucune valeur** ne publie rien du tout.
 Une mesure absente n'est pas un air pur : écrire 1 fausserait l'historique et
@@ -215,16 +248,16 @@ Voici les paramètres demandés par Qualité de l'air dans son écran de configu
 | Réglages généraux | `section` | Non | Ces réglages s'appliquent à tous les lieux configurés. |
 | Langue du nom des appareils | `select` | Non | La langue dans laquelle sont écrits les noms des polluants et des mesures : « Polluant dominant » ou « Dominant pollutant ». Tout le reste de ce que l'intégration affiche suit déjà la langue de votre compte Gladys, mais le nom d'un appareil et de ses fonctionnalités est enregistré tel qu'il est publié : il faut donc le choisir ici. Un appareil déjà ajouté à Gladys conserve les noms avec lesquels il a été créé : supprimez-le et rajoutez-le depuis l'onglet Découverte pour le renommer. |
 | Intervalle de rafraîchissement (s) | `number` | Non | Fréquence de rafraîchissement de chaque lieu, en secondes. L'analyse CAMS est produite une fois par heure : descendre sous une heure n'apporte rien. |
-| Vos lieux | `section` | Non | Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste. |
+| Vos lieux | `section` | Non | Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. « Ajouter mes maisons Gladys » les ajoute toutes en un clic, à partir des maisons que vous avez déjà placées sur la carte dans Gladys. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste. |
 
 ## Comment installer Qualité de l'air dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Qualité de l'air apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-airquality:1.0.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-airquality:1.0.3`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/prohand/gladys-airquality](https://github.com/prohand/gladys-airquality).
 
-Qualité de l'air nécessite Gladys `>=4.62.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+Qualité de l'air nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
 
 Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/reolink.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/reolink.mdx
@@ -157,7 +157,7 @@ Voici les paramètres demandés par Reolink dans son écran de configuration dan
 ## Comment installer Reolink dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Reolink apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/william-de71/gladys-reolink:1.0.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/william-de71/gladys-reolink:1.0.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/William-De71/gladys-reolink](https://github.com/William-De71/gladys-reolink).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/roborock.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/roborock.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Intégration Roborock pour Gladys Assistant"
 sidebar_label: "Roborock"
-description: "Aspirateurs robots de l'application Roborock : état, marche/arrêt, aspiration, base, batterie. Gratuite, open source, installable en un clic."
+description: "Aspirateurs robots de l'application Roborock : état, marche/arrêt, aspiration, base, routines. Gratuite, open source, installable en un clic."
 image: "https://integration-store-storage.gladysassistant.com/covers/callemand--gladys-roborock.jpg"
 keywords:
   - "roborock"
@@ -42,6 +42,9 @@ Pour chaque robot de votre compte :
   turbo, max, doux).
 - **Base** — renvoyer le robot vers sa base de charge.
 - **Batterie** — le niveau de batterie actuel, en pourcentage.
+- **Routines** — un bouton par routine enregistrée dans l'application Roborock.
+  Son appui conserve toute sa personnalisation : pièces, zones, ordre, mode de
+  nettoyage et nombre de passages.
 
 ## Configuration
 
@@ -98,7 +101,7 @@ Voici les paramètres demandés par Roborock dans son écran de configuration da
 ## Comment installer Roborock dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Roborock apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/callemand/gladys-roborock:2.1.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/callemand/gladys-roborock:2.2.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/callemand/gladys-roborock](https://github.com/callemand/gladys-roborock).
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/saunier-duval.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/saunier-duval.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Intégration Saunier Duval pour Gladys Assistant"
 sidebar_label: "Saunier Duval"
-description: "Pilotez votre chauffage Saunier Duval (MiGo) : températures, humidité, état et consigne. Gratuite, open source, installable en un clic."
+description: "Pilotez votre chaudière Saunier Duval via votre compte MiGo / MiGo Link. Gratuite, open source, installable en un clic."
 image: "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-Vaillant-SaunierDuval.png"
 keywords:
   - "saunier duval"
@@ -20,124 +20,196 @@ import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationH
 
 <ExternalIntegrationHeader slug="saunier-duval" />
 
-Cette intégration relie Gladys Assistant à votre chauffage Saunier Duval via le
-cloud du groupe Vaillant — le même service que celui utilisé par l'application
-**MiGo** sur votre téléphone.
+Cette intégration relie votre chaudière **Saunier Duval** à Gladys Assistant :
+températures, consignes, modes de chauffage et eau chaude sanitaire deviennent
+des appareils Gladys, utilisables dans vos scènes et vos graphiques.
 
-Elle vous permet de :
+Elle passe par le **cloud Saunier Duval**, celui de l'application mobile
+**MiGo** / **MiGo Link**. Il n'existe pas d'accès local à ces chaudières :
+tout transite par Internet, et votre passerelle doit donc être en ligne.
 
-- lire la température ambiante mesurée par le thermostat ;
-- lire l'humidité mesurée par le thermostat (selon le modèle) ;
-- lire la température extérieure ;
-- lire l'état de la chaudière (en train de chauffer ou à l'arrêt) ;
-- lire la température de consigne ;
-- **modifier** la température de consigne ;
-- **modifier** l'état de la chaudière (allumer ou éteindre le chauffage).
+## Ce dont vous avez besoin
 
-## Matériel compatible
+- Une chaudière Saunier Duval reliée à une passerelle **MiGo** ou **MiGo Link**
+  (ou un thermostat connecté MiPro Sense / Exacontrol relié à une passerelle).
+- Le **compte** que vous utilisez déjà dans l'application mobile : la même
+  adresse e-mail et le même mot de passe.
+- Le **pays** dans lequel ce compte a été créé.
 
-Toute installation Saunier Duval déjà pilotée depuis l'application MiGo :
+Vous n'avez rien à installer sur la chaudière, ni à demander de clé d'API.
 
-- passerelle **MiGo** ou **MiGo Link** associée à une chaudière (ThemaPlus
-  Condens, Isotwin, Duomax…) ;
-- régulations basées sur un contrôleur **VRC700** (MiPro, MiPro Sense).
+## Installation
 
-Une même installation peut comporter plusieurs zones de chauffage : Gladys crée
-alors un thermostat par zone.
+1. Dans Gladys, ouvrez **Intégrations → Installer une intégration** et
+   installez **Saunier Duval**.
+2. Ouvrez l'écran de configuration de l'intégration et renseignez :
+   - **E-mail** : l'adresse de votre compte MiGo / MiGo Link ;
+   - **Mot de passe** : celui du même compte. Gladys le stocke chiffré et ne le
+     renvoie jamais au navigateur ;
+   - **Pays du compte** : celui dans lequel le compte a été créé. C'est
+     important : un compte créé en France ne peut pas se connecter via un autre
+     pays, la connexion serait refusée sans autre explication ;
+   - **Intervalle de rafraîchissement** : toutes les combien de secondes la
+     chaudière est interrogée. 300 s (5 minutes) est un bon réglage — une
+     chaudière est un système lent, et la plateforme Saunier Duval limite le
+     nombre d'appels ;
+   - **Durée de forçage par défaut** : la durée d'où part chaque zone. Vous la
+     réglez ensuite zone par zone, voir « Changer une température » plus bas.
+3. Cliquez sur **Tester la connexion**. Le message vous indique le nombre
+   d'installations trouvées sur votre compte.
+4. Ouvrez l'onglet **Appareils** de l'intégration : vos appareils y sont déjà
+   listés. Choisissez ceux que vous souhaitez créer dans Gladys.
 
-> Les comptes **Bulex** (Belgique) utilisent le même service, mais un pays
-> différent de ceux proposés ici. Cette intégration cible les comptes Saunier
-> Duval.
+## Les appareils créés
 
-## Prérequis
+Pour chaque installation, l'intégration crée :
 
-1. Une passerelle MiGo déjà installée et **appairée dans l'application MiGo**.
-   Cette intégration ne fait pas l'appairage : elle lit le compte, elle ne le
-   configure pas.
-2. L'adresse e-mail et le mot de passe de ce compte MiGo.
-3. Le **pays** dans lequel le compte a été créé. C'est la cause d'erreur la plus
-   fréquente : un pays incorrect fait échouer la connexion, même avec un mot de
-   passe valide.
+| Appareil                                 | Ce qu'il expose                                                                                                                                                                           |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Chaudière**                            | Température extérieure (instantanée et moyenne 24 h), pression d'eau du circuit de chauffage, activité en cours (chauffage, eau chaude, veille), nombre de codes de défaut et leur détail |
+| **Zone** (une par zone de chauffage)     | Température ambiante, humidité (si votre thermostat la mesure), consigne de température, mode, durée du forçage, et si le chauffage tourne actuellement                                   |
+| **Circuit** (un par circuit hydraulique) | Température de départ réellement produite, consigne de départ calculée par la loi d'eau, état du circuit                                                                                  |
+| **Eau chaude**                           | Température de l'eau, consigne, mode, bouton **Boost**, et si la chaudière est en train de chauffer l'eau                                                                                 |
 
-## Configuration
+Les zones portent le nom que vous leur avez donné dans la chaudière (« Salon »,
+« Étage »…). Une zone déclarée inactive dans la chaudière est ignorée : elle ne
+renvoie aucune valeur.
 
-Dans Gladys, ouvrez la configuration de l'intégration et renseignez :
+La **pression d'eau** est la valeur à surveiller : si elle descend sous ~1 bar,
+l'installation demande un appoint. Une scène Gladys peut vous prévenir.
 
-| Champ                              | Description                                                                                        |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------- |
-| **Adresse e-mail**                 | L'identifiant de votre compte MiGo.                                                                |
-| **Mot de passe**                   | Le mot de passe du compte. Il est stocké chiffré par Gladys et n'est jamais renvoyé au navigateur. |
-| **Pays**                           | Le pays d'enregistrement du compte (France par défaut).                                            |
-| **Quand le chauffage est allumé**  | Le mode auquel la zone revient quand vous rallumez le chauffage.                                   |
-| **Durée d'un forçage temporaire**  | La durée d'une consigne posée alors que la zone suit son programme.                                |
-| **Intervalle de rafraîchissement** | La fréquence de lecture des mesures, en secondes.                                                  |
+## Changer une température
 
-Cliquez ensuite sur **Tester la connexion** : le bouton affiche les
-installations trouvées sur le compte et les températures lues. Si ce test passe,
-tout le reste fonctionnera.
+La valeur affichée dans le champ « Température de consigne » est celle que vous
+éditez : la **température manuelle**, celle que montre l'application Saunier
+Duval — ou la température du forçage temporaire tant qu'il est en cours.
 
-## Appareils créés
+Ce n'est volontairement pas la « demande du moment » de la chaudière : celle-ci
+tombe à 0 dès que le chauffage n'a rien à faire (zone programmée hors de ses
+plages, mode été), et un champ de saisie initialisé à 0 ne servirait à rien.
 
-Pour chaque installation, Gladys crée deux appareils.
+La chaudière n'a pas une consigne unique : ce qui est écrit dépend du mode dans
+lequel se trouve la zone.
 
-**Le thermostat** (un par zone de chauffage) :
+- **Zone en mode programmé** (« Auto ») : changer la température déclenche un
+  **forçage temporaire**. La nouvelle consigne s'applique pendant la durée que
+  vous avez choisie, puis le programme horaire reprend la main. C'est
+  exactement ce que fait l'application mobile quand vous tournez la molette sur
+  une zone programmée : votre programmation n'est jamais écrasée.
+- **Zone en mode manuel** : la consigne est écrite durablement, jusqu'au
+  prochain changement.
+- **Zone à l'arrêt** : la commande est refusée avec un message clair. Changez
+  d'abord le mode de la zone.
 
-| Fonctionnalité             | Lecture / écriture |
-| -------------------------- | ------------------ |
-| Température                | Lecture            |
-| Humidité                   | Lecture            |
-| Température de consigne    | Lecture + écriture |
-| Chauffage (marche / arrêt) | Lecture + écriture |
+### Durée du forçage
 
-**La chaudière** (une par installation) :
+Chaque zone porte une commande **« Durée du forçage »**, réglable de **30
+minutes à 24 heures**, comme dans l'application. Vous la réglez avant de
+changer la température : c'est cette durée que le forçage suivant utilisera.
 
-| Fonctionnalité         | Lecture / écriture |
-| ---------------------- | ------------------ |
-| Température extérieure | Lecture            |
-| État de la chaudière   | Lecture            |
-| Pression d'eau         | Lecture            |
+Elle est exprimée en **minutes** et non en heures, pour une raison précise : le
+curseur de Gladys avance par pas d'une unité, donc en heures les demi-heures
+seraient hors d'atteinte. En minutes, toutes les valeurs de l'application
+restent accessibles. Une valeur qui ne tombe pas juste est ramenée à la
+demi-heure la plus proche (100 minutes → 1 h 30), exactement comme le fait la
+chaudière.
 
-L'humidité et la pression d'eau ne sont créées que si votre installation les
-remonte réellement.
+Cette commande ne parle pas à la chaudière : la plateforme n'accepte la durée
+qu'au moment où le forçage démarre, avec la température. C'est donc un réglage
+de l'intégration, que Gladys mémorise et qui est relu après un redémarrage. La
+valeur de départ d'une zone est celle de l'écran de configuration.
 
-## Comment la consigne est appliquée
+### Correspondance des modes
 
-Le comportement dépend du mode dans lequel se trouve la zone, afin que la valeur
-choisie dans Gladys soit bien celle que le régulateur vise :
+| Mode Gladys | Zone de chauffage                                           | Eau chaude        |
+| ----------- | ----------------------------------------------------------- | ----------------- |
+| Arrêt       | Arrêt                                                       | Arrêt             |
+| Chauffage   | Manuel (ou « Jour » sur les régulateurs MiPro / Exacontrol) | Manuel / « Jour » |
+| Auto        | Programmé                                                   | Programmé         |
 
-- **La zone suit son programme hebdomadaire** → un forçage temporaire est
-  appliqué, exactement comme si vous tourniez la molette du thermostat. Il dure
-  le nombre d'heures configuré, puis le programme reprend la main.
-- **La zone est en mode manuel** → la consigne manuelle est modifiée
-  durablement.
-- **La zone est éteinte** → le chauffage est rallumé en mode manuel à la
-  température demandée : demander une température, c'est demander de la chaleur.
+Ce sont les **trois seuls** modes proposés, sur la zone de chauffage comme sur
+l'eau chaude : les mêmes que dans l'application Saunier Duval, et dans le même
+ordre. Gladys connaît d'autres valeurs — « Refroidissement » pour un
+thermostat, « Éco », « Absence », « Boost » pour un chauffe-eau — mais
+l'intégration lui déclare les modes que votre chaudière accepte réellement,
+donc ces boutons n'apparaissent pas.
 
-Le bouton **Chauffage** éteint la zone (mode `OFF`) ou la rallume dans le mode
-choisi dans la configuration (programme hebdomadaire par défaut).
+En revanche, **les mots ne sont pas les mêmes des deux côtés**, et cela ne
+dépend pas de l'intégration : chaque catégorie a son vocabulaire dans Gladys.
+Ce sont pourtant bien les trois mêmes notions.
 
-## Limites connues
+| Application Saunier Duval | Zone de chauffage (Gladys) | Eau chaude (Gladys) |
+| ------------------------- | -------------------------- | ------------------- |
+| Manuel                    | Chauffage                  | Manuel              |
+| Programmation             | Auto                       | Programmation       |
+| Chauffage éteint / Arrêt  | Arrêt                      | Arrêt               |
 
-- **La passerelle est lente.** Elle ne remonte ses mesures au cloud que toutes
-  les quelques minutes : descendre l'intervalle de rafraîchissement sous 300
-  secondes n'apporte rien et multiplie les appels.
-- **Un changement met un moment à apparaître.** Après une commande, le cloud
-  peut mettre une à deux minutes à refléter la nouvelle valeur.
-- **API non publique.** Saunier Duval ne documente pas cette API : elle est
-  utilisée par l'application mobile. Elle peut évoluer sans préavis.
-- **Un seul compte à la fois.** L'intégration lit toutes les installations d'un
-  compte, mais un seul compte peut être configuré.
+Sur les anciens régulateurs, le mode « Abaissement » (chauffage permanent à la
+température réduite) est lu comme « Chauffage » lui aussi — Gladys n'a pas de
+valeur qui lui corresponde exactement.
+
+## Boost eau chaude
+
+Le **Boost** demande à la chaudière de chauffer le ballon tout de suite, en
+dehors du programme. La chaudière l'arrête d'elle-même une fois le ballon
+chaud : Gladys repassera l'état à « désactivé » au rafraîchissement suivant.
+
+> Sur les versions de Gladys antérieures au correctif
+> [#2815](https://github.com/GladysAssistant/Gladys/pull/2815), le bouton grisé
+> du couple affiche l'état inverse de la réalité (« Boost actif » alors que le
+> boost est éteint). Le bouton cliquable, lui, est correct. C'est un défaut
+> d'affichage du cœur de Gladys, pas de l'intégration : mettre Gladys à jour le
+> corrige.
+
+## Points d'attention
+
+- **Délai d'affichage.** Après une commande, Gladys affiche immédiatement la
+  valeur demandée, puis la remplace par celle que la chaudière confirme au
+  cycle suivant. Il est normal qu'un ou deux rafraîchissements soient
+  nécessaires pour voir l'effet réel.
+- **Limitation d'appels.** La plateforme Saunier Duval limite le nombre de
+  requêtes, et vous la partagez avec l'application mobile. Un cycle de
+  rafraîchissement coûte **une seule requête par installation** : toutes les
+  valeurs publiées viennent d'une même réponse. La liste des installations,
+  l'état de la passerelle et les codes de défaut sont relus séparément, toutes
+  les 30 minutes seulement — c'est pourquoi une passerelle qui vient de passer
+  hors ligne peut mettre jusqu'à une demi-heure à être signalée comme telle.
+  Ne descendez pas l'intervalle sans raison : 60 secondes est le minimum
+  autorisé, 300 secondes le réglage recommandé.
+- **Un seul compte.** L'intégration lit toutes les installations rattachées au
+  compte. Si vous en avez plusieurs, chaque installation produit son propre
+  jeu d'appareils, préfixés par son nom.
+- **API non officielle.** Saunier Duval ne documente ni ne soutient cette API :
+  c'est celle de son application mobile. Elle peut changer sans préavis. Cette
+  intégration n'est ni affiliée ni approuvée par Saunier Duval ou le groupe
+  Vaillant.
+
+## Après une mise à jour de l'intégration
+
+Un appareil déjà créé ne change pas tout seul. L'onglet **Découverte** affiche
+un bouton **Mettre à jour** sur les appareils dont la structure a bougé, et
+c'est ce bouton qui réapplique tout : nouvelles fonctionnalités, unités, et
+liste des modes proposés.
+
+Attention à un cas particulier : Gladys détecte une « structure modifiée » en
+comparant les fonctionnalités, leurs unités et leurs bornes — **pas la liste
+des modes**. Si une mise à jour de l'intégration ne change que les modes
+proposés, aucun bouton **Mettre à jour** n'apparaît, et l'appareil garde son
+ancienne liste. Dans ce cas, supprimez l'appareil et recréez-le depuis
+l'onglet Découverte : il n'y a pas d'autre moyen.
 
 ## En cas de problème
 
-- **« Connexion refusée »** : vérifiez l'adresse e-mail, le mot de passe et
-  surtout le **pays**. Essayez de vous connecter dans l'application MiGo pour
-  confirmer que le compte fonctionne.
-- **Aucun appareil n'apparaît** : lancez **Tester la connexion**. Si aucune
-  installation n'est trouvée, c'est que la passerelle n'est pas rattachée à ce
-  compte.
-- **Les valeurs ne bougent plus** : consultez les logs du conteneur de
-  l'intégration (`LOG_LEVEL=debug` pour le détail des appels).
+- **« Connexion refusée »** : vérifiez l'e-mail, le mot de passe et surtout le
+  **pays** du compte. Vérifiez aussi que vous arrivez à vous connecter avec ces
+  identifiants dans l'application mobile.
+- **Aucune installation trouvée** : le compte n'a pas de chaudière rattachée,
+  ou la passerelle a été associée à un autre compte.
+- **Valeurs figées** : la passerelle est probablement hors ligne. Vérifiez-le
+  dans l'application mobile ; l'intégration ne peut lire que ce que la
+  plateforme connaît.
+- **Diagnostic détaillé** : passez la variable d'environnement `LOG_LEVEL` de
+  l'intégration à `debug` pour voir chaque appel dans les logs du conteneur.
 
 ## Paramètres de configuration
 
@@ -145,22 +217,21 @@ Voici les paramètres demandés par Saunier Duval dans son écran de configurati
 
 | Paramètre | Type | Obligatoire | Description |
 | --- | --- | --- | --- |
-| Connectez votre compte MiGo | `section` | Non | Cette intégration utilise le cloud Saunier Duval, le même service que l'application MiGo. Connectez-vous avec l'adresse e-mail et le mot de passe de cette application, et choisissez le pays dans lequel votre compte a été créé. Votre passerelle (MiGo, MiGo Link) doit déjà être appairée dans l'application. |
-| Adresse e-mail | `string` | Oui | L'adresse e-mail de votre compte MiGo / Saunier Duval. |
-| Mot de passe | `secret` | Oui | Le mot de passe de votre compte MiGo. Il est stocké chiffré par Gladys et n'est jamais renvoyé au navigateur. |
-| Pays | `select` | Oui | Le pays dans lequel votre compte a été créé. Un pays incorrect fait échouer la connexion. |
-| Quand le chauffage est allumé | `select` | Non | Le mode auquel la zone revient quand vous allumez le chauffage : son programme hebdomadaire, ou une température manuelle fixe. |
-| Durée d'un forçage temporaire (h) | `number` | Non | Quand la zone suit son programme, modifier la température de consigne applique un forçage temporaire. Voici sa durée, en heures. |
-| Intervalle de rafraîchissement (s) | `number` | Non | Fréquence de lecture des températures depuis le cloud, en secondes. La passerelle ne remonte ses mesures que toutes les quelques minutes : descendre sous 300 n'apporte pas grand-chose. |
+| Pour commencer | `section` | Non | Utilisez l'e-mail et le mot de passe du compte MiGo ou MiGo Link dont vous vous servez déjà dans l'application mobile. Votre chaudière doit être reliée à une passerelle MiGo ou MiGo Link : tout passe par le cloud Saunier Duval, il n'y a pas d'accès local. |
+| E-mail | `string` | Oui | Adresse e-mail de votre compte MiGo / MiGo Link. |
+| Mot de passe | `secret` | Oui | Mot de passe de votre compte MiGo / MiGo Link. Stocké chiffré par Gladys et jamais renvoyé au navigateur. |
+| Pays du compte | `select` | Oui | Le pays dans lequel votre compte a été créé. Un compte créé en France ne peut pas se connecter via un autre pays. |
+| Intervalle de rafraîchissement (s) | `number` | Non | Fréquence de lecture de la chaudière, en secondes. La plateforme Saunier Duval limite le nombre d'appels : gardez un intervalle confortable, une chaudière est un système lent. |
+| Durée de forçage par défaut (h) | `number` | Non | Lorsqu'une zone suit son programme horaire, changer sa température déclenche un forçage temporaire, puis le programme reprend la main. Ceci est la durée initiale d'une zone : chaque zone dispose ensuite de sa propre commande « Durée du forçage », de 30 minutes à 24 heures par pas de 30 minutes. Demi-heures uniquement. |
 
 ## Comment installer Saunier Duval dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : Saunier Duval apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/philippema/gladys-vaillant-saunierduval:2.0.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/philippema/gladys-vaillant-saunierduval:1.0.1`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/PhilippeMA/gladys-Vaillant-SaunierDuval](https://github.com/PhilippeMA/gladys-Vaillant-SaunierDuval).
 
-Saunier Duval nécessite Gladys `>=4.62.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+Saunier Duval nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
 
 Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/vigieau.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/vigieau.mdx
@@ -30,17 +30,31 @@ L'API VigiEau est gratuite et publique : **aucun compte, aucune clé d'API**.
 ## Ce que vous obtenez
 
 **Un appareil par lieu surveillé**, nommé « Vigilance sécheresse — _votre lieu_ »,
-avec cinq capteurs chacun. Vous pouvez suivre jusqu'à **dix lieux** : une maison,
+avec sept capteurs chacun. Vous pouvez suivre jusqu'à **dix lieux** : une maison,
 une résidence secondaire et un jardin relèvent rarement du même arrêté
 préfectoral.
 
-| Capteur                            | Valeur                                      |
-| ---------------------------------- | ------------------------------------------- |
-| **Niveau de vigilance sécheresse** | 0 à 3 — le plus élevé des trois types d'eau |
-| **Niveau (texte)**                 | « Alerte renforcée », « Crise »…            |
-| **Niveau eau superficielle**       | 0 à 3 — rivières, lacs (zones `SUP`)        |
-| **Niveau eau souterraine**         | 0 à 3 — nappes phréatiques (zones `SOU`)    |
-| **Niveau eau potable**             | 0 à 3 — réseau d'eau potable (zones `AEP`)  |
+| Capteur                            | Valeur                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| **Niveau de vigilance sécheresse** | 0 à 3 — le plus élevé des trois types d'eau                              |
+| **Niveau (texte)**                 | « Alerte renforcée », « Crise »…                                         |
+| **Niveau eau superficielle**       | 0 à 3 — rivières, lacs (zones `SUP`)                                     |
+| **Niveau eau souterraine**         | 0 à 3 — nappes phréatiques (zones `SOU`)                                 |
+| **Niveau eau potable**             | 0 à 3 — réseau d'eau potable (zones `AEP`)                               |
+| **Dernière mise à jour**           | « 15/06/2026 09:26 » — dernière lecture réussie de VigiEau pour ce lieu  |
+| **Arrêté en vigueur depuis**       | « 15/06/2026 » — date d'entrée en vigueur de l'arrêté qui fixe le niveau |
+
+> **Les deux dates ne disent pas la même chose.** VigiEau ne publie aucun
+> horodatage de ses propres données : rien dans l'API ne dit « ces informations
+> datent de… ». **Dernière mise à jour** est donc le moment où _l'intégration_ a
+> interrogé VigiEau avec succès pour ce lieu — c'est ce qui distingue un capteur
+> figé d'un niveau qui n'a simplement pas bougé. Elle n'avance que sur une
+> lecture réussie : après une panne, elle reste sur sa valeur précédente, en même
+> temps que le niveau. **Arrêté en vigueur depuis** est, elle, une date de la
+> source : celle à laquelle l'arrêté préfectoral applicable est entré en
+> vigueur. Quand rien n'est en vigueur, le capteur affiche « Aucun arrêté en
+> vigueur » plutôt que de conserver la date d'un arrêté levé. Les deux sont
+> affichées à l'heure de Paris, quel que soit le fuseau du serveur.
 
 L'échelle numérique suit celle des arrêtés préfectoraux, ramenée aux quatre
 valeurs que Gladys sait nommer :
@@ -71,7 +85,10 @@ sont exposés séparément, en plus du niveau global.
    dans l'onglet **Découverte**, prêt à être ajouté. Si vous connaissez déjà le
    point, renseignez plutôt les champs facultatifs **Latitude** et
    **Longitude** : ils sont utilisés tels quels, sans géocodage.
-3. Recommencez pour chaque lieu à surveiller, jusqu'à dix.
+3. Recommencez pour chaque lieu à surveiller, jusqu'à dix. Si les lieux que vous
+   voulez surveiller sont vos **maisons Gladys**, le bouton
+   **« Ajouter mes maisons Gladys »** vous évite de saisir quoi que ce soit :
+   voir « Ajouter vos maisons Gladys en un clic » ci-dessous.
 4. Dans **« Réglages généraux »**, choisissez votre **profil d'usager** : particulier, entreprise, collectivité
    ou exploitation agricole. Les restrictions ne sont pas les mêmes pour tous, et
    VigiEau renvoie celles qui s'appliquent au vôtre. Ce réglage vaut pour **tous
@@ -85,6 +102,33 @@ sont exposés séparément, en plus du niveau global.
 > Tant qu'aucun lieu n'a de point utilisable, aucun appareil n'est proposé.
 > C'est voulu : mieux vaut pas d'appareil qu'un appareil rattaché à un lieu
 > vide.
+
+### Ajouter vos maisons Gladys en un clic
+
+Vous avez déjà dit à Gladys où vous habitez : c'est la carte de
+**Réglages > Maisons**. Le bouton **« Ajouter mes maisons Gladys »** lit ces
+maisons et crée un lieu pour chacune qui n'est pas déjà surveillée — aucune
+adresse à saisir, aucun risque de géocoder la mauvaise commune. Le nom du lieu
+est celui de la maison dans Gladys, et l'adresse affichée dans la liste est
+recherchée pour vous à partir du point.
+
+Quelques règles, que le message affiché sous le bouton rappelle à chaque fois :
+
+- **L'accès aux coordonnées de vos maisons est une autorisation.** Votre domicile
+  est une donnée personnelle : l'intégration la demande dans son manifeste, et
+  Gladys vous montre cette demande à l'installation. Si le bouton répond que
+  Gladys refuse de partager ces coordonnées, c'est que la version installée ne
+  l'avait pas demandée : mettez l'intégration à jour, ou supprimez-la et
+  réinstallez-la en acceptant la demande.
+- **Une maison jamais placée sur la carte n'a pas de coordonnées.** Elle est
+  nommée dans la réponse, et rien n'est surveillé à sa place : localisez-la dans
+  **Réglages > Maisons**, puis relancez l'action.
+- **Une maison déjà surveillée n'est pas ajoutée deux fois.** Vous pouvez cliquer
+  autant de fois que vous voulez : le message vous dit quel lieu la surveille
+  déjà.
+- **Ce n'est pas une synchronisation.** Les maisons sont lues une fois, au clic.
+  Un lieu ainsi créé est un lieu ordinaire : si vous déplacez la maison dans
+  Gladys ensuite, le lieu, lui, ne bouge pas — supprimez-le et relancez l'action.
 
 ### Consulter les lieux
 
@@ -211,6 +255,10 @@ connaît pas, ou un point relevé sur une carte.
   lieu, ou crée le lieu directement sur la latitude et la longitude que vous
   saisissez (facultatives). Voir « Pourquoi une adresse et pas un code postal »
   plus haut.
+- **Ajouter mes maisons Gladys** — lit les maisons configurées dans Gladys et
+  ajoute un lieu pour chacune qui n'est pas déjà surveillée, sans rien saisir.
+  Nécessite Gladys 4.85.0 ou plus récent, et l'autorisation acceptée à
+  l'installation.
 - **Afficher les lieux** — liste tous les lieux configurés, numérotés, avec leur
   nom, leur adresse et leurs coordonnées. Ce sont ces numéros que propose la
   suppression.
@@ -285,9 +333,12 @@ connaît pas, ou un point relevé sur une carte.
 - **Les fonctionnalités s'appellent toutes « Niveau de risque »** — c'est
   l'affichage de Gladys : la liste « Fonctionnalités » de la fiche appareil
   montre le libellé générique de la catégorie, pas le nom publié par
-  l'intégration. Dans l'ordre, ce sont : niveau global, texte, eau
-  superficielle, eau souterraine, eau potable. Sur un tableau de bord ou dans
-  une scène, les quatre niveaux affichent bien leurs vrais noms.
+  l'intégration. Les trois capteurs textuels — niveau (texte), dernière mise à
+  jour, arrêté en vigueur depuis — souffrent du même travers et portent eux
+  aussi un libellé générique identique. Dans l'ordre, ce sont : niveau global,
+  texte, eau superficielle, eau souterraine, eau potable, dernière mise à jour,
+  arrêté en vigueur depuis. Sur un tableau de bord ou dans une scène, tous
+  affichent bien leurs vrais noms.
 - **« VigiEau n'arrive pas à déterminer la zone applicable ici »** — le point
   configuré ne tombe pas dans une seule zone. Le message nomme le lieu
   concerné : ajoutez-le à nouveau avec une adresse plus précise (numéro et rue
@@ -332,11 +383,11 @@ Voici les paramètres demandés par VigiEau dans son écran de configuration dan
 ## Comment installer VigiEau dans Gladys
 
 1. Dans Gladys, ouvrez **Intégrations** : VigiEau apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
-2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-vigieau:2.0.0`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-vigieau:2.0.2`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
 3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
 4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/prohand/gladys-vigieau](https://github.com/prohand/gladys-vigieau).
 
-VigiEau nécessite Gladys `>=4.62.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+VigiEau nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
 
 Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/z2m-devices-monitor.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/integrations/external/z2m-devices-monitor.mdx
@@ -1,0 +1,371 @@
+---
+title: "Intégration Z2M Devices Monitor pour Gladys Assistant"
+sidebar_label: "Z2M Devices Monitor"
+description: "Vous alerte quand un appareil Zigbee2MQTT ne donne plus signe de vie. Gratuite, open source, installable en un clic."
+image: "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-z2m-devices-monitor.jpg"
+keywords:
+  - "z2m devices monitor"
+  - "gladys z2m devices monitor"
+  - "z2m devices monitor gladys assistant"
+  - "intégration externe"
+  - "domotique open source"
+custom_edit_url: null
+---
+
+{/* GENERATED FILE: built by `yarn load-external-integrations` from the
+integration store. Do not edit by hand, edit docs/fr.md in
+https://github.com/prohand/gladys-z2m-devices-monitor instead. */}
+
+import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";
+
+<ExternalIntegrationHeader slug="z2m-devices-monitor" />
+
+Cette intégration surveille vos appareils Zigbee2MQTT et vous alerte quand l'un
+d'eux **ne donne plus signe de vie**.
+
+## Pourquoi ne pas se fier à la batterie
+
+Le pourcentage de batterie remonté par un appareil Zigbee est une estimation
+grossière, rarement rafraîchie et souvent fausse : une pile CR2032 affiche
+couramment 100 % jusqu'au jour où le capteur cesse de répondre. Et surtout, la
+batterie ne dit rien des autres façons de mourir : un appareil débranché, sorti
+du réseau, qui a perdu sa route ou dont le routeur parent est tombé.
+
+Un appareil Zigbee vivant **parle**. Les capteurs envoient leurs mesures, les
+routeurs répondent, tout se manifeste au moins périodiquement. Le seul fait
+vraiment fiable est donc : _quand ai-je entendu cet appareil pour la dernière
+fois ?_ — et la seule question utile : _se tait-il depuis plus longtemps qu'il ne
+le devrait ?_
+
+C'est exactement ce que fait cette intégration.
+
+## Ce qu'elle fait
+
+Elle s'abonne à tout ce que publie Zigbee2MQTT sur votre broker MQTT
+(`zigbee2mqtt/#`), mémorise la date du dernier message de chaque appareil, et
+réévalue en continu leur silence.
+
+Elle ne publie **jamais** rien sur votre réseau Zigbee : elle se contente
+d'écouter. Elle sait aussi faire la différence entre :
+
+- un message publié **par** l'appareil → preuve qu'il est vivant ;
+- un message rejoué par le broker (drapeau _retained_, à chaque reconnexion) →
+  il peut dater de plusieurs jours, il ne prouve rien ;
+- une commande `set`/`get` envoyée **vers** l'appareil par Gladys, Home Assistant
+  ou une scène → ce n'est pas l'appareil qui parle. Sans cette distinction, un
+  capteur mort paraîtrait vivant tant que quelque chose continue de lui parler.
+
+Si vous avez activé l'option `advanced.last_seen` dans Zigbee2MQTT, l'intégration
+utilise l'horodatage que l'appareil joint à ses rapports : c'est la source la
+plus fiable, et elle rend même les messages _retained_ exploitables. Ce n'est pas
+obligatoire.
+
+## Installation
+
+### 1. Pré-requis
+
+- Zigbee2MQTT en fonctionnement, publiant sur un broker MQTT ;
+- ce broker doit être joignable depuis Gladys (même réseau local).
+
+### 2. Configuration
+
+| Champ                                | À renseigner                                                                                                                       |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **URL du broker**                    | L'adresse de votre broker MQTT, par exemple `mqtt://192.168.1.10:1883`. Les schémas `mqtts://`, `ws://` et `wss://` sont acceptés. |
+| **Nom d'utilisateur / Mot de passe** | À laisser vides si votre broker accepte les connexions anonymes.                                                                   |
+| **Topic de base**                    | Le `mqtt.base_topic` configuré dans Zigbee2MQTT. `zigbee2mqtt` dans la quasi-totalité des cas.                                     |
+
+Cliquez ensuite sur **Tester la connexion MQTT** : le bouton indique s'il est
+connecté, combien d'appareils il voit et combien de messages il a reçus. C'est le
+moyen le plus rapide de repérer l'erreur classique — bon broker, mauvais topic de
+base, et rien ne se passe.
+
+#### Où trouver ces trois valeurs
+
+**Ces valeurs doivent être saisies à la main : l'intégration ne peut pas les
+récupérer toute seule dans Gladys.** Une intégration externe tourne dans son
+propre conteneur et ne reçoit de Gladys que sa _propre_ configuration ; l'API que
+Gladys lui expose ne donne accès ni aux réglages ni aux variables des autres
+intégrations. C'est une limite volontaire du bac à sable, pas un oubli : sans
+elle, n'importe quelle intégration du store pourrait lire les identifiants de vos
+autres services.
+
+Le copier-coller reste court :
+
+- **si c'est Gladys qui a installé Zigbee2MQTT** (mode « Installation depuis
+  Gladys »), le broker est le conteneur Mosquitto que Gladys gère. Allez dans
+  l'intégration **Zigbee2MQTT → onglet Configuration**, bloc **« Connexion pour
+  outils externes »** : Gladys y affiche l'URL, le nom d'utilisateur et le mot de
+  passe, avec un bouton de copie. Le mot de passe est engendré
+  aléatoirement à la première activation, il n'y a pas de valeur « par défaut » à
+  deviner. Ce broker écoute sur le port **1884**, et l'URL affichée pointe sur
+  `localhost` : **remplacez `localhost` par l'adresse IP de votre machine
+  Gladys**, sinon `localhost` désignerait le conteneur de cette intégration
+  elle-même. Le topic de base est `zigbee2mqtt` ;
+- **si vous avez votre propre broker** (Zigbee2MQTT autonome, Mosquitto,
+  Home Assistant…), reprenez simplement l'URL et les identifiants que
+  Zigbee2MQTT utilise, c'est-à-dire le bloc `mqtt:` de son
+  `configuration.yaml`.
+
+### 3. Ajouter les appareils
+
+Allez dans **Appareils → Découvrir**, puis créez les appareils que vous voulez
+surveiller. Vous en trouverez :
+
+- un appareil **par appareil Zigbee** connu de Zigbee2MQTT ;
+- un appareil **Zigbee2MQTT monitor**, qui résume tout le réseau.
+
+Les appareils surveillés portent le nom Zigbee2MQTT **suivi d'un suffixe**,
+`(monitor)` par défaut : `prise bureau (monitor)`. Sans lui, ils seraient
+impossibles à distinguer des appareils que l'intégration Zigbee2MQTT de Gladys
+remonte déjà sous le même nom — un sélecteur de scène afficherait deux fois
+« prise bureau ». Le suffixe se change (ou se vide) dans **Nommage des
+appareils**. Il ne s'applique qu'aux appareils créés ensuite : Gladys ne renomme
+jamais un appareil déjà ajouté, à vous de le renommer sur sa fiche.
+
+### Et quand le réseau Zigbee change ?
+
+L'intégration relit l'inventaire de Zigbee2MQTT en continu, donc la liste de
+l'écran **Découvrir** se met à jour toute seule :
+
+- **un appareil que vous venez d'appairer** apparaît dans la liste en quelques
+  secondes, sans redémarrage ni action de votre part. En revanche, sa **création
+  dans Gladys reste manuelle** : c'est vous qui décidez ce qui entre dans votre
+  installation. C'est aussi pourquoi la scène à bâtir est celle de l'appareil
+  **Zigbee2MQTT monitor** — ses compteurs comptent tous les appareils vus par
+  Zigbee2MQTT, y compris ceux que vous n'avez pas créés dans Gladys, donc un
+  nouvel appareil est couvert par l'alerte dès son appairage ;
+- **un appareil retiré de Zigbee2MQTT** disparaît de l'écran **Découvrir** et
+  cesse d'être compté et d'émettre des valeurs. S'il avait déjà été créé dans
+  Gladys, sa fiche **n'est pas supprimée automatiquement** : elle reste, figée
+  sur sa dernière valeur. Une intégration n'a pas le droit de supprimer vos
+  appareils — supprimez-la depuis **Appareils** quand vous le souhaitez.
+
+## Les seuils de silence
+
+Un appareil est déclaré mort dès qu'il se tait depuis plus longtemps que son
+seuil. Deux valeurs par défaut :
+
+- **appareils sur secteur** (prises, ampoules, routeurs) : 120 minutes, ils
+  parlent souvent ;
+- **appareils sur pile** (capteurs) : 1440 minutes, soit 24 heures — ils dorment
+  la plupart du temps.
+
+Vous pouvez affiner appareil par appareil dans le champ **Seuils par appareil**,
+une paire `appareil=minutes` par ligne ou séparées par des virgules :
+
+```
+capteur boite aux lettres=4320
+mouvement garage=180
+0x00158d0001abcdef=60
+```
+
+L'appareil se désigne par son nom convivial Zigbee2MQTT ou par son adresse IEEE.
+
+**Commencez large.** Un seuil trop serré produit des fausses alertes, et une
+alerte à laquelle on cesse de croire ne sert plus à rien. Laissez tourner
+quelques jours, regardez la valeur « Silence » de chaque appareil sur sa fiche
+(Gladys l'affiche sous le libellé _Durée (entier)_), puis resserrez.
+
+## Ce que chaque appareil expose
+
+Chaque appareil surveillé expose **2 fonctionnalités** :
+
+| Fonctionnalité | Nom affiché par Gladys | Description                                                                                                                                                         |
+| -------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Alive**      | _Etat de l'entrée_     | On = l'appareil donne signe de vie, Off = il se tait depuis plus que son seuil. C'est la fonctionnalité sur laquelle bâtir une alerte. Son historique est conservé. |
+| **Silence**    | _Durée (entier)_       | Depuis combien de minutes l'appareil n'a rien dit. Utile pour calibrer les seuils.                                                                                  |
+
+Si vous avez ajouté vos appareils avec la version 1.0.1 ou antérieure, leur
+fonctionnalité **Alive** était publiée dans une autre catégorie, que les écrans
+de Gladys dessinent sous la forme d'une étiquette vide — l'appareil semble ne
+porter que **Silence**. L'écran de découverte propose un bouton **Mettre à jour**
+sur ces appareils : cliquez-le et la fonctionnalité réapparaît, historique
+compris.
+
+L'appareil **Zigbee2MQTT monitor** expose de son côté **5 fonctionnalités** :
+
+| Fonctionnalité                | Nom affiché par Gladys | Description                                                                                                                                        |
+| ----------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Silent devices**            | _Silent devices_       | Le nombre d'appareils actuellement silencieux. C'est le déclencheur de la scène d'alerte.                                                          |
+| **Silent device names**       | _Texte_                | Leurs noms, pour les citer dans une notification. Affiche « No silent device » tant que tout le réseau répond (texte modifiable, voir ci-dessous). |
+| **Devices alive**             | _Devices alive_        | Le nombre d'appareils qui répondent.                                                                                                               |
+| **Devices monitored**         | _Devices monitored_    | Le nombre d'appareils surveillés.                                                                                                                  |
+| **Zigbee2MQTT bridge online** | _Etat de l'entrée_     | L'état du bridge Zigbee2MQTT lui-même.                                                                                                             |
+
+### Pourquoi certains noms changent à l'affichage
+
+Gladys ne montre pas toujours le nom donné par l'intégration. Quand une
+fonctionnalité est **la seule de son type sur son appareil**, l'interface affiche
+à la place le libellé standard de sa catégorie — d'où _Texte_ pour « Silent
+device names », _Etat de l'entrée_ pour « Alive » et « Zigbee2MQTT bridge
+online », ou _Compteur entier_ sur l'écran de modification. Les trois compteurs
+du moniteur partagent le même type, donc ils gardent leur nom.
+
+C'est un comportement de Gladys, pas un réglage de cette intégration. Deux
+conséquences pratiques :
+
+- dans un sélecteur de scène, repérez la fonctionnalité par ce nom affiché
+  (« Zigbee2MQTT monitor (Texte) » = les noms des appareils silencieux) ;
+- vous pouvez renommer une fonctionnalité depuis la fiche de l'appareil si le
+  libellé standard ne vous parle pas.
+
+### Le texte affiché quand tout va bien
+
+« Silent device names » est un texte, et il passe l'essentiel de sa vie à ne
+citer personne — c'est bon signe. Il affiche alors une phrase explicite plutôt
+qu'un tiret : **No silent device** par défaut. Le champ **Texte affiché quand
+aucun appareil n'est silencieux** (section _Appareil Zigbee2MQTT monitor_) permet
+de le traduire, par exemple « Aucun appareil silencieux ». Videz le champ pour
+revenir à la valeur par défaut : ce texte ne peut jamais être vide, Gladys
+n'enregistre pas un état texte vide.
+
+### Et l'intensité du signal ?
+
+Elle n'est **pas** publiée par cette intégration : l'intégration Zigbee2MQTT de
+Gladys remonte déjà le LQI de chaque appareil, et un deuxième exemplaire de la
+même valeur ne ferait qu'encombrer les listes d'appareils et les sélecteurs de
+scène.
+
+## Être alerté : créer la scène
+
+L'intégration lève le drapeau, Gladys envoie l'alerte. La scène la plus utile est
+celle bâtie sur l'appareil **Zigbee2MQTT monitor** : elle couvre tout le réseau,
+y compris les appareils que vous appairerez dans six mois.
+
+1. **Scènes → Nouvelle scène** ;
+2. déclencheur : **La valeur d'un appareil change** → appareil
+   _Zigbee2MQTT monitor_, fonctionnalité **Silent devices**, condition
+   _supérieur à_ `0` ;
+3. première action : **Récupérer le dernier état** → dans _Sélectionnez un
+   appareil_, choisissez **Zigbee2MQTT monitor (Texte)**, c'est-à-dire la
+   fonctionnalité **Silent device names**.
+
+   C'est l'étape qu'on oublie : dans Gladys, un message ne peut insérer que les
+   valeurs récupérées par une action **placée avant lui**. Sans ce bloc, le
+   sélecteur de variables du message est vide et l'alerte ne pourra pas nommer
+   les capteurs concernés ;
+
+4. seconde action : **Envoyer un message** (notification mobile, Telegram…) avec
+   un texte du type :
+
+   > Appareil(s) Zigbee sans signe de vie : _Dernière valeur de l'appareil_
+
+   Pour insérer cette variable, tapez `{{` à l'endroit voulu dans le message :
+   Gladys propose alors la valeur récupérée à l'étape 3, affichée
+   « 1.1. Dernière valeur de l'appareil » (le numéro est la position de l'action
+   _Récupérer le dernier état_ dans la scène). Passez toujours par ce sélecteur
+   plutôt que de taper la variable à la main : le message nommera les capteurs
+   concernés au lieu de dire simplement que quelque chose ne va pas.
+
+Pour un capteur critique en particulier (détecteur de fumée, alarme, congélateur),
+créez en plus une scène dédiée sur sa fonctionnalité **Alive** passant à Off (dans
+le sélecteur : _nom de l'appareil (Etat de l'entrée)_).
+
+Astuce : ajoutez une condition d'horaire à la scène si vous ne voulez pas être
+réveillé la nuit — un capteur muet peut presque toujours attendre le matin.
+
+## Les boutons de l'écran de configuration
+
+- **Tester la connexion MQTT** — état réel de la connexion, nombre d'appareils
+  surveillés, nombre de messages reçus, et la raison précise en cas d'échec.
+- **Lister les appareils silencieux** — qui se tait, et depuis combien de temps.
+- **Rafraîchir la liste des appareils** — republie la liste vers Gladys, après un
+  appairage ou un renommage dans Zigbee2MQTT.
+
+## Bon à savoir
+
+- **Les appareils sont identifiés par leur adresse IEEE**, pas par leur nom.
+  Renommer un appareil dans Zigbee2MQTT met à jour son nom dans Gladys sans
+  perdre son historique.
+- **Les appareils désactivés dans Zigbee2MQTT ne sont pas surveillés** par
+  défaut : ils sont censés se taire. Une option permet de les inclure.
+- **Le coordinateur (la clé USB) n'est pas surveillé** : ce n'est pas un appareil
+  qui peut tomber de son côté. Utilisez la fonctionnalité _Zigbee2MQTT bridge
+  online_ pour cela.
+- **L'historique du dernier signe de vie est persisté** dans le volume `/data` de
+  l'intégration. Un redémarrage du conteneur ne remet donc pas tous vos appareils
+  à zéro — sans quoi un capteur mort depuis un mois repartirait pour un seuil
+  complet sans jamais déclencher l'alerte.
+- **Si vous mettez à jour depuis une version qui publiait l'intensité du
+  signal**, les appareils déjà créés dans Gladys conservent cette
+  fonctionnalité : une intégration ne peut pas retirer une fonctionnalité d'un
+  appareil que vous avez créé. Elle ne reçoit plus de valeur et reste figée sur
+  la dernière. Pour la faire disparaître, supprimez l'appareil dans Gladys et
+  recréez-le depuis **Découvrir** (son historique est alors perdu) ; sinon,
+  ignorez-la.
+- **Un appareil jamais entendu** dispose d'un seuil complet à partir du démarrage
+  du moniteur avant d'être signalé. Une intégration fraîchement installée ne
+  déclare donc pas tout le réseau mort à la première minute.
+
+## En cas de problème
+
+**Le bouton de test dit qu'il n'est pas connecté.** Vérifiez l'URL (avec le port,
+`1883` par défaut), les identifiants, et que le broker autorise les connexions
+depuis l'adresse de Gladys.
+
+**Il est connecté, mais ne voit aucun appareil.** Le topic de base ne correspond
+probablement pas à celui de Zigbee2MQTT. Comparez-le avec `mqtt.base_topic` dans
+votre `configuration.yaml`.
+
+**Un appareil est signalé silencieux alors qu'il fonctionne.** Son seuil est trop
+serré : regardez sa fonctionnalité _Silence_ (_Durée (entier)_) pour connaître son rythme réel, et
+donnez-lui un seuil sur mesure. Les capteurs de porte, de fuite ou les boutons
+sont typiquement muets pendant des jours s'il ne se passe rien.
+
+**Tous les appareils passent silencieux en même temps.** Regardez d'abord
+_Zigbee2MQTT bridge online_ : c'est probablement Zigbee2MQTT lui-même, le broker
+ou le coordinateur qui est tombé, pas vos capteurs.
+
+**Un appareil que je viens d'ajouter affiche « Pas de valeur récente ».** Une
+fonctionnalité ne reçoit de valeur qu'une fois l'appareil créé dans Gladys : tout
+ce qui a été publié avant que vous cliquiez sur _Ajouter_ n'est allé nulle part.
+L'intégration republie donc les états d'un appareil dès que Gladys lui signale sa
+création, et la valeur arrive en quelques secondes. Si le bandeau est toujours là,
+**rechargez la page** : le tableau de bord calcule ce bandeau au chargement de ses
+données et ne l'efface pas sur les mises à jour temps réel qui suivent.
+
+## Paramètres de configuration
+
+Voici les paramètres demandés par Z2M Devices Monitor dans son écran de configuration dans Gladys.
+
+| Paramètre | Type | Obligatoire | Description |
+| --- | --- | --- | --- |
+| Comment ça marche | `section` | Non | Un appareil Zigbee vivant parle. Cette intégration écoute tout ce que publie Zigbee2MQTT, mémorise la dernière fois que chaque appareil s'est manifesté, et signale ceux qui se taisent depuis trop longtemps. Elle n'utilise jamais le niveau de batterie : un pourcentage de batterie Zigbee est une estimation grossière, souvent à 100% jusqu'au jour où le capteur cesse de répondre. |
+| Broker MQTT | `section` | Non | Le même broker que celui utilisé par Zigbee2MQTT. L'intégration ne fait que s'abonner : elle ne publie jamais rien sur votre réseau Zigbee. Ces valeurs doivent être saisies ici : une intégration tourne dans son propre bac à sable et Gladys ne lui communique jamais les réglages d'une autre intégration. Si c'est Gladys qui a installé Zigbee2MQTT, recopiez-les depuis l'intégration Zigbee2MQTT, onglet Configuration, bloc « Connexion pour outils externes » — en remplaçant localhost dans l'URL par l'adresse IP de votre machine Gladys. |
+| URL du broker | `string` | Oui | Adresse du broker MQTT, par exemple mqtt://192.168.1.10:1883 (mqtts:// et ws:// sont aussi acceptés). |
+| Nom d'utilisateur | `string` | Non | Laissez vide si votre broker accepte les connexions anonymes. |
+| Mot de passe | `secret` | Non |  |
+| Topic de base | `string` | Oui | Le topic de base configuré dans Zigbee2MQTT (mqtt.base_topic). |
+| Seuils de silence | `section` | Non | Un appareil est déclaré mort dès qu'il se tait depuis plus longtemps que son seuil. Les capteurs sur pile parlent bien moins souvent que les appareils sur secteur, d'où deux valeurs par défaut distinctes. Commencez large : mieux vaut être alerté quelques heures trop tard que réveillé par une fausse alerte. |
+| Seuil pour les appareils sur secteur (min) | `number` | Non | S'applique aux prises, ampoules et routeurs, qui parlent souvent. |
+| Seuil pour les appareils sur pile (min) | `number` | Non | S'applique aux capteurs sur pile, qui dorment la plupart du temps. 1440 minutes valent 24 heures. |
+| Seuils par appareil | `string` | Non | Une paire appareil=minutes par ligne ou séparées par des virgules. L'appareil est désigné par son nom convivial Zigbee2MQTT ou son adresse IEEE. Exemple : capteur boite aux lettres=4320, 0x00158d0001abcdef=60 |
+| Nommage des appareils | `section` | Non | Gladys connaît très probablement déjà ces appareils sous leur nom Zigbee2MQTT, via sa propre intégration Zigbee2MQTT. Sans suffixe, un sélecteur de scène affiche deux fois le même nom sans moyen de les distinguer. |
+| Suffixe ajouté aux noms d'appareils | `string` | Non | Ajouté au nom Zigbee2MQTT de chaque appareil surveillé, par exemple « prise bureau (monitor) ». Laissez vide pour garder le nom brut. N'affecte que les appareils créés ensuite : Gladys ne renomme jamais un appareil déjà ajouté. |
+| Appareil Zigbee2MQTT monitor | `section` | Non | L'appareil unique qui résume tout le réseau : combien d'appareils sont surveillés, combien sont silencieux, et le nom de ceux qui se taisent — le texte qu'une notification de scène reprend. C'est sur lui qu'il faut bâtir l'alerte : ses compteurs couvrent tous les appareils connus de Zigbee2MQTT, y compris ceux que vous appairerez plus tard. |
+| Texte affiché quand aucun appareil n'est silencieux | `string` | Non | Ce qu'affiche la fonctionnalité « Silent device names » tant que tout le réseau répond. Écrivez-le dans votre langue ; vide rétablit la valeur par défaut. |
+| Avancé | `section` | Non |  |
+| Appareils à ignorer | `string` | Non | Noms conviviaux ou adresses IEEE, séparés par des virgules. Les appareils ignorés ne sont pas publiés vers Gladys et ne déclenchent jamais d'alerte. |
+| Surveiller aussi les appareils désactivés dans Zigbee2MQTT | `boolean` | Non | Désactivé par défaut : un appareil que vous avez désactivé volontairement est censé se taire. |
+| Intervalle de vérification (s) | `number` | Non | Fréquence de réévaluation du silence de chaque appareil. |
+
+## Comment installer Z2M Devices Monitor dans Gladys
+
+1. Dans Gladys, ouvrez **Intégrations** : Z2M Devices Monitor apparaît dans le catalogue, aux côtés des intégrations natives, avec un badge communautaire.
+2. Cliquez sur **Installer**. Gladys télécharge l'image Docker (`ghcr.io/prohand/gladys-z2m-devices-monitor:1.0.3`), la démarre dans un bac à sable isolé du cœur, et génère l'interface de l'intégration (appareils, découverte et configuration).
+3. Ouvrez l'écran **Configuration** de l'intégration, remplissez les paramètres, puis enregistrez.
+4. Vous pouvez aussi l'installer directement depuis l'URL de son dépôt : [https://github.com/prohand/gladys-z2m-devices-monitor](https://github.com/prohand/gladys-z2m-devices-monitor).
+
+Z2M Devices Monitor nécessite Gladys `>=4.85.0`. Le catalogue dans Gladys se rafraîchit toutes les heures : une nouvelle version est donc disponible au plus tard une heure après sa sortie.
+
+Vous n'utilisez pas encore Gladys ? C'est gratuit et open source : [suivez le guide d'installation](/fr/docs/) pour démarrer.
+
+## À propos des intégrations externes
+
+Z2M Devices Monitor est une **intégration externe** : une intégration communautaire empaquetée dans un conteneur Docker et publiée sur GitHub, que Gladys installe en un clic et exécute dans un bac à sable isolé de son cœur. Elle est publiée et maintenue par [prohand](https://github.com/prohand), et non par l'équipe cœur de Gladys.
+
+- [Parcourir toutes les intégrations externes](/fr/docs/integrations/external/)
+- [Découvrir les intégrations natives](/fr/docs/integrations/) intégrées à Gladys
+- [Créer et publier votre propre intégration externe](/fr/docs/dev/external-integrations/)
+- [Code source sur GitHub](https://github.com/prohand/gladys-z2m-devices-monitor) — [source de cette documentation](https://github.com/prohand/gladys-z2m-devices-monitor/blob/HEAD/docs/fr.md)

--- a/scripts/load_external_integrations.js
+++ b/scripts/load_external_integrations.js
@@ -150,14 +150,28 @@ const trimIntegration = (integration, slug) => ({
     : null,
 });
 
-const yaml = (value) =>
-  `"${String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-
-const cell = (value) =>
+const oneLine = (value) =>
   String(value === undefined || value === null ? "" : value)
-    .replace(/\|/g, "\\|")
     .replace(/\r?\n/g, " ")
     .trim();
+
+const yaml = (value) =>
+  `"${oneLine(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+
+// Manifest values are written by the integration author too, so they get the
+// same treatment as the documentation below: a configuration description
+// containing `{{gladys_host}}` would otherwise reach the MDX compiler as a JSX
+// expression and fail the build.
+const text = (value) =>
+  oneLine(value).replace(/[<{}]/g, (character) => `\\${character}`);
+
+const cell = (value) => text(value).replace(/\|/g, "\\|");
+
+// MDX leaves the content of a code span alone: only its delimiters matter.
+const code = (value) => oneLine(value).replace(/`/g, "");
+
+// A space or a parenthesis would cut a Markdown link destination short.
+const url = (value) => oneLine(value).replace(/[ ()<>]/g, encodeURIComponent);
 
 // The documentation is written by the integration author, so it can contain
 // anything: `<`, `{` and `}` outside code would be read as JSX by the MDX
@@ -220,14 +234,14 @@ const configTable = (integration, texts, locale) => {
     const description = field.description
       ? field.description[locale] || field.description.en
       : "";
-    return `| ${cell(label || field.key)} | \`${cell(field.type)}\` | ${
+    return `| ${cell(label || field.key)} | \`${code(field.type)}\` | ${
       field.required ? texts.required : texts.optional
     } | ${cell(description)} |`;
   });
   return [
     `## ${texts.configTitle}`,
     "",
-    texts.configIntro(integration.name),
+    texts.configIntro(text(integration.name)),
     "",
     `| ${texts.configColumns.join(" | ")} |`,
     `| --- | --- | --- | --- |`,
@@ -244,6 +258,12 @@ const buildPage = (integration, authorDoc, locale, hasNativeDoc) => {
     ? texts.titleWithNative(integration.name)
     : texts.title(integration.name);
   const ownerName = owner(integration.store_slug);
+  // Everything below the frontmatter is Markdown compiled as MDX: what the
+  // manifest provides has to be escaped for the context it lands in (prose,
+  // code span or link destination). The frontmatter itself is YAML, quoted by
+  // `yaml()`.
+  const name = text(integration.name);
+  const repoUrl = url(integration.repo_url);
   const metaDescription =
     description.length > 120
       ? description
@@ -274,7 +294,7 @@ const buildPage = (integration, authorDoc, locale, hasNativeDoc) => {
     "",
     `${GENERATED_MARKER}: built by \`yarn load-external-integrations\` from the`,
     `integration store. Do not edit by hand, edit ${docPath} in`,
-    `${integration.repo_url} instead. */}`,
+    `${repoUrl} instead. */}`,
     "",
     `import ExternalIntegrationHeader from "@site/src/components/ExternalIntegrationHeader";`,
     "",
@@ -283,31 +303,25 @@ const buildPage = (integration, authorDoc, locale, hasNativeDoc) => {
     authorDoc || texts.docSourceMissing,
     "",
     configTable(integration, texts, locale),
-    `## ${texts.installTitle(integration.name)}`,
+    `## ${texts.installTitle(name)}`,
     "",
     ...texts
-      .installSteps(
-        integration.name,
-        integration.docker_image,
-        integration.repo_url
-      )
+      .installSteps(name, code(integration.docker_image), repoUrl)
       .map((step, index) => `${index + 1}. ${step}`),
     "",
-    texts.installRequirement(integration.name, integration.gladys_version),
+    texts.installRequirement(name, code(integration.gladys_version)),
     "",
     texts.installNoGladys,
     "",
     `## ${texts.aboutTitle}`,
     "",
     texts.aboutBody(
-      integration.name,
-      ownerName,
-      `https://github.com/${ownerName}`
+      name,
+      text(ownerName),
+      url(`https://github.com/${ownerName}`)
     ),
     "",
-    ...texts
-      .aboutLinks(integration.repo_url, docPath)
-      .map((link) => `- ${link}`),
+    ...texts.aboutLinks(repoUrl, docPath).map((link) => `- ${link}`),
   ].join("\n")}\n`;
 };
 

--- a/src/data/externalIntegrations.json
+++ b/src/data/externalIntegrations.json
@@ -1,19 +1,324 @@
 {
-  "generated_at": "2026-08-07T14:20:52.986Z",
+  "generated_at": "2026-08-13T17:08:35.797Z",
   "integrations": [
+    {
+      "slug": "apple-tv",
+      "store_slug": "valentinhttr/gladys-apple-tv",
+      "repo_url": "https://github.com/valentinhttr/gladys-apple-tv",
+      "name": "Apple TV",
+      "type": "device",
+      "version": "1.0.0",
+      "description": {
+        "en": "Control your Apple TV: power, remote, playback, volume and applications.",
+        "fr": "Contrôlez votre Apple TV : alimentation, télécommande, lecture, volume et applications."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/valentinhttr--gladys-apple-tv.jpg",
+      "docker_image": "ghcr.io/valentinhttr/gladys-apple-tv:1.0.0",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "how_it_works",
+          "type": "section",
+          "label": {
+            "en": "Setting up your Apple TV, step by step",
+            "fr": "Configurer votre Apple TV, étape par étape"
+          },
+          "description": {
+            "en": "An Apple TV has to be added AND paired before a single command works. Three steps, in this order. 1) Discovery tab: press \"Scan\", wait, then press \"Add to Gladys\" on your Apple TV. It now exists in Gladys, but obeys nothing yet. 2) Back on this page, at the bottom: run \"1. Pair an Apple TV\" and pick it from the list — no IP address to look up. A code appears on your television; type it in \"2. Enter the code\". Apple asks for one code per protocol, so a second code follows: clear the field and type the new one in its place. 3) Discovery tab again: press \"Update\" on your Apple TV to pick up the volume control and the application shortcuts that the pairing revealed.",
+            "fr": "Une Apple TV doit être ajoutée ET appairée avant que la moindre commande fonctionne. Trois étapes, dans cet ordre. 1) Onglet Découverte : cliquez sur « Scanner », patientez, puis sur « Ajouter à Gladys » sur votre Apple TV. Elle existe alors dans Gladys, mais n'obéit encore à rien. 2) De retour sur cette page, tout en bas : lancez « 1. Appairer une Apple TV » et choisissez-la dans la liste — aucune adresse IP à chercher. Un code s'affiche sur votre téléviseur ; saisissez-le dans « 2. Saisir le code ». Apple demande un code par protocole, un second code suit donc : effacez le champ et saisissez le nouveau à la place. 3) Onglet Découverte à nouveau : cliquez sur « Mettre à jour » sur votre Apple TV pour récupérer le volume et les raccourcis d'applications révélés par l'appairage."
+          },
+          "links": [
+            {
+              "url": "https://pyatv.dev/documentation/supported_features/",
+              "label": {
+                "en": "Features supported by pyatv",
+                "fr": "Fonctionnalités prises en charge par pyatv"
+              }
+            }
+          ]
+        },
+        {
+          "key": "discovery_settings",
+          "type": "section",
+          "label": {
+            "en": "Finding your Apple TV",
+            "fr": "Trouver votre Apple TV"
+          },
+          "description": {
+            "en": "These two settings only affect the scan of the Discovery tab. The defaults work on a normal home network: leave them alone unless a scan comes back empty.",
+            "fr": "Ces deux réglages ne concernent que le scan de l'onglet Découverte. Les valeurs par défaut conviennent à un réseau domestique classique : n'y touchez que si un scan ne trouve rien."
+          }
+        },
+        {
+          "key": "scan_timeout",
+          "type": "number",
+          "label": {
+            "en": "Discovery duration (seconds)",
+            "fr": "Durée de la recherche (secondes)"
+          },
+          "description": {
+            "en": "How long Gladys listens for AirPlay announcements. Increase it on a busy or slow network.",
+            "fr": "Durée d'écoute des annonces AirPlay. À augmenter sur un réseau chargé ou lent."
+          },
+          "required": false,
+          "default": 8,
+          "min": 2,
+          "max": 25
+        },
+        {
+          "key": "manual_hosts",
+          "type": "string",
+          "label": {
+            "en": "Manual IPv4 addresses",
+            "fr": "Adresses IPv4 manuelles"
+          },
+          "description": {
+            "en": "Optional, comma separated. Needed only when Gladys and your Apple TV are on different subnets or VLANs, where mDNS announcements do not travel. They are added to the automatic discovery, so the Apple TV still shows up in the Discovery tab like any other.",
+            "fr": "Facultatif, séparées par des virgules. Utile uniquement si Gladys et votre Apple TV sont sur des sous-réseaux ou VLAN différents, où les annonces mDNS ne circulent pas. Elles s'ajoutent à la découverte automatique : l'Apple TV apparaît alors dans l'onglet Découverte comme les autres."
+          },
+          "placeholder": {
+            "en": "192.168.1.20, 192.168.1.21",
+            "fr": "192.168.1.20, 192.168.1.21"
+          },
+          "required": false,
+          "default": ""
+        },
+        {
+          "key": "device_settings",
+          "type": "section",
+          "label": {
+            "en": "What the device exposes",
+            "fr": "Ce que l'appareil expose"
+          },
+          "description": {
+            "en": "These settings shape the Gladys device itself. Changing one takes effect on the next \"Update\" you accept in the Discovery tab.",
+            "fr": "Ces réglages façonnent l'appareil Gladys lui-même. Une modification prend effet au prochain « Mettre à jour » accepté dans l'onglet Découverte."
+          }
+        },
+        {
+          "key": "poll_frequency",
+          "type": "select",
+          "label": {
+            "en": "Refresh interval",
+            "fr": "Intervalle de rafraîchissement"
+          },
+          "description": {
+            "en": "The Apple TV pushes what it can in real time. This interval reconciles what it does not push, typically the power state on some models.",
+            "fr": "L'Apple TV pousse en temps réel ce qu'elle peut. Cet intervalle réconcilie ce qu'elle ne pousse pas, généralement l'état d'alimentation sur certains modèles."
+          },
+          "required": false,
+          "default": "30000",
+          "options": [
+            {
+              "value": "10000",
+              "label": {
+                "en": "10 seconds",
+                "fr": "10 secondes"
+              }
+            },
+            {
+              "value": "15000",
+              "label": {
+                "en": "15 seconds",
+                "fr": "15 secondes"
+              }
+            },
+            {
+              "value": "30000",
+              "label": {
+                "en": "30 seconds",
+                "fr": "30 secondes"
+              }
+            },
+            {
+              "value": "60000",
+              "label": {
+                "en": "1 minute",
+                "fr": "1 minute"
+              }
+            }
+          ]
+        },
+        {
+          "key": "enable_app_shortcuts",
+          "type": "boolean",
+          "label": {
+            "en": "Application shortcuts",
+            "fr": "Raccourcis d'applications"
+          },
+          "description": {
+            "en": "Add one button per installed application to the device, so scenes can open Netflix or Disney+ directly. Read from the Apple TV after pairing.",
+            "fr": "Ajoute un bouton par application installée sur l'appareil, pour ouvrir Netflix ou Disney+ directement depuis une scène. Lu sur l'Apple TV après l'appairage."
+          },
+          "required": false,
+          "default": true
+        },
+        {
+          "key": "max_app_shortcuts",
+          "type": "number",
+          "label": {
+            "en": "Maximum number of shortcuts",
+            "fr": "Nombre maximum de raccourcis"
+          },
+          "description": {
+            "en": "An Apple TV can have a hundred applications. This bound keeps the device readable.",
+            "fr": "Une Apple TV peut compter une centaine d'applications. Cette limite garde l'appareil lisible."
+          },
+          "required": false,
+          "default": 25,
+          "min": 0,
+          "max": 100
+        },
+        {
+          "key": "actions_intro",
+          "type": "section",
+          "label": {
+            "en": "Pairing and tools, with the buttons below",
+            "fr": "Appairage et outils, avec les boutons ci-dessous"
+          },
+          "description": {
+            "en": "Everything below this line acts on an Apple TV you already added from the Discovery tab: pick it in the list, then press \"Run\". The first two buttons are the pairing itself and they go together — start with \"1. Pair an Apple TV\". The others are troubleshooting tools you will rarely need.",
+            "fr": "Tout ce qui suit agit sur une Apple TV déjà ajoutée depuis l'onglet Découverte : choisissez-la dans la liste, puis cliquez sur « Exécuter ». Les deux premiers boutons forment l'appairage et vont ensemble — commencez par « 1. Appairer une Apple TV ». Les autres sont des outils de dépannage dont vous n'aurez presque jamais besoin."
+          }
+        }
+      ],
+      "stars": 1,
+      "pushed_at": "2026-08-09T15:56:06Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/20521112?v=4"
+    },
+    {
+      "slug": "grdf-gazpar",
+      "store_slug": "PhilippeMA/gladys-grdf",
+      "repo_url": "https://github.com/PhilippeMA/gladys-grdf",
+      "name": "GRDF Gazpar",
+      "type": "device",
+      "version": "1.1.4",
+      "description": {
+        "en": "Reads the daily gas consumption of your GRDF Gazpar meter from your GRDF account.",
+        "fr": "Lit la consommation de gaz quotidienne de votre compteur Gazpar depuis votre compte GRDF."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-grdf.png",
+      "docker_image": "ghcr.io/philippema/gladys-grdf:1.1.4",
+      "gladys_version": ">=4.62.0",
+      "config_schema": [
+        {
+          "key": "intro",
+          "type": "section",
+          "label": {
+            "en": "Before you start",
+            "fr": "Avant de commencer"
+          },
+          "description": {
+            "en": "This integration signs in to your GRDF customer account, the same one you use on monespace.grdf.fr, and reads the daily readings of your Gazpar meter. GRDF publishes them one to two days late: nothing shows up in real time. Your account must not require an extra verification step at login.",
+            "fr": "Cette intégration se connecte à votre compte client GRDF, celui de monespace.grdf.fr, et lit les relevés quotidiens de votre compteur Gazpar. GRDF les publie avec un à deux jours de retard : rien n'arrive en temps réel. Votre compte ne doit pas demander d'étape de vérification supplémentaire à la connexion."
+          },
+          "links": [
+            {
+              "url": "https://monespace.grdf.fr",
+              "label": {
+                "en": "GRDF customer area",
+                "fr": "Espace client GRDF"
+              }
+            }
+          ]
+        },
+        {
+          "key": "email",
+          "type": "string",
+          "label": {
+            "en": "GRDF account email",
+            "fr": "E-mail du compte GRDF"
+          },
+          "description": {
+            "en": "The email address you use to sign in on monespace.grdf.fr.",
+            "fr": "L'adresse e-mail utilisée pour vous connecter sur monespace.grdf.fr."
+          },
+          "placeholder": {
+            "en": "you@example.com",
+            "fr": "vous@exemple.com"
+          },
+          "required": true
+        },
+        {
+          "key": "password",
+          "type": "secret",
+          "label": {
+            "en": "GRDF account password",
+            "fr": "Mot de passe du compte GRDF"
+          },
+          "description": {
+            "en": "Stored encrypted by Gladys and only sent to GRDF.",
+            "fr": "Stocké chiffré par Gladys et transmis uniquement à GRDF."
+          },
+          "required": true
+        },
+        {
+          "key": "pce_list",
+          "type": "string",
+          "label": {
+            "en": "PCE to follow",
+            "fr": "PCE à suivre"
+          },
+          "description": {
+            "en": "Optional. 14-digit metering point identifiers, separated by commas. Leave empty to follow every meter of the account.",
+            "fr": "Facultatif. Identifiants de point de comptage à 14 chiffres, séparés par des virgules. Laissez vide pour suivre tous les compteurs du compte."
+          },
+          "placeholder": {
+            "en": "01234567890123",
+            "fr": "01234567890123"
+          },
+          "required": false
+        },
+        {
+          "key": "history_days",
+          "type": "number",
+          "label": {
+            "en": "History to import (days)",
+            "fr": "Historique à importer (jours)"
+          },
+          "description": {
+            "en": "Days of past consumption imported on the first synchronization. GRDF keeps about three years.",
+            "fr": "Nombre de jours de consommation passée importés à la première synchronisation. GRDF conserve environ trois ans."
+          },
+          "required": false,
+          "default": 7,
+          "min": 1,
+          "max": 1095
+        },
+        {
+          "key": "poll_frequency",
+          "type": "number",
+          "label": {
+            "en": "Refresh interval (s)",
+            "fr": "Intervalle de rafraîchissement (s)"
+          },
+          "description": {
+            "en": "How often GRDF is queried, in seconds. A new reading appears once a day, so there is no point going below a few hours.",
+            "fr": "Fréquence d'interrogation de GRDF, en secondes. Un nouveau relevé n'arrive qu'une fois par jour : inutile de descendre en dessous de quelques heures."
+          },
+          "required": false,
+          "default": 21600,
+          "min": 3600,
+          "max": 86400
+        }
+      ],
+      "stars": 1,
+      "pushed_at": "2026-08-11T16:31:29Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/25247304?v=4"
+    },
     {
       "slug": "ipp-printers",
       "store_slug": "guim31/gladys-ipp",
       "repo_url": "https://github.com/guim31/gladys-ipp",
       "name": "IPP Printers",
       "type": "device",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "description": {
         "en": "Ink/toner levels and state of your network printers over IPP (AirPrint). Local, no cloud.",
         "fr": "Niveaux d'encre/toner et état de vos imprimantes réseau via IPP (AirPrint). Local, sans cloud."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/guim31--gladys-ipp.png",
-      "docker_image": "ghcr.io/guim31/gladys-ipp:1.0.5",
+      "docker_image": "ghcr.io/guim31/gladys-ipp:1.0.7",
       "gladys_version": ">=4.62.0",
       "config_schema": [
         {
@@ -105,7 +410,7 @@
         }
       ],
       "stars": 1,
-      "pushed_at": "2026-08-07T09:51:14Z",
+      "pushed_at": "2026-08-07T20:35:26Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/33096540?v=4"
     },
     {
@@ -181,13 +486,13 @@
       "repo_url": "https://github.com/prohand/gladys-prixcarburants",
       "name": "Prix carburants",
       "type": "device",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "description": {
         "en": "Follow the price of your fuel at the petrol stations near you, from official open data.",
         "fr": "Suivez le prix de votre carburant dans les stations-service proches de chez vous."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-prixcarburants.png",
-      "docker_image": "ghcr.io/prohand/gladys-prixcarburants:1.0.1",
+      "docker_image": "ghcr.io/prohand/gladys-prixcarburants:1.0.3",
       "gladys_version": ">=4.62.0",
       "config_schema": [
         {
@@ -368,7 +673,7 @@
         }
       ],
       "stars": 1,
-      "pushed_at": "2026-08-06T14:03:45Z",
+      "pushed_at": "2026-08-10T13:09:20Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/20227162?v=4"
     },
     {
@@ -410,14 +715,14 @@
       "repo_url": "https://github.com/prohand/gladys-vigieau",
       "name": "VigiEau",
       "type": "device",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "description": {
         "en": "French drought alert levels and water restrictions, from the official VigiEau service.",
         "fr": "Vigilance sécheresse et restrictions d'eau en France, depuis le service officiel VigiEau."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-vigieau.png",
-      "docker_image": "ghcr.io/prohand/gladys-vigieau:2.0.0",
-      "gladys_version": ">=4.62.0",
+      "docker_image": "ghcr.io/prohand/gladys-vigieau:2.0.2",
+      "gladys_version": ">=4.85.0",
       "config_schema": [
         {
           "key": "intro",
@@ -521,7 +826,7 @@
         }
       ],
       "stars": 1,
-      "pushed_at": "2026-08-06T08:18:51Z",
+      "pushed_at": "2026-08-08T19:10:55Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/20227162?v=4"
     },
     {
@@ -672,18 +977,50 @@
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/7365162?v=4"
     },
     {
+      "slug": "charger-station",
+      "store_slug": "sescandell/gladys-ocpp-integration",
+      "repo_url": "https://github.com/sescandell/gladys-ocpp-integration",
+      "name": "Charger Station",
+      "type": "device",
+      "version": "1.0.0",
+      "description": {
+        "en": "Follow your charging stations in Gladys, live, through the OCPP protocol.",
+        "fr": "Suivez vos bornes de recharge dans Gladys, en direct, grâce au protocole OCPP."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/sescandell--gladys-ocpp-integration.png",
+      "docker_image": "ghcr.io/sescandell/gladys-ocpp-integration:1.0.0",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "how_to",
+          "type": "section",
+          "label": {
+            "en": "Connecting a charge point",
+            "fr": "Raccorder une borne"
+          },
+          "description": {
+            "en": "In your charge point's app, note down its current OCPP URL and keep every setting you find there: that's what lets you get back to normal operation if anything goes wrong.\nReplace that URL with ws://{{gladys_host}}:{{port:ocpp}}/ - the same one for every charge point. Your charge point reconnects right away and appears in the Discovery tab: add it to Gladys.\nThen come back here, in the Action section below, select your charge point and paste the OCPP URL you noted in the first step - that's what lets it keep talking to its vendor's cloud, now relayed through Gladys.",
+            "fr": "Dans l'application de votre borne, notez son URL OCPP actuelle et conservez toutes les informations de configuration qui s'y trouvent : c'est ce qui vous permettra de revenir à un fonctionnement normal en cas de problème.\nRemplacez cette URL par ws://{{gladys_host}}:{{port:ocpp}}/ - la même pour toutes vos bornes. Votre borne s'y reconnecte aussitôt et apparaît dans l'onglet Découverte : ajoutez-la à Gladys.\nRevenez ensuite ici, dans la zone Action ci-dessous, sélectionnez votre borne et saisissez l'URL OCPP notée à la première étape - c'est elle qui permet à votre borne de continuer à dialoguer avec le cloud de son fabricant, désormais relayé par Gladys."
+          }
+        }
+      ],
+      "stars": 0,
+      "pushed_at": "2026-08-10T16:41:01Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/1559970?v=4"
+    },
+    {
       "slug": "daikin-cloud",
       "store_slug": "prohand/gladys-daikin-cloud",
       "repo_url": "https://github.com/prohand/gladys-daikin-cloud",
       "name": "Daikin Cloud",
       "type": "device",
-      "version": "1.0.7",
+      "version": "1.0.10",
       "description": {
         "en": "Control your Daikin air conditioners through the official Onecta cloud API.",
         "fr": "Pilotez vos climatiseurs Daikin via l'API cloud officielle Daikin Onecta."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-daikin-cloud.png",
-      "docker_image": "ghcr.io/prohand/gladys-daikin-cloud:1.0.7",
+      "docker_image": "ghcr.io/prohand/gladys-daikin-cloud:1.0.10",
       "gladys_version": ">=4.62.0",
       "config_schema": [
         {
@@ -784,7 +1121,7 @@
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-07T13:48:39Z",
+      "pushed_at": "2026-08-10T20:19:49Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/20227162?v=4"
     },
     {
@@ -968,19 +1305,600 @@
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/11477113?v=4"
     },
     {
+      "slug": "gardena-smart-system",
+      "store_slug": "Nagromdark/gladys-gardena",
+      "repo_url": "https://github.com/Nagromdark/gladys-gardena",
+      "name": "GARDENA smart system",
+      "type": "device",
+      "version": "1.0.1",
+      "description": {
+        "en": "Control your GARDENA mowers, valves, power sockets and sensors from Gladys.",
+        "fr": "Pilotez vos tondeuses, vannes, prises et capteurs GARDENA depuis Gladys."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/Nagromdark--gladys-gardena.png",
+      "docker_image": "ghcr.io/nagromdark/gladys-gardena:1.0.1",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "intro",
+          "type": "section",
+          "label": {
+            "en": "Connect your GARDENA account",
+            "fr": "Connectez votre compte GARDENA"
+          },
+          "description": {
+            "en": "This integration uses the official public GARDENA smart system API. Create a free account on the Husqvarna developer portal, sign in with your GARDENA (Husqvarna) account, create an application, connect the \"GARDENA smart system API\" to it, then copy its Application key and Application secret below.",
+            "fr": "Cette intégration utilise l'API publique officielle GARDENA smart system. Créez un compte gratuit sur le portail développeur Husqvarna, connectez-vous avec votre compte GARDENA (Husqvarna), créez une application, connectez-lui l'API « GARDENA smart system API », puis copiez sa clé et son secret d'application ci-dessous."
+          },
+          "links": [
+            {
+              "url": "https://developer.husqvarnagroup.cloud/",
+              "label": {
+                "en": "Husqvarna developer portal",
+                "fr": "Portail développeur Husqvarna"
+              }
+            },
+            {
+              "url": "https://developer.husqvarnagroup.cloud/apis/gardena-smart-system-api",
+              "label": {
+                "en": "GARDENA smart system API",
+                "fr": "API GARDENA smart system"
+              }
+            }
+          ]
+        },
+        {
+          "key": "application_key",
+          "type": "string",
+          "label": {
+            "en": "Application key",
+            "fr": "Clé d'application"
+          },
+          "description": {
+            "en": "The Application key of your application on the Husqvarna developer portal.",
+            "fr": "La clé d'application de votre application sur le portail développeur Husqvarna."
+          },
+          "placeholder": {
+            "en": "00000000-0000-0000-0000-000000000000",
+            "fr": "00000000-0000-0000-0000-000000000000"
+          },
+          "required": true
+        },
+        {
+          "key": "application_secret",
+          "type": "secret",
+          "label": {
+            "en": "Application secret",
+            "fr": "Secret d'application"
+          },
+          "description": {
+            "en": "The Application secret of the same application. It is stored encrypted and never sent back to the browser.",
+            "fr": "Le secret d'application de cette même application. Il est stocké chiffré et n'est jamais renvoyé au navigateur."
+          },
+          "required": true
+        },
+        {
+          "key": "location_id",
+          "type": "string",
+          "label": {
+            "en": "Location id (optional)",
+            "fr": "Identifiant d'emplacement (optionnel)"
+          },
+          "description": {
+            "en": "Restrict the integration to a single GARDENA location (garden). Leave empty to use every location of the account.",
+            "fr": "Limiter l'intégration à un seul emplacement GARDENA (jardin). Laissez vide pour utiliser tous les emplacements du compte."
+          },
+          "required": false
+        },
+        {
+          "key": "poll_frequency",
+          "type": "number",
+          "label": {
+            "en": "GARDENA API refresh (s)",
+            "fr": "Relecture de l'API GARDENA (s)"
+          },
+          "description": {
+            "en": "Minimum delay between two full reads of the GARDENA API, the safety net behind the real-time stream. GARDENA counts a weekly request quota and this is what spends it: one hour costs about 170 calls a week, fifteen minutes would cost about 670. Changes already arrive in real time, so keep it high.",
+            "fr": "Délai minimum entre deux relectures complètes de l'API GARDENA, le filet de sécurité derrière le flux temps réel. GARDENA compte un quota hebdomadaire de requêtes et c'est ce réglage qui le consomme : une heure coûte environ 170 appels par semaine, quinze minutes en coûteraient environ 670. Les changements arrivent déjà en temps réel, gardez une valeur élevée."
+          },
+          "required": false,
+          "default": 3600,
+          "min": 900,
+          "max": 86400
+        },
+        {
+          "key": "default_duration",
+          "type": "number",
+          "label": {
+            "en": "Default duration (min)",
+            "fr": "Durée par défaut (min)"
+          },
+          "description": {
+            "en": "How long a valve waters, or a power socket stays on, when you switch it on from Gladys.",
+            "fr": "Durée d'arrosage d'une vanne, ou d'allumage d'une prise, lorsque vous l'activez depuis Gladys."
+          },
+          "required": false,
+          "default": 30,
+          "min": 1,
+          "max": 1440
+        },
+        {
+          "key": "power_socket_on_mode",
+          "type": "select",
+          "label": {
+            "en": "Power socket switch-on",
+            "fr": "Allumage des prises"
+          },
+          "description": {
+            "en": "What happens when a GARDENA power socket is switched on from Gladys.",
+            "fr": "Ce qui se passe lorsqu'une prise GARDENA est allumée depuis Gladys."
+          },
+          "required": false,
+          "default": "duration",
+          "options": [
+            {
+              "value": "duration",
+              "label": {
+                "en": "Switch off after the default duration",
+                "fr": "Éteindre après la durée par défaut"
+              }
+            },
+            {
+              "value": "forever",
+              "label": {
+                "en": "Stay on until switched off",
+                "fr": "Rester allumée jusqu'à extinction"
+              }
+            }
+          ]
+        },
+        {
+          "key": "mower_start_mode",
+          "type": "select",
+          "label": {
+            "en": "Mower start",
+            "fr": "Démarrage de la tondeuse"
+          },
+          "description": {
+            "en": "What starting the mower from Gladys means: let it obey its own calendar, or override it for a fixed duration.",
+            "fr": "Ce que signifie démarrer la tondeuse depuis Gladys : la laisser suivre son calendrier, ou le forcer pendant une durée fixe."
+          },
+          "required": false,
+          "default": "schedule",
+          "options": [
+            {
+              "value": "schedule",
+              "label": {
+                "en": "Obey the mower schedule",
+                "fr": "Suivre le calendrier de la tondeuse"
+              }
+            },
+            {
+              "value": "duration",
+              "label": {
+                "en": "Mow for the duration below",
+                "fr": "Tondre pendant la durée ci-dessous"
+              }
+            }
+          ]
+        },
+        {
+          "key": "mower_duration",
+          "type": "number",
+          "label": {
+            "en": "Mowing duration (min)",
+            "fr": "Durée de tonte (min)"
+          },
+          "description": {
+            "en": "Used when the mower start mode overrides the schedule.",
+            "fr": "Utilisée lorsque le mode de démarrage force le calendrier."
+          },
+          "required": false,
+          "default": 180,
+          "min": 1,
+          "max": 1440
+        },
+        {
+          "key": "mower_stop_mode",
+          "type": "select",
+          "label": {
+            "en": "Mower stop",
+            "fr": "Arrêt de la tondeuse"
+          },
+          "description": {
+            "en": "What stopping the mower from Gladys means: park it until the next scheduled task, or cancel the schedule entirely.",
+            "fr": "Ce que signifie arrêter la tondeuse depuis Gladys : la garer jusqu'à la prochaine tâche planifiée, ou annuler le calendrier."
+          },
+          "required": false,
+          "default": "next_task",
+          "options": [
+            {
+              "value": "next_task",
+              "label": {
+                "en": "Park until the next scheduled task",
+                "fr": "Garer jusqu'à la prochaine tâche"
+              }
+            },
+            {
+              "value": "further_notice",
+              "label": {
+                "en": "Park until further notice",
+                "fr": "Garer jusqu'à nouvel ordre"
+              }
+            }
+          ]
+        }
+      ],
+      "stars": 0,
+      "pushed_at": "2026-08-11T17:43:18Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/214889285?v=4"
+    },
+    {
+      "slug": "home-connect",
+      "store_slug": "prohand/gladys-homeconnect",
+      "repo_url": "https://github.com/prohand/gladys-homeconnect",
+      "name": "Home Connect",
+      "type": "device",
+      "version": "1.0.4",
+      "description": {
+        "en": "Monitor and control your Bosch, Siemens, Neff and Gaggenau appliances via Home Connect.",
+        "fr": "Pilotez et suivez vos appareils Bosch, Siemens, Neff et Gaggenau via Home Connect."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-homeconnect.png",
+      "docker_image": "ghcr.io/prohand/gladys-homeconnect:1.0.4",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "intro",
+          "type": "section",
+          "label": {
+            "en": "Before you start",
+            "fr": "Avant de commencer"
+          },
+          "description": {
+            "en": "Home Connect has no local API: everything goes through the BSH cloud. Create a free developer account, register an application of type \"Home Connect Application\" with the Authorization Code Grant Flow, and paste its Client ID and Client Secret below. The redirect URI to register is shown by the \"Test the connection\" action once you start the connection.",
+            "fr": "Home Connect n'a pas d'API locale : tout passe par le cloud BSH. Créez un compte développeur gratuit, enregistrez une application de type « Home Connect Application » avec le flux Authorization Code Grant, puis collez ses Client ID et Client Secret ci-dessous. L'URL de redirection à déclarer est affichée par l'action « Tester la connexion » une fois la connexion lancée."
+          },
+          "links": [
+            {
+              "url": "https://developer.home-connect.com/",
+              "label": {
+                "en": "Home Connect developer portal",
+                "fr": "Portail développeur Home Connect"
+              }
+            },
+            {
+              "url": "https://developer.home-connect.com/application/add",
+              "label": {
+                "en": "Register an application",
+                "fr": "Enregistrer une application"
+              }
+            }
+          ]
+        },
+        {
+          "key": "client_id",
+          "type": "string",
+          "label": {
+            "en": "Client ID",
+            "fr": "Client ID"
+          },
+          "description": {
+            "en": "Client ID of your Home Connect application.",
+            "fr": "Client ID de votre application Home Connect."
+          },
+          "required": true,
+          "placeholder": {
+            "en": "1A2B3C…",
+            "fr": "1A2B3C…"
+          }
+        },
+        {
+          "key": "client_secret",
+          "type": "secret",
+          "label": {
+            "en": "Client Secret",
+            "fr": "Client Secret"
+          },
+          "description": {
+            "en": "Client Secret of your Home Connect application. Leave empty only if you registered a public client without a secret.",
+            "fr": "Client Secret de votre application Home Connect. Laissez vide uniquement si vous avez enregistré un client public sans secret."
+          },
+          "required": false
+        },
+        {
+          "key": "account",
+          "type": "oauth2",
+          "label": {
+            "en": "Home Connect account",
+            "fr": "Compte Home Connect"
+          },
+          "description": {
+            "en": "Sign in with the Home Connect account your appliances are paired with, then allow Gladys.",
+            "fr": "Connectez-vous avec le compte Home Connect auquel vos appareils sont associés, puis autorisez Gladys."
+          },
+          "required": true
+        },
+        {
+          "key": "language",
+          "type": "select",
+          "label": {
+            "en": "Language",
+            "fr": "Langue"
+          },
+          "description": {
+            "en": "Language of the device feature names and of the program names returned by Home Connect.",
+            "fr": "Langue des noms de fonctionnalités et des noms de programmes renvoyés par Home Connect."
+          },
+          "required": false,
+          "default": "fr",
+          "options": [
+            {
+              "value": "fr",
+              "label": {
+                "en": "French",
+                "fr": "Français"
+              }
+            },
+            {
+              "value": "en",
+              "label": {
+                "en": "English",
+                "fr": "Anglais"
+              }
+            }
+          ]
+        },
+        {
+          "key": "poll_frequency",
+          "type": "number",
+          "label": {
+            "en": "Refresh interval (s)",
+            "fr": "Intervalle de rafraîchissement (s)"
+          },
+          "description": {
+            "en": "Safety net behind the real-time event stream. Home Connect enforces a daily request quota, so keep it high unless you have a reason not to.",
+            "fr": "Filet de sécurité derrière le flux d'événements temps réel. Home Connect impose un quota de requêtes quotidien : gardez une valeur élevée sauf raison particulière."
+          },
+          "required": false,
+          "default": 900,
+          "min": 120,
+          "max": 3600
+        },
+        {
+          "key": "scope",
+          "type": "string",
+          "label": {
+            "en": "OAuth scopes",
+            "fr": "Scopes OAuth"
+          },
+          "description": {
+            "en": "Space-separated Home Connect scopes requested during authorization. Narrow it down if your developer application was registered with fewer permissions.",
+            "fr": "Scopes Home Connect demandés lors de l'autorisation, séparés par des espaces. Réduisez-les si votre application développeur a été enregistrée avec moins de permissions."
+          },
+          "required": false,
+          "default": "IdentifyAppliance Monitor Settings Control"
+        },
+        {
+          "key": "use_simulator",
+          "type": "boolean",
+          "label": {
+            "en": "Use the Home Connect simulator",
+            "fr": "Utiliser le simulateur Home Connect"
+          },
+          "description": {
+            "en": "Talk to simulator.home-connect.com instead of the production API, to test without real appliances.",
+            "fr": "Utiliser simulator.home-connect.com au lieu de l'API de production, pour tester sans appareil réel."
+          },
+          "required": false,
+          "default": false
+        }
+      ],
+      "stars": 0,
+      "pushed_at": "2026-08-13T11:11:52Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/20227162?v=4"
+    },
+    {
+      "slug": "immich-slideshow",
+      "store_slug": "gboulvin/Gladys-Immich",
+      "repo_url": "https://github.com/gboulvin/Gladys-Immich",
+      "name": "Immich Slideshow",
+      "type": "device",
+      "version": "0.1.2",
+      "description": {
+        "en": "Streams an Immich album or memories as a Gladys dashboard camera slideshow.",
+        "fr": "Diffuse un album ou les souvenirs Immich en diaporama caméra sur le dashboard Gladys."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/gboulvin--Gladys-Immich.jpg",
+      "docker_image": "ghcr.io/gboulvin/gladys-immich:0.1.2",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "intro",
+          "type": "section",
+          "label": {
+            "en": "Connect Immich",
+            "fr": "Connecter Immich"
+          },
+          "description": {
+            "en": "Create an Immich API key with album.read, asset.view, and memory.read permissions. The key is securely stored by Gladys and is never sent to the dashboard browser.",
+            "fr": "Créez une clé API Immich avec les permissions album.read, asset.view et memory.read. Gladys stocke cette clé de manière sécurisée ; elle n’est jamais envoyée au navigateur du dashboard."
+          },
+          "links": [
+            {
+              "url": "https://docs.immich.app/features/administration/user-settings/",
+              "label": {
+                "en": "Immich user settings",
+                "fr": "Paramètres utilisateur Immich"
+              }
+            },
+            {
+              "url": "https://api.immich.app/endpoints",
+              "label": {
+                "en": "Immich API reference",
+                "fr": "Référence de l’API Immich"
+              }
+            }
+          ]
+        },
+        {
+          "key": "immich_url",
+          "type": "string",
+          "label": {
+            "en": "Immich server URL",
+            "fr": "URL du serveur Immich"
+          },
+          "description": {
+            "en": "For example: http://192.168.1.20:2283. The Gladys integration container must be able to reach this address.",
+            "fr": "Par exemple : http://192.168.1.20:2283. Le conteneur d’intégration Gladys doit pouvoir joindre cette adresse."
+          },
+          "placeholder": {
+            "en": "https://immich.example.net",
+            "fr": "https://immich.exemple.net"
+          },
+          "required": true
+        },
+        {
+          "key": "api_key",
+          "type": "secret",
+          "label": {
+            "en": "Immich API key",
+            "fr": "Clé API Immich"
+          },
+          "placeholder": {
+            "en": "Paste the API key",
+            "fr": "Collez la clé API"
+          },
+          "required": true
+        },
+        {
+          "key": "source_mode",
+          "type": "select",
+          "label": {
+            "en": "Photo source",
+            "fr": "Source des photos"
+          },
+          "description": {
+            "en": "Choose a specific album or Immich memories from this day in previous years.",
+            "fr": "Choisissez un album précis ou les souvenirs Immich de cette date les années précédentes."
+          },
+          "required": true,
+          "default": "album",
+          "options": [
+            {
+              "value": "album",
+              "label": {
+                "en": "Album",
+                "fr": "Album"
+              }
+            },
+            {
+              "value": "memories",
+              "label": {
+                "en": "Memories — on this day",
+                "fr": "Souvenirs — ce jour-là"
+              }
+            }
+          ]
+        },
+        {
+          "key": "album_id",
+          "type": "string",
+          "label": {
+            "en": "Album UUID",
+            "fr": "UUID de l’album"
+          },
+          "description": {
+            "en": "Required only when the source is Album. Copy the UUID from the album URL in Immich; leave it empty for Memories.",
+            "fr": "Requis uniquement pour la source Album. Copiez l’UUID dans l’URL de l’album Immich ; laissez vide pour Souvenirs."
+          },
+          "placeholder": {
+            "en": "e.g. 1033b9e2-…",
+            "fr": "ex. 1033b9e2-…"
+          },
+          "required": false
+        },
+        {
+          "key": "slide_interval",
+          "type": "number",
+          "label": {
+            "en": "Slide interval (seconds)",
+            "fr": "Intervalle entre les photos (secondes)"
+          },
+          "description": {
+            "en": "How long each image stays on the dashboard camera. The minimum respects Gladys camera-channel limits.",
+            "fr": "Durée d’affichage de chaque image sur la caméra du dashboard. Le minimum respecte les limites du canal caméra Gladys."
+          },
+          "required": true,
+          "default": 60,
+          "min": 10,
+          "max": 3600
+        },
+        {
+          "key": "source_refresh_interval",
+          "type": "number",
+          "label": {
+            "en": "Source refresh interval (seconds)",
+            "fr": "Intervalle d’actualisation de la source (secondes)"
+          },
+          "description": {
+            "en": "How often the integration asks Immich again for the album or today’s memories. Existing slides continue between refreshes.",
+            "fr": "Fréquence à laquelle l’intégration redemande l’album ou les souvenirs du jour à Immich. Les diapositives existantes défilent entre deux actualisations."
+          },
+          "required": true,
+          "default": 3600,
+          "min": 300,
+          "max": 86400
+        },
+        {
+          "key": "max_assets",
+          "type": "number",
+          "label": {
+            "en": "Maximum images",
+            "fr": "Nombre maximal d’images"
+          },
+          "description": {
+            "en": "Caps large albums to keep the integration responsive. The newest images are selected unless random order is enabled.",
+            "fr": "Limite les grands albums pour préserver la réactivité. Les images les plus récentes sont sélectionnées, sauf si l’ordre aléatoire est activé."
+          },
+          "required": true,
+          "default": 200,
+          "min": 1,
+          "max": 500
+        },
+        {
+          "key": "random_order",
+          "type": "boolean",
+          "label": {
+            "en": "Randomize images",
+            "fr": "Mélanger les images"
+          },
+          "description": {
+            "en": "When disabled, the slideshow starts with the most recent image.",
+            "fr": "Lorsqu’il est désactivé, le diaporama commence par l’image la plus récente."
+          },
+          "required": false,
+          "default": false
+        }
+      ],
+      "stars": 0,
+      "pushed_at": "2026-08-13T16:55:40Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/78817935?v=4"
+    },
+    {
       "slug": "indice-uv",
       "store_slug": "prohand/gladys-uvindex",
       "repo_url": "https://github.com/prohand/gladys-uvindex",
       "name": "Indice UV",
       "type": "device",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "description": {
         "en": "UV index for the locations you choose, from the Copernicus CAMS forecast.",
         "fr": "Indice UV des lieux de votre choix, via la prévision CAMS de Copernicus."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-uvindex.jpg",
-      "docker_image": "ghcr.io/prohand/gladys-uvindex:1.0.2",
-      "gladys_version": ">=4.62.0",
+      "docker_image": "ghcr.io/prohand/gladys-uvindex:1.0.4",
+      "gladys_version": ">=4.85.0",
       "config_schema": [
         {
           "key": "intro",
@@ -1083,13 +2001,13 @@
             "fr": "Vos lieux"
           },
           "description": {
-            "en": "Use the buttons below to add, list and remove your locations. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list.",
-            "fr": "Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste."
+            "en": "Use the buttons below to add, list and remove your locations. \"Add my Gladys houses\" adds them all in one click, from the houses you already placed on the map in Gladys. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list.",
+            "fr": "Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. « Ajouter mes maisons Gladys » les ajoute tous en un clic, à partir des maisons que vous avez déjà placées sur la carte dans Gladys. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste."
           }
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-07T09:31:59Z",
+      "pushed_at": "2026-08-08T19:24:32Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/20227162?v=4"
     },
     {
@@ -1145,6 +2063,306 @@
       "stars": 0,
       "pushed_at": "2026-07-23T12:42:21Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/7365162?v=4"
+    },
+    {
+      "slug": "meross",
+      "store_slug": "PhilippeMA/gladys-Meross",
+      "repo_url": "https://github.com/PhilippeMA/gladys-Meross",
+      "name": "Meross",
+      "type": "device",
+      "version": "1.1.0",
+      "description": {
+        "en": "Read and control your Meross smart plugs, switches, lights and garage doors.",
+        "fr": "Pilotez vos prises, interrupteurs, lampes et portes de garage Meross."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-Meross.png",
+      "docker_image": "ghcr.io/philippema/gladys-meross:1.1.0",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "intro",
+          "type": "section",
+          "label": {
+            "en": "Connect your Meross account",
+            "fr": "Connectez votre compte Meross"
+          },
+          "description": {
+            "en": "Sign in with the same email and password you use in the Meross mobile app. Your devices are then discovered automatically, with no pairing to redo. Meross allows a limited number of[...]",
+            "fr": "Utilisez les mêmes identifiants que dans l'application mobile Meross. Vos appareils sont ensuite découverts automatiquement, sans réappairage. Meross limite le nombre de sessions[...]"
+          },
+          "links": [
+            {
+              "url": "https://www.meross.com/support/",
+              "label": {
+                "en": "Meross support",
+                "fr": "Support Meross"
+              }
+            }
+          ]
+        },
+        {
+          "key": "email",
+          "type": "string",
+          "label": {
+            "en": "Meross email",
+            "fr": "E-mail Meross"
+          },
+          "description": {
+            "en": "The email address of your Meross account.",
+            "fr": "L'adresse e-mail de votre compte Meross."
+          },
+          "placeholder": {
+            "en": "you@example.com",
+            "fr": "vous@exemple.com"
+          },
+          "required": true
+        },
+        {
+          "key": "password",
+          "type": "secret",
+          "label": {
+            "en": "Meross password",
+            "fr": "Mot de passe Meross"
+          },
+          "description": {
+            "en": "Stored encrypted by Gladys and only ever sent, hashed, to the Meross authentication server.",
+            "fr": "Stocké chiffré par Gladys et envoyé uniquement, sous forme hachée, au serveur d'authentification Meross."
+          },
+          "required": true
+        },
+        {
+          "key": "region",
+          "type": "select",
+          "label": {
+            "en": "Meross region",
+            "fr": "Région Meross"
+          },
+          "description": {
+            "en": "The region your Meross account was created in. Pick the wrong one and the login is refused.",
+            "fr": "La région de création de votre compte Meross. En cas d'erreur, la connexion est refusée."
+          },
+          "required": true,
+          "default": "eu",
+          "options": [
+            {
+              "value": "eu",
+              "label": {
+                "en": "Europe",
+                "fr": "Europe"
+              }
+            },
+            {
+              "value": "us",
+              "label": {
+                "en": "America",
+                "fr": "Amérique"
+              }
+            },
+            {
+              "value": "ap",
+              "label": {
+                "en": "Asia / Pacific",
+                "fr": "Asie / Pacifique"
+              }
+            },
+            {
+              "value": "global",
+              "label": {
+                "en": "Global (default)",
+                "fr": "Global (par défaut)"
+              }
+            }
+          ]
+        },
+        {
+          "key": "poll_frequency",
+          "type": "select",
+          "label": {
+            "en": "Refresh interval",
+            "fr": "Intervalle de rafraîchissement"
+          },
+          "description": {
+            "en": "How often metering plugs and hub sensors are read. On/off states arrive in real time and are never polled, so the slowest setting suits most homes.",
+            "fr": "Fréquence de lecture des prises avec mesure et des capteurs de hub. Les états on/off arrivent en temps réel : l'intervalle le plus lent convient à la plupart des installations.[...]"
+          },
+          "required": false,
+          "default": "60000",
+          "options": [
+            {
+              "value": "60000",
+              "label": {
+                "en": "Every minute",
+                "fr": "Chaque minute"
+              }
+            },
+            {
+              "value": "30000",
+              "label": {
+                "en": "Every 30 seconds",
+                "fr": "Toutes les 30 secondes"
+              }
+            },
+            {
+              "value": "15000",
+              "label": {
+                "en": "Every 15 seconds",
+                "fr": "Toutes les 15 secondes"
+              }
+            },
+            {
+              "value": "10000",
+              "label": {
+                "en": "Every 10 seconds",
+                "fr": "Toutes les 10 secondes"
+              }
+            },
+            {
+              "value": "2000",
+              "label": {
+                "en": "Every 2 seconds",
+                "fr": "Toutes les 2 secondes"
+              }
+            },
+            {
+              "value": "1000",
+              "label": {
+                "en": "Every second",
+                "fr": "Chaque seconde"
+              }
+            }
+          ]
+        }
+      ],
+      "stars": 0,
+      "pushed_at": "2026-08-11T15:57:06Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/25247304?v=4"
+    },
+    {
+      "slug": "meteo-benelux",
+      "store_slug": "gboulvin/Gladys-IRM-KMI-V2",
+      "repo_url": "https://github.com/gboulvin/Gladys-IRM-KMI-V2",
+      "name": "Météo Bénélux",
+      "type": "weather",
+      "version": "1.0.2",
+      "description": {
+        "fr": "Prévisions, conditions courantes et avertissements météo de l’IRM/KMI pour le Benelux.",
+        "en": "IRM/KMI current weather, forecasts and alerts for Belgium, Luxembourg and the Netherlands."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/placeholder.png",
+      "docker_image": "ghcr.io/gboulvin/gladys-irm-kmi-v2:1.0.2",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "intro",
+          "type": "section",
+          "label": {
+            "fr": "Données IRM/KMI",
+            "en": "IRM/KMI data"
+          },
+          "description": {
+            "fr": "Cette intégration utilise l’API mobile non documentée de l’Institut royal météorologique de Belgique. Aucun compte ni clé personnelle n’est requis. Le service couvre la Belgique, le Luxembourg et les Pays-Bas ; son interface peut évoluer sans préavis.",
+            "en": "This integration uses the undocumented mobile API of the Royal Meteorological Institute of Belgium. No account or personal key is required. The service covers Belgium, Luxembourg and the Netherlands; its interface may change without notice."
+          },
+          "links": [
+            {
+              "url": "https://github.com/jdejaegh/irm-kmi-api",
+              "label": {
+                "fr": "Référence technique du protocole IRM/KMI",
+                "en": "IRM/KMI protocol technical reference"
+              }
+            }
+          ]
+        },
+        {
+          "key": "cache_duration",
+          "type": "number",
+          "label": {
+            "fr": "Durée du cache (secondes)",
+            "en": "Cache duration (seconds)"
+          },
+          "description": {
+            "fr": "Durée de conservation d’une prévision pour une même position. La valeur 0 désactive le cache.",
+            "en": "How long a forecast for the same location is kept. Set to 0 to disable caching."
+          },
+          "required": false,
+          "default": 600,
+          "min": 0,
+          "max": 3600
+        }
+      ],
+      "stars": 0,
+      "pushed_at": "2026-08-12T20:29:27Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/78817935?v=4"
+    },
+    {
+      "slug": "meteo-france",
+      "store_slug": "William-De71/gladys-meteo-france",
+      "repo_url": "https://github.com/William-De71/gladys-meteo-france",
+      "name": "Météo France",
+      "type": "weather",
+      "version": "1.0.1",
+      "description": {
+        "en": "French weather forecasts and official vigilance alerts from Météo France.",
+        "fr": "Prévisions météo et vigilance officielle Météo France pour la France."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/William-De71--gladys-meteo-france.jpg",
+      "docker_image": "ghcr.io/william-de71/gladys-meteo-france:1.0.1",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "intro",
+          "type": "section",
+          "label": {
+            "en": "Ready to use",
+            "fr": "Prêt à l'emploi"
+          },
+          "description": {
+            "en": "Forecasts and vigilance alerts work with no configuration at all. The optional API key below only unlocks the national vigilance map image.",
+            "fr": "Les prévisions et la vigilance fonctionnent sans aucune configuration. La clé d'API optionnelle ci-dessous sert uniquement à afficher la carte de vigilance nationale."
+          },
+          "links": [
+            {
+              "url": "https://portail-api.meteofrance.fr/",
+              "label": {
+                "en": "Météo France API portal",
+                "fr": "Portail API Météo France"
+              }
+            }
+          ]
+        },
+        {
+          "key": "api_key",
+          "type": "secret",
+          "label": {
+            "en": "Météo France API key (optional)",
+            "fr": "Clé d'API Météo France (optionnelle)"
+          },
+          "description": {
+            "en": "Only needed to display the national vigilance map. Create a free account on the Météo France API portal and subscribe to the \"Données Publiques de Vigilance\" API. Pick the \"API Key\" token type, NOT OAuth2 (which expires after about an hour), and set the mandatory \"Durée\" field to 94672800 seconds — about 3 years, the maximum the portal accepts. The map stops loading once that duration runs out.",
+            "fr": "Nécessaire uniquement pour afficher la carte de vigilance nationale. Créez un compte gratuit sur le portail API Météo France et souscrivez à l'API « Données Publiques de Vigilance ». Choisissez le type de token « API Key », PAS OAuth2 (qui expire au bout d'une heure environ), et renseignez le champ obligatoire « Durée » avec 94672800 secondes — environ 3 ans, le maximum accepté par le portail. La carte cesse de s'afficher une fois cette durée écoulée."
+          },
+          "required": false
+        },
+        {
+          "key": "cache_duration",
+          "type": "number",
+          "label": {
+            "en": "Cache duration (s)",
+            "fr": "Durée du cache (s)"
+          },
+          "description": {
+            "en": "In seconds, between 0 and 3600. How long a weather answer is reused before calling Météo France again. The forecast endpoint can take up to 20 seconds on a cold cache, so reusing a recent answer keeps the dashboard responsive. The default of 600 (10 min) suits most setups; raising it to 1800 costs almost no freshness, as Météo France only refreshes a few times an hour. Set to 0 to always call the API (slower dashboard). A vigilance change always refreshes immediately, whatever this value.",
+            "fr": "En secondes, entre 0 et 3600. Durée pendant laquelle une réponse est réutilisée avant de rappeler Météo France. L'API de prévisions peut mettre jusqu'à 20 secondes à froid : réutiliser une réponse récente garde le tableau de bord réactif. La valeur par défaut de 600 (10 min) convient à la plupart des installations ; monter à 1800 ne fait presque rien perdre en fraîcheur, Météo France ne mettant à jour que quelques fois par heure. Mettre 0 pour toujours appeler l'API (tableau de bord plus lent). Une vigilance qui change rafraîchit toujours immédiatement, quelle que soit cette valeur."
+          },
+          "required": false,
+          "default": 600,
+          "min": 0,
+          "max": 3600
+        }
+      ],
+      "stars": 0,
+      "pushed_at": "2026-08-08T12:55:55Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/11477113?v=4"
     },
     {
       "slug": "myneomitis-axenco",
@@ -1239,13 +2457,13 @@
       "repo_url": "https://github.com/Terdious/gladys-netatmo",
       "name": "Netatmo",
       "type": "device",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "description": {
         "en": "Connect your Netatmo devices (weather station, thermostats, cameras) to Gladys Assistant.",
         "fr": "Connectez vos appareils Netatmo (station météo, thermostats, caméras) à Gladys Assistant."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/Terdious--gladys-netatmo.png",
-      "docker_image": "ghcr.io/terdious/gladys-netatmo:1.1.1",
+      "docker_image": "ghcr.io/terdious/gladys-netatmo:1.2.0",
       "gladys_version": ">=4.83.0",
       "config_schema": [
         {
@@ -1415,7 +2633,7 @@
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-07-23T21:59:24Z",
+      "pushed_at": "2026-08-08T16:11:16Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/35010958?v=4"
     },
     {
@@ -1531,13 +2749,13 @@
       "repo_url": "https://github.com/GladysAssistant/gladys-openweather",
       "name": "OpenWeather",
       "type": "weather",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": {
         "en": "Weather conditions, forecasts and alerts from OpenWeather.",
         "fr": "Conditions, prévisions et alertes météo fournies par OpenWeather."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/GladysAssistant--gladys-openweather.png",
-      "docker_image": "ghcr.io/gladysassistant/gladys-openweather:1.0.1",
+      "docker_image": "ghcr.io/gladysassistant/gladys-openweather:1.0.2",
       "gladys_version": ">=4.85.0",
       "config_schema": [
         {
@@ -1634,7 +2852,7 @@
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-07T13:32:16Z",
+      "pushed_at": "2026-08-10T13:36:24Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/7365162?v=4"
     },
     {
@@ -1643,13 +2861,13 @@
       "repo_url": "https://github.com/cicoub13/gladys-overkiz",
       "name": "Overkiz",
       "type": "device",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "description": {
         "en": "Control your Overkiz devices (Somfy TaHoma, Connexoon, Cozytouch...).",
         "fr": "Contrôlez vos appareils Overkiz (Somfy TaHoma, Connexoon, Cozytouch...)."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/cicoub13--gladys-overkiz.png",
-      "docker_image": "ghcr.io/cicoub13/gladys-overkiz:1.1.0",
+      "docker_image": "ghcr.io/cicoub13/gladys-overkiz:1.1.1",
       "gladys_version": ">=4.84.0",
       "config_schema": [
         {
@@ -1774,7 +2992,7 @@
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-07T11:36:12Z",
+      "pushed_at": "2026-08-10T12:20:03Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/1773153?v=4"
     },
     {
@@ -1873,14 +3091,14 @@
       "repo_url": "https://github.com/prohand/gladys-pollen",
       "name": "Pollens",
       "type": "device",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "description": {
         "en": "Pollen risk for the locations you choose, from the Copernicus CAMS European forecast.",
         "fr": "Risque pollinique pour les lieux de votre choix, via la prévision européenne CAMS de Copernicus."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-pollen.png",
-      "docker_image": "ghcr.io/prohand/gladys-pollen:1.0.1",
-      "gladys_version": ">=4.62.0",
+      "docker_image": "ghcr.io/prohand/gladys-pollen:1.0.3",
+      "gladys_version": ">=4.85.0",
       "config_schema": [
         {
           "key": "intro",
@@ -1976,13 +3194,13 @@
             "fr": "Vos lieux"
           },
           "description": {
-            "en": "Use the buttons below to add, list and remove your locations. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list.",
-            "fr": "Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste."
+            "en": "Use the buttons below to add, list and remove your locations. \"Add my Gladys houses\" turns the houses you already placed on the map in Gladys into locations, in one click. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list.",
+            "fr": "Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. « Ajouter mes maisons Gladys » transforme en lieux, en un clic, les maisons que vous avez déjà placées sur la carte dans Gladys. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste."
           }
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-06T15:33:04Z",
+      "pushed_at": "2026-08-08T19:05:20Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/20227162?v=4"
     },
     {
@@ -1991,14 +3209,14 @@
       "repo_url": "https://github.com/prohand/gladys-airquality",
       "name": "Qualité de l'air",
       "type": "device",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "description": {
         "en": "Air quality index of any town in the world, from the Copernicus CAMS data.",
         "fr": "Indice de qualité de l'air de n'importe quelle commune du monde, données CAMS Copernicus."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-airquality.png",
-      "docker_image": "ghcr.io/prohand/gladys-airquality:1.0.1",
-      "gladys_version": ">=4.62.0",
+      "docker_image": "ghcr.io/prohand/gladys-airquality:1.0.3",
+      "gladys_version": ">=4.85.0",
       "config_schema": [
         {
           "key": "intro",
@@ -2101,13 +3319,13 @@
             "fr": "Vos lieux"
           },
           "description": {
-            "en": "Use the buttons below to add, list and remove your locations. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list.",
-            "fr": "Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste."
+            "en": "Use the buttons below to add, list and remove your locations. \"Add my Gladys houses\" adds them all in one click, from the houses you already placed on the map in Gladys. They are not fields of this form: a list you build as you go cannot be one, so everything about them happens under a button, and the answer displayed there is what shows you the list.",
+            "fr": "Utilisez les boutons ci-dessous pour ajouter, lister et supprimer vos lieux. « Ajouter mes maisons Gladys » les ajoute toutes en un clic, à partir des maisons que vous avez déjà placées sur la carte dans Gladys. Ce ne sont pas des champs de ce formulaire : une liste que l'on construit au fil de l'eau ne peut pas en être un, donc tout se passe sous un bouton et c'est la réponse affichée là qui vous montre la liste."
           }
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-07T12:20:24Z",
+      "pushed_at": "2026-08-11T08:42:19Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/20227162?v=4"
     },
     {
@@ -2116,13 +3334,13 @@
       "repo_url": "https://github.com/William-De71/gladys-reolink",
       "name": "Reolink",
       "type": "device",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": {
         "en": "Your Reolink cameras in Gladys: images, detections, spotlight and siren.",
         "fr": "Vos caméras Reolink dans Gladys : images, détections, projecteur et sirène."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/William-De71--gladys-reolink.jpg",
-      "docker_image": "ghcr.io/william-de71/gladys-reolink:1.0.0",
+      "docker_image": "ghcr.io/william-de71/gladys-reolink:1.0.1",
       "gladys_version": ">=4.84.0",
       "config_schema": [
         {
@@ -2379,7 +3597,7 @@
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-02T21:07:43Z",
+      "pushed_at": "2026-08-07T21:22:14Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/11477113?v=4"
     },
     {
@@ -2388,13 +3606,13 @@
       "repo_url": "https://github.com/callemand/gladys-roborock",
       "name": "Roborock",
       "type": "device",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "description": {
-        "en": "Robot vacuums paired in the Roborock app: state, start/stop, fan power, dock, battery.",
-        "fr": "Aspirateurs robots de l'application Roborock : état, marche/arrêt, aspiration, base, batterie."
+        "en": "Robot vacuums paired in the Roborock app: state, start/stop, fan power, dock, battery and routines.",
+        "fr": "Aspirateurs robots de l'application Roborock : état, marche/arrêt, aspiration, base, routines."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/callemand--gladys-roborock.jpg",
-      "docker_image": "ghcr.io/callemand/gladys-roborock:2.1.1",
+      "docker_image": "ghcr.io/callemand/gladys-roborock:2.2.0",
       "gladys_version": ">=4.62.0",
       "config_schema": [
         {
@@ -2411,7 +3629,7 @@
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-07T12:47:36Z",
+      "pushed_at": "2026-08-11T11:29:27Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/11317212?v=4"
     },
     {
@@ -2420,46 +3638,46 @@
       "repo_url": "https://github.com/PhilippeMA/gladys-Vaillant-SaunierDuval",
       "name": "Saunier Duval",
       "type": "device",
-      "version": "2.0.0",
+      "version": "1.0.1",
       "description": {
-        "en": "Control your Saunier Duval heating (MiGo): temperatures, humidity, boiler state and setpoint.",
-        "fr": "Pilotez votre chauffage Saunier Duval (MiGo) : températures, humidité, état et consigne."
+        "en": "Control your Saunier Duval boiler through your MiGo / MiGo Link account.",
+        "fr": "Pilotez votre chaudière Saunier Duval via votre compte MiGo / MiGo Link."
       },
       "cover_url": "https://integration-store-storage.gladysassistant.com/covers/PhilippeMA--gladys-Vaillant-SaunierDuval.png",
-      "docker_image": "ghcr.io/philippema/gladys-vaillant-saunierduval:2.0.0",
-      "gladys_version": ">=4.62.0",
+      "docker_image": "ghcr.io/philippema/gladys-vaillant-saunierduval:1.0.1",
+      "gladys_version": ">=4.85.0",
       "config_schema": [
         {
           "key": "intro",
           "type": "section",
           "label": {
-            "en": "Connect your MiGo account",
-            "fr": "Connectez votre compte MiGo"
+            "en": "Getting started",
+            "fr": "Pour commencer"
           },
           "description": {
-            "en": "This integration talks to the Saunier Duval cloud, the same service the MiGo app uses. Sign in with the email address and the password of that app, and pick the country your account was created in. Your gateway (MiGo, MiGo Link) must already be paired in the app.",
-            "fr": "Cette intégration utilise le cloud Saunier Duval, le même service que l'application MiGo. Connectez-vous avec l'adresse e-mail et le mot de passe de cette application, et choisissez le pays dans lequel votre compte a été créé. Votre passerelle (MiGo, MiGo Link) doit déjà être appairée dans l'application."
+            "en": "Use the email and password of the MiGo or MiGo Link account you already use in the mobile application. Your boiler must be connected through a MiGo or MiGo Link gateway: everything goes through the Saunier Duval cloud, there is no local access.",
+            "fr": "Utilisez l'e-mail et le mot de passe du compte MiGo ou MiGo Link dont vous vous servez déjà dans l'application mobile. Votre chaudière doit être reliée à une passerelle MiGo ou MiGo Link : tout passe par le cloud Saunier Duval, il n'y a pas d'accès local."
           },
           "links": [
             {
-              "url": "https://www.saunierduval.fr/particulier/produits/regulation-et-connectivite/",
+              "url": "https://www.saunierduval.fr/particulier/produits/thermostats-et-regulations/",
               "label": {
-                "en": "Saunier Duval connectivity",
-                "fr": "Connectivité Saunier Duval"
+                "en": "Saunier Duval thermostats and controls",
+                "fr": "Thermostats et régulations Saunier Duval"
               }
             }
           ]
         },
         {
-          "key": "username",
+          "key": "email",
           "type": "string",
           "label": {
-            "en": "Email address",
-            "fr": "Adresse e-mail"
+            "en": "Email",
+            "fr": "E-mail"
           },
           "description": {
-            "en": "The email address of your MiGo / Saunier Duval account.",
-            "fr": "L'adresse e-mail de votre compte MiGo / Saunier Duval."
+            "en": "Email address of your MiGo / MiGo Link account.",
+            "fr": "Adresse e-mail de votre compte MiGo / MiGo Link."
           },
           "placeholder": {
             "en": "you@example.com",
@@ -2475,8 +3693,8 @@
             "fr": "Mot de passe"
           },
           "description": {
-            "en": "The password of your MiGo account. It is stored encrypted by Gladys and never sent back to the browser.",
-            "fr": "Le mot de passe de votre compte MiGo. Il est stocké chiffré par Gladys et n'est jamais renvoyé au navigateur."
+            "en": "Password of your MiGo / MiGo Link account. Stored encrypted by Gladys and never sent back to the browser.",
+            "fr": "Mot de passe de votre compte MiGo / MiGo Link. Stocké chiffré par Gladys et jamais renvoyé au navigateur."
           },
           "required": true
         },
@@ -2484,12 +3702,12 @@
           "key": "country",
           "type": "select",
           "label": {
-            "en": "Country",
-            "fr": "Pays"
+            "en": "Country of the account",
+            "fr": "Pays du compte"
           },
           "description": {
-            "en": "The country your account was registered in. A wrong country makes the login fail.",
-            "fr": "Le pays dans lequel votre compte a été créé. Un pays incorrect fait échouer la connexion."
+            "en": "The country you registered your account in. An account created in France cannot log in through another country.",
+            "fr": "Le pays dans lequel votre compte a été créé. Un compte créé en France ne peut pas se connecter via un autre pays."
           },
           "required": true,
           "default": "france",
@@ -2595,52 +3813,6 @@
           ]
         },
         {
-          "key": "heating_on_mode",
-          "type": "select",
-          "label": {
-            "en": "When heating is turned on",
-            "fr": "Quand le chauffage est allumé"
-          },
-          "description": {
-            "en": "Which mode the zone goes back to when you switch heating on: its weekly schedule, or a fixed manual temperature.",
-            "fr": "Le mode auquel la zone revient quand vous allumez le chauffage : son programme hebdomadaire, ou une température manuelle fixe."
-          },
-          "required": false,
-          "default": "TIME_CONTROLLED",
-          "options": [
-            {
-              "value": "TIME_CONTROLLED",
-              "label": {
-                "en": "Weekly schedule",
-                "fr": "Programme hebdomadaire"
-              }
-            },
-            {
-              "value": "MANUAL",
-              "label": {
-                "en": "Manual temperature",
-                "fr": "Température manuelle"
-              }
-            }
-          ]
-        },
-        {
-          "key": "quick_veto_duration",
-          "type": "number",
-          "label": {
-            "en": "Temporary override duration (h)",
-            "fr": "Durée d'un forçage temporaire (h)"
-          },
-          "description": {
-            "en": "When the zone follows its schedule, changing the target temperature applies a temporary override. This is how long it lasts, in hours.",
-            "fr": "Quand la zone suit son programme, modifier la température de consigne applique un forçage temporaire. Voici sa durée, en heures."
-          },
-          "required": false,
-          "default": 3,
-          "min": 0.5,
-          "max": 24
-        },
-        {
           "key": "poll_frequency",
           "type": "number",
           "label": {
@@ -2648,17 +3820,33 @@
             "fr": "Intervalle de rafraîchissement (s)"
           },
           "description": {
-            "en": "How often the temperatures are read from the cloud, in seconds. The gateway itself only reports every few minutes, so there is little value in going below 300.",
-            "fr": "Fréquence de lecture des températures depuis le cloud, en secondes. La passerelle ne remonte ses mesures que toutes les quelques minutes : descendre sous 300 n'apporte pas grand-chose."
+            "en": "How often the boiler is read, in seconds. The Saunier Duval platform is rate limited: keep a comfortable interval, a boiler is a slow system.",
+            "fr": "Fréquence de lecture de la chaudière, en secondes. La plateforme Saunier Duval limite le nombre d'appels : gardez un intervalle confortable, une chaudière est un système lent."
           },
           "required": false,
           "default": 300,
           "min": 60,
           "max": 3600
+        },
+        {
+          "key": "quick_veto_duration",
+          "type": "number",
+          "label": {
+            "en": "Default override duration (h)",
+            "fr": "Durée de forçage par défaut (h)"
+          },
+          "description": {
+            "en": "When a zone follows its schedule, changing its temperature starts a temporary override, after which the schedule takes over again. This is the duration a zone starts from: each zone then carries its own \"Override duration\" control, from 30 minutes to 24 hours in 30-minute steps. Half-hours only.",
+            "fr": "Lorsqu'une zone suit son programme horaire, changer sa température déclenche un forçage temporaire, puis le programme reprend la main. Ceci est la durée initiale d'une zone : chaque zone dispose ensuite de sa propre commande « Durée du forçage », de 30 minutes à 24 heures par pas de 30 minutes. Demi-heures uniquement."
+          },
+          "required": false,
+          "default": 3,
+          "min": 0.5,
+          "max": 24
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-05T15:02:44Z",
+      "pushed_at": "2026-08-11T12:43:04Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/25247304?v=4"
     },
     {
@@ -3714,7 +4902,7 @@
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-02T20:49:54Z",
+      "pushed_at": "2026-08-13T09:51:29Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/11477113?v=4"
     },
     {
@@ -4032,8 +5220,294 @@
         }
       ],
       "stars": 0,
-      "pushed_at": "2026-08-06T08:55:23Z",
+      "pushed_at": "2026-08-11T11:31:44Z",
       "owner_avatar_url": "https://avatars.githubusercontent.com/u/11317212?v=4"
+    },
+    {
+      "slug": "z2m-devices-monitor",
+      "store_slug": "prohand/gladys-z2m-devices-monitor",
+      "repo_url": "https://github.com/prohand/gladys-z2m-devices-monitor",
+      "name": "Z2M Devices Monitor",
+      "type": "device",
+      "version": "1.0.3",
+      "description": {
+        "en": "Alerts you when a Zigbee2MQTT device stops giving signs of life.",
+        "fr": "Vous alerte quand un appareil Zigbee2MQTT ne donne plus signe de vie."
+      },
+      "cover_url": "https://integration-store-storage.gladysassistant.com/covers/prohand--gladys-z2m-devices-monitor.jpg",
+      "docker_image": "ghcr.io/prohand/gladys-z2m-devices-monitor:1.0.3",
+      "gladys_version": ">=4.85.0",
+      "config_schema": [
+        {
+          "key": "intro",
+          "type": "section",
+          "label": {
+            "en": "How it works",
+            "fr": "Comment ça marche"
+          },
+          "description": {
+            "en": "A Zigbee device that is alive talks. This integration listens to everything Zigbee2MQTT publishes, remembers when each device last spoke, and flags the ones that have been silent for too long. It never uses the battery level: a Zigbee battery percentage is a coarse estimate that often reads 100% right up to the day the sensor stops answering.",
+            "fr": "Un appareil Zigbee vivant parle. Cette intégration écoute tout ce que publie Zigbee2MQTT, mémorise la dernière fois que chaque appareil s'est manifesté, et signale ceux qui se taisent depuis trop longtemps. Elle n'utilise jamais le niveau de batterie : un pourcentage de batterie Zigbee est une estimation grossière, souvent à 100% jusqu'au jour où le capteur cesse de répondre."
+          },
+          "links": [
+            {
+              "url": "https://www.zigbee2mqtt.io/guide/usage/mqtt_topics_and_messages.html",
+              "label": {
+                "en": "Zigbee2MQTT MQTT topics",
+                "fr": "Topics MQTT de Zigbee2MQTT"
+              }
+            }
+          ]
+        },
+        {
+          "key": "broker",
+          "type": "section",
+          "label": {
+            "en": "MQTT broker",
+            "fr": "Broker MQTT"
+          },
+          "description": {
+            "en": "The same broker Zigbee2MQTT publishes on. The integration only ever subscribes: it never publishes anything to your Zigbee network. These values have to be typed in here: an integration runs in its own sandbox and Gladys never hands it the settings of another integration. If Gladys installed Zigbee2MQTT for you, copy them from the Zigbee2MQTT integration, Setup tab, \"External tools connection\" block — and replace localhost in the URL with the IP address of your Gladys machine.",
+            "fr": "Le même broker que celui utilisé par Zigbee2MQTT. L'intégration ne fait que s'abonner : elle ne publie jamais rien sur votre réseau Zigbee. Ces valeurs doivent être saisies ici : une intégration tourne dans son propre bac à sable et Gladys ne lui communique jamais les réglages d'une autre intégration. Si c'est Gladys qui a installé Zigbee2MQTT, recopiez-les depuis l'intégration Zigbee2MQTT, onglet Configuration, bloc « Connexion pour outils externes » — en remplaçant localhost dans l'URL par l'adresse IP de votre machine Gladys."
+          }
+        },
+        {
+          "key": "mqtt_url",
+          "type": "string",
+          "label": {
+            "en": "Broker URL",
+            "fr": "URL du broker"
+          },
+          "description": {
+            "en": "Address of the MQTT broker, e.g. mqtt://192.168.1.10:1883 (mqtts:// and ws:// are supported too).",
+            "fr": "Adresse du broker MQTT, par exemple mqtt://192.168.1.10:1883 (mqtts:// et ws:// sont aussi acceptés)."
+          },
+          "placeholder": {
+            "en": "mqtt://192.168.1.10:1883",
+            "fr": "mqtt://192.168.1.10:1883"
+          },
+          "required": true,
+          "default": "mqtt://localhost:1883"
+        },
+        {
+          "key": "mqtt_username",
+          "type": "string",
+          "label": {
+            "en": "Username",
+            "fr": "Nom d'utilisateur"
+          },
+          "description": {
+            "en": "Leave empty if your broker allows anonymous connections.",
+            "fr": "Laissez vide si votre broker accepte les connexions anonymes."
+          },
+          "required": false,
+          "default": ""
+        },
+        {
+          "key": "mqtt_password",
+          "type": "secret",
+          "label": {
+            "en": "Password",
+            "fr": "Mot de passe"
+          },
+          "required": false
+        },
+        {
+          "key": "base_topic",
+          "type": "string",
+          "label": {
+            "en": "Base topic",
+            "fr": "Topic de base"
+          },
+          "description": {
+            "en": "The base topic configured in Zigbee2MQTT (mqtt.base_topic).",
+            "fr": "Le topic de base configuré dans Zigbee2MQTT (mqtt.base_topic)."
+          },
+          "placeholder": {
+            "en": "zigbee2mqtt",
+            "fr": "zigbee2mqtt"
+          },
+          "required": true,
+          "default": "zigbee2mqtt"
+        },
+        {
+          "key": "thresholds",
+          "type": "section",
+          "label": {
+            "en": "Silence thresholds",
+            "fr": "Seuils de silence"
+          },
+          "description": {
+            "en": "A device is declared dead once it has been silent for longer than its threshold. Battery sensors report far less often than mains-powered devices, hence two separate defaults. Start generous: it is better to be alerted a few hours late than to be woken up by a false alarm.",
+            "fr": "Un appareil est déclaré mort dès qu'il se tait depuis plus longtemps que son seuil. Les capteurs sur pile parlent bien moins souvent que les appareils sur secteur, d'où deux valeurs par défaut distinctes. Commencez large : mieux vaut être alerté quelques heures trop tard que réveillé par une fausse alerte."
+          }
+        },
+        {
+          "key": "default_timeout_minutes",
+          "type": "number",
+          "label": {
+            "en": "Threshold for mains-powered devices (min)",
+            "fr": "Seuil pour les appareils sur secteur (min)"
+          },
+          "description": {
+            "en": "Applies to plugs, bulbs and routers, which report often.",
+            "fr": "S'applique aux prises, ampoules et routeurs, qui parlent souvent."
+          },
+          "required": false,
+          "default": 120,
+          "min": 5,
+          "max": 20160
+        },
+        {
+          "key": "battery_timeout_minutes",
+          "type": "number",
+          "label": {
+            "en": "Threshold for battery devices (min)",
+            "fr": "Seuil pour les appareils sur pile (min)"
+          },
+          "description": {
+            "en": "Applies to battery sensors, which sleep most of the time. 1440 minutes is 24 hours.",
+            "fr": "S'applique aux capteurs sur pile, qui dorment la plupart du temps. 1440 minutes valent 24 heures."
+          },
+          "required": false,
+          "default": 1440,
+          "min": 5,
+          "max": 20160
+        },
+        {
+          "key": "custom_timeouts",
+          "type": "string",
+          "label": {
+            "en": "Per-device thresholds",
+            "fr": "Seuils par appareil"
+          },
+          "description": {
+            "en": "One device=minutes pair per line or separated by commas. The device is designated by its Zigbee2MQTT friendly name or its IEEE address. Example: mailbox sensor=4320, 0x00158d0001abcdef=60",
+            "fr": "Une paire appareil=minutes par ligne ou séparées par des virgules. L'appareil est désigné par son nom convivial Zigbee2MQTT ou son adresse IEEE. Exemple : capteur boite aux lettres=4320, 0x00158d0001abcdef=60"
+          },
+          "placeholder": {
+            "en": "mailbox sensor=4320, garage motion=180",
+            "fr": "capteur boite aux lettres=4320, mouvement garage=180"
+          },
+          "required": false,
+          "default": ""
+        },
+        {
+          "key": "naming",
+          "type": "section",
+          "label": {
+            "en": "Device naming",
+            "fr": "Nommage des appareils"
+          },
+          "description": {
+            "en": "Gladys most likely already knows these devices under their Zigbee2MQTT name, through its own Zigbee2MQTT integration. Without a suffix, a scene picker shows the same name twice with no way to tell which is which.",
+            "fr": "Gladys connaît très probablement déjà ces appareils sous leur nom Zigbee2MQTT, via sa propre intégration Zigbee2MQTT. Sans suffixe, un sélecteur de scène affiche deux fois le même nom sans moyen de les distinguer."
+          }
+        },
+        {
+          "key": "device_name_suffix",
+          "type": "string",
+          "label": {
+            "en": "Suffix added to device names",
+            "fr": "Suffixe ajouté aux noms d'appareils"
+          },
+          "description": {
+            "en": "Appended to the Zigbee2MQTT name of each watched device, e.g. \"office plug (monitor)\". Leave empty to keep the raw name. Only affects the devices you create afterwards: Gladys never renames a device you already added.",
+            "fr": "Ajouté au nom Zigbee2MQTT de chaque appareil surveillé, par exemple « prise bureau (monitor) ». Laissez vide pour garder le nom brut. N'affecte que les appareils créés ensuite : Gladys ne renomme jamais un appareil déjà ajouté."
+          },
+          "placeholder": {
+            "en": "(monitor)",
+            "fr": "(monitor)"
+          },
+          "required": false,
+          "default": "(monitor)"
+        },
+        {
+          "key": "summary_device",
+          "type": "section",
+          "label": {
+            "en": "Zigbee2MQTT monitor device",
+            "fr": "Appareil Zigbee2MQTT monitor"
+          },
+          "description": {
+            "en": "The single device summarizing the whole network: how many devices are watched, how many are silent, and the names of the silent ones — the text a scene notification quotes. It is the one to build your alert on: its counters cover every device Zigbee2MQTT knows about, including the ones you pair later.",
+            "fr": "L'appareil unique qui résume tout le réseau : combien d'appareils sont surveillés, combien sont silencieux, et le nom de ceux qui se taisent — le texte qu'une notification de scène reprend. C'est sur lui qu'il faut bâtir l'alerte : ses compteurs couvrent tous les appareils connus de Zigbee2MQTT, y compris ceux que vous appairerez plus tard."
+          }
+        },
+        {
+          "key": "no_silent_devices_text",
+          "type": "string",
+          "label": {
+            "en": "Text shown when no device is silent",
+            "fr": "Texte affiché quand aucun appareil n'est silencieux"
+          },
+          "description": {
+            "en": "What the \"Silent device names\" feature reads while the whole network is answering. Write it in your own language; empty restores the default.",
+            "fr": "Ce qu'affiche la fonctionnalité « Silent device names » tant que tout le réseau répond. Écrivez-le dans votre langue ; vide rétablit la valeur par défaut."
+          },
+          "placeholder": {
+            "en": "No silent device",
+            "fr": "Aucun appareil silencieux"
+          },
+          "required": false,
+          "default": "No silent device"
+        },
+        {
+          "key": "advanced",
+          "type": "section",
+          "label": {
+            "en": "Advanced",
+            "fr": "Avancé"
+          }
+        },
+        {
+          "key": "ignored_devices",
+          "type": "string",
+          "label": {
+            "en": "Devices to ignore",
+            "fr": "Appareils à ignorer"
+          },
+          "description": {
+            "en": "Friendly names or IEEE addresses, separated by commas. Ignored devices are not published to Gladys and never raise an alert.",
+            "fr": "Noms conviviaux ou adresses IEEE, séparés par des virgules. Les appareils ignorés ne sont pas publiés vers Gladys et ne déclenchent jamais d'alerte."
+          },
+          "required": false,
+          "default": ""
+        },
+        {
+          "key": "monitor_disabled_devices",
+          "type": "boolean",
+          "label": {
+            "en": "Also watch devices disabled in Zigbee2MQTT",
+            "fr": "Surveiller aussi les appareils désactivés dans Zigbee2MQTT"
+          },
+          "description": {
+            "en": "Off by default: a device you disabled on purpose is expected to be silent.",
+            "fr": "Désactivé par défaut : un appareil que vous avez désactivé volontairement est censé se taire."
+          },
+          "required": false,
+          "default": false
+        },
+        {
+          "key": "check_interval_seconds",
+          "type": "number",
+          "label": {
+            "en": "Check interval (s)",
+            "fr": "Intervalle de vérification (s)"
+          },
+          "description": {
+            "en": "How often the silence of every device is re-evaluated.",
+            "fr": "Fréquence de réévaluation du silence de chaque appareil."
+          },
+          "required": false,
+          "default": 60,
+          "min": 10,
+          "max": 3600
+        }
+      ],
+      "stars": 0,
+      "pushed_at": "2026-08-12T23:37:33Z",
+      "owner_avatar_url": "https://avatars.githubusercontent.com/u/20227162?v=4"
     },
     {
       "slug": "zendure",


### PR DESCRIPTION
## The bug

The "refresh external integrations" job failed the build on the new Charger Station page:

```
Can't render static file for pathname "/docs/integrations/external/charger-station/"
  [cause]: ReferenceError: gladys_host is not defined
```

`scripts/load_external_integrations.js` escapes `<`, `{` and `}` in the documentation written by the integration author (`escapeForMdx`), but **not** in the values it reads from the integration manifest. The Charger Station manifest describes its OCPP URL in a configuration setting:

```
Replace that URL with ws://{{gladys_host}}:{{port:ocpp}}/ - the same one for every charge point.
```

That description is written straight into the "Configuration settings" table, so `{{gladys_host}}` reached the MDX compiler as a JSX expression — an object literal with a shorthand property — and SSG crashed on the undefined `gladys_host`. Any manifest containing a brace would have done the same.

## The fix

Manifest values are now escaped for the context they land in:

- `text()` — prose: escapes `<`, `{`, `}` (used for the config table cells, the integration name and the owner name)
- `code()` — inline code spans: strips backticks, since MDX leaves the content of a code span alone (used for the setting type, the Docker image and the required Gladys version)
- `url()` — link destinations: percent-encodes spaces, parentheses and angle brackets (used for the repository and owner URLs)
- `yaml()` — frontmatter: now collapses newlines as well, so a multi-line description cannot break the YAML block

The rendered page shows the URL exactly as the author wrote it, `ws://{{gladys_host}}:{{port:ocpp}}/`, with no escaping visible.

## Catalog refresh

The run also regenerates the catalog: 45 integrations, including the ten published since the last refresh — Apple TV, Charger Station, Gardena Smart System, GRDF Gazpar, Home Connect, Immich Slideshow, Meross, Météo Benelux, Météo France and Z2M Devices Monitor — plus the updated documentation of the integrations already listed.

## Test plan

- `yarn load-external-integrations` then `yarn build`: both locales build successfully (the only warning, on `/fr/starter-kit/`, is pre-existing and unrelated)
- Checked the diff of the already-published pages: no escaping regression, every change comes from upstream documentation updates
- Verified in `build/docs/integrations/external/charger-station/index.html` and its French counterpart that the setting description renders as plain text

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxHSEVKZEsynUZhmuzKFxG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for Apple TV, Charger Station, GARDENA, GRDF Gazpar, Home Connect, Immich Slideshow, Meross, Météo services, and Zigbee2MQTT monitoring.
  * Expanded integration documentation with setup, configuration, supported devices, troubleshooting, privacy, limitations, and usage guidance.
  * Added French documentation for the same integrations.
  * Clarified energy monitoring, webhook behavior, house imports, timestamps, alerts, routines, and device states.
  * Updated installation requirements and documented integration versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->