### PR TITLE
fix(dev): align the headline commit count with GitHub Insights

### DIFF
--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -1672,8 +1672,8 @@
     "description": "Pace card kicker"
   },
   "devPage.pace.count": {
-    "message": "{count} commits ces 7 derniers jours",
-    "description": "Commits in the last 7 days"
+    "message": "{count} commits cette semaine",
+    "description": "Commits in the current week"
   },
   "devPage.pace.next": {
     "message": "Encore un commit avant {tier}|Encore {count} commits avant {tier}",
@@ -1850,5 +1850,17 @@
   "devPage.updatedJustNow": {
     "message": "Mis à jour à l'instant",
     "description": "Last update line once the live refresh succeeded"
+  },
+  "devPage.rhythm.barTooltip": {
+    "message": "Semaine du {date} : {count} commits",
+    "description": "Tooltip of a bar in the weekly commits chart"
+  },
+  "devPage.rhythm.barInProgress": {
+    "message": "(semaine en cours)",
+    "description": "Tooltip suffix for the week in progress"
+  },
+  "devPage.rhythm.sameAsGithub": {
+    "message": "Les mêmes chiffres que GitHub Insights → Commits, via la même API →",
+    "description": "Link to the GitHub commit activity graph"
   }
 }

--- a/src/data/devActivity.json
+++ b/src/data/devActivity.json
@@ -1,15 +1,15 @@
 {
-  "generatedAt": "2026-08-13T17:33:03.577Z",
+  "generatedAt": "2026-08-14T10:14:23.889Z",
   "repository": {
     "owner": "GladysAssistant",
     "name": "Gladys",
     "url": "https://github.com/GladysAssistant/Gladys",
-    "stars": 3101,
+    "stars": 3102,
     "forks": 311,
-    "openIssues": 50,
+    "openIssues": 34,
     "watchers": 73,
     "createdAt": "2015-06-05T11:10:33Z",
-    "pushedAt": "2026-08-13T13:17:16Z"
+    "pushedAt": "2026-08-14T10:11:15Z"
   },
   "weeks": [
     {
@@ -677,14 +677,14 @@
     },
     {
       "w": 1786233600,
-      "t": 34,
+      "t": 56,
       "d": [
         0,
         22,
         12,
         0,
-        0,
-        0,
+        1,
+        21,
         0
       ]
     }
@@ -902,12 +902,110 @@
       ]
     }
   ],
-  "openPullRequestsCount": 34,
+  "openPullRequestsCount": 21,
   "openPullRequests": [
     {
-      "number": 2858,
-      "title": "feat(scene): multi-select device features in the device state trigger",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2858",
+      "number": 2873,
+      "title": "fix(front): recommend external integrations instead of Matterbridge in the catalog empty-search suggestion",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2873",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:chore",
+        "area:front"
+      ],
+      "createdAt": "2026-08-14T09:45:55Z",
+      "updatedAt": "2026-08-14T10:13:36Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2869,
+      "title": "feat(device): add text/select feature type with string-valued supported_options",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2869",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "risk:high",
+        "needs:human-review",
+        "area:database"
+      ],
+      "createdAt": "2026-08-14T08:07:06Z",
+      "updatedAt": "2026-08-14T10:06:21Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2709,
+      "title": "feat(system): reboot / shutdown the host from the System settings",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2709",
+      "author": "callemand",
+      "avatar": "https://avatars.githubusercontent.com/u/11317212?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "area:infra",
+        "risk:high",
+        "needs:human-review"
+      ],
+      "createdAt": "2026-07-24T14:42:13Z",
+      "updatedAt": "2026-08-14T09:02:03Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2708,
+      "title": "Scenes: expose trigger device info as variables in actions",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2708",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front"
+      ],
+      "createdAt": "2026-07-23T19:14:04Z",
+      "updatedAt": "2026-08-14T07:39:34Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2762,
+      "title": "docs: add living specification for camera PTZ control",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2762",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:chore",
+        "area:server",
+        "area:front"
+      ],
+      "createdAt": "2026-08-03T09:22:00Z",
+      "updatedAt": "2026-08-14T06:52:53Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2862,
+      "title": "Upgrade ESLint to v10 (flat config) and Prettier to v3",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2862",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "area:server",
+        "area:front",
+        "area:integration",
+        "area:ai",
+        "needs:human-review",
+        "area:database"
+      ],
+      "createdAt": "2026-08-13T20:57:47Z",
+      "updatedAt": "2026-08-14T06:32:33Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2707,
+      "title": "Scene: propose instantaneous device values in \"Only continue if\" conditions",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2707",
       "author": "Pierre-Gilles",
       "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
       "labels": [
@@ -915,44 +1013,10 @@
         "area:server",
         "area:front",
         "area:integration",
-        "needs:human-review",
         "area:database"
       ],
-      "createdAt": "2026-08-13T09:31:01Z",
-      "updatedAt": "2026-08-13T13:21:15Z",
-      "mergedAt": null
-    },
-    {
-      "number": 2859,
-      "title": "Fix flaky zigbee2mqtt/mqtt publish logging tests (require cache leak)",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2859",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:fix",
-        "area:server",
-        "area:integration"
-      ],
-      "createdAt": "2026-08-13T13:10:01Z",
-      "updatedAt": "2026-08-13T13:16:43Z",
-      "mergedAt": null
-    },
-    {
-      "number": 2857,
-      "title": "feat(scene): add \"Get calendar events\" action to announce upcoming events",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2857",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:server",
-        "area:front",
-        "area:integration",
-        "needs:human-review",
-        "area:database"
-      ],
-      "createdAt": "2026-08-12T13:55:24Z",
-      "updatedAt": "2026-08-13T08:51:55Z",
+      "createdAt": "2026-07-23T18:43:08Z",
+      "updatedAt": "2026-08-14T06:14:58Z",
       "mergedAt": null
     },
     {
@@ -970,56 +1034,7 @@
         "area:database"
       ],
       "createdAt": "2026-08-07T16:04:08Z",
-      "updatedAt": "2026-08-13T08:50:10Z",
-      "mergedAt": null
-    },
-    {
-      "number": 2707,
-      "title": "Scene: propose instantaneous device values in \"Only continue if\" conditions",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2707",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:server",
-        "area:front",
-        "area:integration",
-        "area:database"
-      ],
-      "createdAt": "2026-07-23T18:43:08Z",
-      "updatedAt": "2026-08-13T06:13:10Z",
-      "mergedAt": null
-    },
-    {
-      "number": 2855,
-      "title": "feat(device): add generic maintenance feature category for consumable life tracking",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2855",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:server",
-        "area:front",
-        "needs:human-review"
-      ],
-      "createdAt": "2026-08-12T06:24:32Z",
-      "updatedAt": "2026-08-13T06:05:59Z",
-      "mergedAt": null
-    },
-    {
-      "number": 2848,
-      "title": "Add network wake functionality to external integrations",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2848",
-      "author": "vincentBesseau",
-      "avatar": "https://avatars.githubusercontent.com/u/33568805?v=4",
-      "labels": [
-        "type:feature",
-        "area:server",
-        "area:front",
-        "needs:human-review"
-      ],
-      "createdAt": "2026-08-11T11:43:59Z",
-      "updatedAt": "2026-08-13T03:05:37Z",
+      "updatedAt": "2026-08-14T06:07:13Z",
       "mergedAt": null
     },
     {
@@ -1058,75 +1073,6 @@
       "mergedAt": null
     },
     {
-      "number": 2856,
-      "title": "feat(scene): allow sending text to a device from the control-device action",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2856",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:server",
-        "area:front",
-        "area:integration",
-        "needs:human-review",
-        "area:database"
-      ],
-      "createdAt": "2026-08-12T06:34:07Z",
-      "updatedAt": "2026-08-12T18:07:07Z",
-      "mergedAt": null
-    },
-    {
-      "number": 2853,
-      "title": "Answer weather questions in the AI chat",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2853",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:server",
-        "area:front",
-        "area:integration",
-        "area:ai",
-        "needs:human-review"
-      ],
-      "createdAt": "2026-08-12T02:24:06Z",
-      "updatedAt": "2026-08-12T18:06:41Z",
-      "mergedAt": null
-    },
-    {
-      "number": 2750,
-      "title": "Add while loop action for scene automation",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2750",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "area:server",
-        "area:front",
-        "area:integration",
-        "risk:high",
-        "needs:human-review",
-        "area:database"
-      ],
-      "createdAt": "2026-08-02T09:16:19Z",
-      "updatedAt": "2026-08-12T18:06:40Z",
-      "mergedAt": null
-    },
-    {
-      "number": 2852,
-      "title": "fix: answer device.get-state when the model targets the house instead of a room (#2850)",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2852",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:fix",
-        "area:integration",
-        "needs:human-review"
-      ],
-      "createdAt": "2026-08-12T00:34:56Z",
-      "updatedAt": "2026-08-12T18:06:32Z",
-      "mergedAt": null
-    },
-    {
       "number": 2854,
       "title": "chore(deps): security audit — apply non-breaking fixes for google-cast and mcp services",
       "url": "https://github.com/GladysAssistant/Gladys/pull/2854",
@@ -1144,197 +1090,261 @@
       "mergedAt": null
     },
     {
-      "number": 2762,
-      "title": "docs: add living specification for camera PTZ control",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2762",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "number": 2780,
+      "title": "Add an account_link config field for providers that are not OAuth2",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2780",
+      "author": "callemand",
+      "avatar": "https://avatars.githubusercontent.com/u/11317212?v=4",
       "labels": [
-        "type:chore",
+        "type:feature",
         "area:server",
         "area:front"
       ],
-      "createdAt": "2026-08-03T09:22:00Z",
-      "updatedAt": "2026-08-11T18:47:36Z",
+      "createdAt": "2026-08-05T20:05:27Z",
+      "updatedAt": "2026-08-11T16:56:20Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2719,
+      "title": "feat(external-integration): disconnect an oauth2 account",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2719",
+      "author": "callemand",
+      "avatar": "https://avatars.githubusercontent.com/u/11317212?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "needs:human-review"
+      ],
+      "createdAt": "2026-07-29T12:33:04Z",
+      "updatedAt": "2026-08-11T15:25:37Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2783,
+      "title": "Add a per-feature setpoint step, driven by the device",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2783",
+      "author": "callemand",
+      "avatar": "https://avatars.githubusercontent.com/u/11317212?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "risk:high",
+        "area:database"
+      ],
+      "createdAt": "2026-08-06T16:26:13Z",
+      "updatedAt": "2026-08-08T18:06:40Z",
+      "mergedAt": null
+    },
+    {
+      "number": 2537,
+      "title": "feat(matter): add MediaPlayback, KeypadInput and LevelControl volume clusters support",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2537",
+      "author": "b3n0",
+      "avatar": "https://avatars.githubusercontent.com/u/17109016?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "area:integration"
+      ],
+      "createdAt": "2026-05-31T09:54:14Z",
+      "updatedAt": "2026-08-07T03:09:46Z",
       "mergedAt": null
     }
   ],
   "mergedPullRequests": [
     {
-      "number": 2832,
-      "title": "fix: log MQTT/Zigbee2mqtt published payload and warn on invalid JSON (#2825)",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2832",
+      "number": 2857,
+      "title": "feat(scene): add \"Get calendar events\" action to announce upcoming events",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2857",
       "author": "Pierre-Gilles",
       "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
       "labels": [
-        "type:fix",
+        "type:feature",
         "area:server",
+        "area:front",
         "area:integration",
-        "needs:human-review"
+        "needs:human-review",
+        "area:database"
       ],
-      "createdAt": "2026-08-10T13:36:41Z",
-      "updatedAt": "2026-08-11T18:30:45Z",
-      "mergedAt": "2026-08-11T18:30:42Z"
+      "createdAt": "2026-08-12T13:55:24Z",
+      "updatedAt": "2026-08-14T09:56:24Z",
+      "mergedAt": "2026-08-14T09:56:21Z"
     },
     {
-      "number": 2851,
-      "title": "Resolve the master merge conflict in PR #2829 (sendState.js)",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2851",
+      "number": 2868,
+      "title": "Add a Devices page listing all instance devices",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2868",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:feature",
+        "area:front"
+      ],
+      "createdAt": "2026-08-14T07:44:26Z",
+      "updatedAt": "2026-08-14T09:50:16Z",
+      "mergedAt": "2026-08-14T09:50:14Z"
+    },
+    {
+      "number": 2860,
+      "title": "feat(integrations): browse categories, facet filters and newest sort in the catalog (spec + implementation)",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2860",
       "author": "Pierre-Gilles",
       "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
       "labels": [
         "type:chore",
         "area:server",
         "area:front",
-        "area:integration",
-        "area:infra"
+        "needs:human-review"
       ],
-      "createdAt": "2026-08-11T17:06:11Z",
-      "updatedAt": "2026-08-11T17:10:27Z",
-      "mergedAt": "2026-08-11T17:09:50Z"
+      "createdAt": "2026-08-13T17:52:06Z",
+      "updatedAt": "2026-08-14T09:55:50Z",
+      "mergedAt": "2026-08-14T09:40:49Z"
     },
     {
-      "number": 2846,
-      "title": "feat(homekit): expose presence sensors as an OccupancySensor",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2846",
+      "number": 2858,
+      "title": "feat(scene): multi-select device features in the device state trigger",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2858",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "area:integration",
+        "needs:human-review",
+        "area:database"
+      ],
+      "createdAt": "2026-08-13T09:31:01Z",
+      "updatedAt": "2026-08-14T09:37:47Z",
+      "mergedAt": "2026-08-14T09:37:44Z"
+    },
+    {
+      "number": 2866,
+      "title": "Dashboard: make chart tooltip follow the cursor instead of masking the curves",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2866",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:feature",
+        "area:front"
+      ],
+      "createdAt": "2026-08-14T07:32:43Z",
+      "updatedAt": "2026-08-14T09:29:27Z",
+      "mergedAt": "2026-08-14T09:29:24Z"
+    },
+    {
+      "number": 2864,
+      "title": "Add network wake functionality to external integrations (hardened follow-up of #2848)",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2864",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "needs:human-review"
+      ],
+      "createdAt": "2026-08-14T06:53:09Z",
+      "updatedAt": "2026-08-14T09:23:39Z",
+      "mergedAt": "2026-08-14T09:23:36Z"
+    },
+    {
+      "number": 2863,
+      "title": "feat(scene): add a \"Set a variable\" action",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2863",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "area:integration",
+        "needs:human-review",
+        "area:database"
+      ],
+      "createdAt": "2026-08-14T02:20:37Z",
+      "updatedAt": "2026-08-14T09:26:05Z",
+      "mergedAt": "2026-08-14T09:19:20Z"
+    },
+    {
+      "number": 2872,
+      "title": "fix(front): make drag & drop work with a mouse on touchscreen PCs",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2872",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:fix",
+        "area:front"
+      ],
+      "createdAt": "2026-08-14T08:41:42Z",
+      "updatedAt": "2026-08-14T08:54:53Z",
+      "mergedAt": "2026-08-14T08:54:51Z"
+    },
+    {
+      "number": 2871,
+      "title": "fix(front): stop showing last state report time as last motion on motion sensors",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2871",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:fix",
+        "area:front"
+      ],
+      "createdAt": "2026-08-14T08:10:39Z",
+      "updatedAt": "2026-08-14T08:44:55Z",
+      "mergedAt": "2026-08-14T08:44:52Z"
+    },
+    {
+      "number": 2853,
+      "title": "Answer weather questions in the AI chat",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2853",
+      "author": "Pierre-Gilles",
+      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
+      "labels": [
+        "type:feature",
+        "area:server",
+        "area:front",
+        "area:integration",
+        "area:ai",
+        "needs:human-review"
+      ],
+      "createdAt": "2026-08-12T02:24:06Z",
+      "updatedAt": "2026-08-14T08:24:44Z",
+      "mergedAt": "2026-08-14T08:22:56Z"
+    },
+    {
+      "number": 2847,
+      "title": "feat(homekit): expose the house alarm as a SecuritySystem",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2847",
       "author": "Dreamthy",
       "avatar": "https://avatars.githubusercontent.com/u/86977969?v=4",
       "labels": [
         "type:feature",
-        "area:integration"
-      ],
-      "createdAt": "2026-08-11T09:28:17Z",
-      "updatedAt": "2026-08-11T17:01:02Z",
-      "mergedAt": "2026-08-11T17:01:02Z"
-    },
-    {
-      "number": 2844,
-      "title": "Fix flaky CI: stop the gateway restore tests from poisoning the shared test database",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2844",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:chore",
-        "area:server"
-      ],
-      "createdAt": "2026-08-11T07:39:08Z",
-      "updatedAt": "2026-08-11T16:57:40Z",
-      "mergedAt": "2026-08-11T16:57:36Z"
-    },
-    {
-      "number": 2845,
-      "title": "Add NO2, O3 and SO2 device feature categories",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2845",
-      "author": "prohand",
-      "avatar": "https://avatars.githubusercontent.com/u/20227162?v=4",
-      "labels": [
-        "type:feature",
-        "area:server",
         "area:front",
-        "area:integration"
-      ],
-      "createdAt": "2026-08-11T08:49:37Z",
-      "updatedAt": "2026-08-11T16:01:35Z",
-      "mergedAt": "2026-08-11T16:01:35Z"
-    },
-    {
-      "number": 2849,
-      "title": "[ZWave] Deprecate internal service",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2849",
-      "author": "sescandell",
-      "avatar": "https://avatars.githubusercontent.com/u/1559970?v=4",
-      "labels": [
-        "area:front",
+        "area:integration",
         "needs:human-review"
       ],
-      "createdAt": "2026-08-11T13:40:27Z",
-      "updatedAt": "2026-08-11T16:00:19Z",
-      "mergedAt": "2026-08-11T16:00:19Z"
+      "createdAt": "2026-08-11T09:28:38Z",
+      "updatedAt": "2026-08-14T07:48:55Z",
+      "mergedAt": "2026-08-14T07:48:55Z"
     },
     {
-      "number": 2841,
-      "title": "External integrations: allow installing and updating from a locally built Docker image",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2841",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:server",
-        "area:front"
-      ],
-      "createdAt": "2026-08-10T18:34:42Z",
-      "updatedAt": "2026-08-11T15:42:37Z",
-      "mergedAt": "2026-08-11T15:42:34Z"
-    },
-    {
-      "number": 2835,
-      "title": "Show labeled value lists in the scene editor instead of raw numbers",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2835",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:front"
-      ],
-      "createdAt": "2026-08-10T14:13:33Z",
-      "updatedAt": "2026-08-11T07:17:59Z",
-      "mergedAt": "2026-08-11T07:17:56Z"
-    },
-    {
-      "number": 2834,
-      "title": "Fix the integration counter mixing scopes across catalog views",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2834",
+      "number": 2828,
+      "title": "fix: map thermostat:mode and thermostat:operating-state in the HomeKit bridge (#2806)",
+      "url": "https://github.com/GladysAssistant/Gladys/pull/2828",
       "author": "Pierre-Gilles",
       "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
       "labels": [
         "type:fix",
-        "area:front"
+        "area:integration",
+        "needs:human-review"
       ],
-      "createdAt": "2026-08-10T13:53:21Z",
-      "updatedAt": "2026-08-11T07:15:40Z",
-      "mergedAt": "2026-08-11T07:15:37Z"
-    },
-    {
-      "number": 2830,
-      "title": "Integration catalog: make the search accent-insensitive",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2830",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:front"
-      ],
-      "createdAt": "2026-08-10T12:54:00Z",
-      "updatedAt": "2026-08-11T07:13:38Z",
-      "mergedAt": "2026-08-11T07:13:35Z"
-    },
-    {
-      "number": 2840,
-      "title": "ci: accept the autofix fire URL from a secret as well as a variable",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2840",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:chore",
-        "area:infra"
-      ],
-      "createdAt": "2026-08-10T18:19:58Z",
-      "updatedAt": "2026-08-11T07:04:18Z",
-      "mergedAt": "2026-08-11T07:04:15Z"
-    },
-    {
-      "number": 2842,
-      "title": "Add a \"back to integrations\" link on every integration page",
-      "url": "https://github.com/GladysAssistant/Gladys/pull/2842",
-      "author": "Pierre-Gilles",
-      "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
-      "labels": [
-        "type:feature",
-        "area:front"
-      ],
-      "createdAt": "2026-08-11T02:14:02Z",
-      "updatedAt": "2026-08-11T07:03:33Z",
-      "mergedAt": "2026-08-11T07:03:31Z"
+      "createdAt": "2026-08-10T12:35:24Z",
+      "updatedAt": "2026-08-14T07:47:05Z",
+      "mergedAt": "2026-08-14T07:47:02Z"
     }
   ],
   "contributorsCount": 57,
@@ -1343,7 +1353,7 @@
       "login": "Pierre-Gilles",
       "avatar": "https://avatars.githubusercontent.com/u/7365207?v=4",
       "url": "https://github.com/Pierre-Gilles",
-      "contributions": 2382
+      "contributions": 2402
     },
     {
       "login": "atrovato",
@@ -1379,7 +1389,7 @@
       "login": "William-De71",
       "avatar": "https://avatars.githubusercontent.com/u/11477113?v=4",
       "url": "https://github.com/William-De71",
-      "contributions": 39
+      "contributions": 40
     },
     {
       "login": "callemand",
@@ -1414,14 +1424,28 @@
   ],
   "forumRequests": [
     {
+      "id": 9505,
+      "title": "[Scènes] Pouvoir créer une variable 'ponctuelle'",
+      "url": "https://community.gladysassistant.com/t/scenes-pouvoir-creer-une-variable-ponctuelle/9505",
+      "views": 130,
+      "replies": 5,
+      "likes": 5,
+      "createdAt": "2025-05-11T20:15:11.640Z",
+      "bumpedAt": "2026-08-14T09:20:00.663Z",
+      "author": "StephaneB",
+      "tags": [
+        "demande-core"
+      ]
+    },
+    {
       "id": 10523,
       "title": "Scène: Nouveau déclencheur sur la météo",
       "url": "https://community.gladysassistant.com/t/scene-nouveau-declencheur-sur-la-meteo/10523",
-      "views": 37,
-      "replies": 0,
+      "views": 45,
+      "replies": 2,
       "likes": 0,
       "createdAt": "2026-08-10T19:47:26.970Z",
-      "bumpedAt": "2026-08-10T19:47:27.212Z",
+      "bumpedAt": "2026-08-14T08:43:04.404Z",
       "author": "Chris75",
       "tags": [
         "demande-core"
@@ -1431,33 +1455,19 @@
       "id": 10517,
       "title": "IA : pouvoir demander la météo dans le chat",
       "url": "https://community.gladysassistant.com/t/ia-pouvoir-demander-la-meteo-dans-le-chat/10517",
-      "views": 21,
-      "replies": 0,
-      "likes": 0,
+      "views": 35,
+      "replies": 2,
+      "likes": 4,
       "createdAt": "2026-08-10T12:54:21.590Z",
-      "bumpedAt": "2026-08-10T12:54:21.810Z",
+      "bumpedAt": "2026-08-14T08:31:50.636Z",
       "author": "Chris75",
       "tags": []
-    },
-    {
-      "id": 10417,
-      "title": "Affichage températures",
-      "url": "https://community.gladysassistant.com/t/affichage-temperatures/10417",
-      "views": 56,
-      "replies": 2,
-      "likes": 0,
-      "createdAt": "2026-07-31T15:01:38.921Z",
-      "bumpedAt": "2026-08-07T16:09:32.756Z",
-      "author": "l.dolle",
-      "tags": [
-        "demande-core"
-      ]
     },
     {
       "id": 10392,
       "title": "Décaler le jour de départ du suivi de l'énergie",
       "url": "https://community.gladysassistant.com/t/decaler-le-jour-de-depart-du-suivi-de-lenergie/10392",
-      "views": 45,
+      "views": 46,
       "replies": 3,
       "likes": 2,
       "createdAt": "2026-07-29T08:21:28.972Z",
@@ -1471,7 +1481,7 @@
       "id": 10393,
       "title": "Possibilité de dupliquer un tableau de bord",
       "url": "https://community.gladysassistant.com/t/possibilite-de-dupliquer-un-tableau-de-bord/10393",
-      "views": 27,
+      "views": 28,
       "replies": 0,
       "likes": 0,
       "createdAt": "2026-07-29T17:47:55.716Z",
@@ -1499,7 +1509,7 @@
       "id": 10354,
       "title": "Concernant l'IA : état des piles",
       "url": "https://community.gladysassistant.com/t/concernant-lia-etat-des-piles/10354",
-      "views": 25,
+      "views": 26,
       "replies": 0,
       "likes": 0,
       "createdAt": "2026-07-17T12:50:48.778Z",
@@ -1541,7 +1551,7 @@
       "id": 10227,
       "title": "Matter : Intégration lave vaisselle",
       "url": "https://community.gladysassistant.com/t/matter-integration-lave-vaisselle/10227",
-      "views": 56,
+      "views": 57,
       "replies": 2,
       "likes": 2,
       "createdAt": "2026-05-17T19:02:00.449Z",
@@ -1555,7 +1565,7 @@
       "id": 10095,
       "title": "Gestion du capteur de fuite d’eau Ikea dans l’intégration Matter",
       "url": "https://community.gladysassistant.com/t/gestion-du-capteur-de-fuite-d-eau-ikea-dans-l-integration-matter/10095",
-      "views": 32,
+      "views": 33,
       "replies": 0,
       "likes": 0,
       "createdAt": "2026-03-05T08:32:58.541Z",
@@ -1623,24 +1633,10 @@
       ]
     },
     {
-      "id": 9505,
-      "title": "[Scènes] Pouvoir créer une variable 'ponctuelle'",
-      "url": "https://community.gladysassistant.com/t/scenes-pouvoir-creer-une-variable-ponctuelle/9505",
-      "views": 124,
-      "replies": 4,
-      "likes": 5,
-      "createdAt": "2025-05-11T20:15:11.640Z",
-      "bumpedAt": "2025-09-08T07:33:37.782Z",
-      "author": "StephaneB",
-      "tags": [
-        "demande-core"
-      ]
-    },
-    {
       "id": 9620,
       "title": "[Matter] Ajouter la gestion de la qualité de l'air",
       "url": "https://community.gladysassistant.com/t/matter-ajouter-la-gestion-de-la-qualite-de-lair/9620",
-      "views": 33,
+      "views": 34,
       "replies": 0,
       "likes": 0,
       "createdAt": "2025-06-23T12:42:33.575Z",

--- a/src/pages/dev.js
+++ b/src/pages/dev.js
@@ -311,15 +311,37 @@ function WeeklyBars({ weeks, locale }) {
       description: "Accessible label of the weekly commits chart",
       message: "Commits per week over the last 52 weeks",
     })}>
-      {weeks.map((week) => {
+      {weeks.map((week, index) => {
         const height = Math.max(3, Math.round((week.t / max) * 100));
+        // The last bucket is the week in progress: it is meant to look
+        // unfinished rather than to look like a slowdown.
+        const inProgress = index === weeks.length - 1;
+        const title = translate(
+          {
+            id: "devPage.rhythm.barTooltip",
+            description: "Tooltip of a bar in the weekly commits chart",
+            message: "Week of {date}: {count} commits",
+          },
+          { date: formatDayLabel(week.w * 1000, locale), count: week.t }
+        );
         return (
           <div
             key={week.w}
             className={styles.barSlot}
-            title={`${formatDayLabel(week.w * 1000, locale)} · ${week.t}`}
+            title={
+              inProgress
+                ? `${title} ${translate({
+                    id: "devPage.rhythm.barInProgress",
+                    description: "Tooltip suffix for the week in progress",
+                    message: "(week in progress)",
+                  })}`
+                : title
+            }
           >
-            <div className={styles.bar} style={{ height: `${height}%` }} />
+            <div
+              className={`${styles.bar} ${inProgress ? styles.barInProgress : ""}`}
+              style={{ height: `${height}%` }}
+            />
           </div>
         );
       })}
@@ -533,16 +555,16 @@ function DevPage() {
               <p className={styles.paceCount}>
                 <Translate
                   id="devPage.pace.count"
-                  description="Commits in the last 7 days"
+                  description="Commits in the current week"
                   values={{
                     count: (
                       <strong key="count" className={styles.paceNumber}>
-                        {stats.commitsLast7Days}
+                        {stats.commitsThisWeek}
                       </strong>
                     ),
                   }}
                 >
-                  {"{count} commits in the last 7 days"}
+                  {"{count} commits this week"}
                 </Translate>
               </p>
               <div
@@ -561,7 +583,7 @@ function DevPage() {
               <div className={styles.progressLegend}>
                 {stats.tier.next ? (
                   selectMessage(
-                    stats.tier.next.min - stats.commitsLast7Days,
+                    stats.tier.next.min - stats.commitsThisWeek,
                     translate(
                       {
                         id: "devPage.pace.next",
@@ -570,7 +592,7 @@ function DevPage() {
                           "One commit away from {tier}|{count} commits away from {tier}",
                       },
                       {
-                        count: stats.tier.next.min - stats.commitsLast7Days,
+                        count: stats.tier.next.min - stats.commitsThisWeek,
                         tier: TIER_LABELS[stats.tier.next.key],
                       }
                     )
@@ -738,6 +760,17 @@ function DevPage() {
                 >
                   {"{count} commits over the last 52 weeks. Each bar is a week, each square below is a day."}
                 </Translate>
+              </p>
+              <p className={styles.panelHint}>
+                <Link to="https://github.com/GladysAssistant/Gladys/graphs/commit-activity">
+                  <Translate
+                    id="devPage.rhythm.sameAsGithub"
+                    description="Link to the GitHub commit activity graph"
+                  >
+                    Same numbers as GitHub Insights → Commits, straight from the
+                    same API →
+                  </Translate>
+                </Link>
               </p>
             </div>
             <WeeklyBars weeks={data.weeks || []} locale={locale} />

--- a/src/pages/dev.module.css
+++ b/src/pages/dev.module.css
@@ -317,6 +317,16 @@
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
+/* The week in progress: same data, drawn as unfinished so a mid-week dip does
+   not read as a slowdown. */
+.barInProgress {
+  background: repeating-linear-gradient(
+    -45deg,
+    rgba(101, 199, 247, 0.85) 0 4px,
+    rgba(101, 199, 247, 0.35) 4px 8px
+  );
+}
+
 .barSlot:hover .bar {
   opacity: 1;
   transform: scaleY(1.03);

--- a/src/utils/devActivity.js
+++ b/src/utils/devActivity.js
@@ -97,7 +97,11 @@ export function computeStats(data, now) {
   const weeklyTotals = weeks.map((week) => week.t);
   const days = buildDailySeries(weeks, nowDate);
 
-  const commitsLast7Days = sumLastDays(days, 7);
+  // The current week, Sunday to now: the same number GitHub prints as the last
+  // bar of Insights > Commits, because it comes from the same payload.
+  const commitsThisWeek = weeklyTotals.length
+    ? weeklyTotals[weeklyTotals.length - 1]
+    : 0;
   const commitsLast30Days = sumLastDays(days, 30);
   const commitsLastYear = weeklyTotals.reduce((total, week) => total + week, 0);
 
@@ -149,7 +153,7 @@ export function computeStats(data, now) {
   ).length;
 
   return {
-    commitsLast7Days,
+    commitsThisWeek,
     commitsLast30Days,
     commitsLastYear,
     recentAverage: Math.round(recentAverage),
@@ -171,9 +175,9 @@ export function computeStats(data, now) {
     contributorsCount: data.contributorsCount || 0,
     forumRequestsCount: (data.forumRequests || []).length,
     stars: data.repository ? data.repository.stars : 0,
-    // The pace tile drives the tier: a trailing 7-day count reacts faster than
-    // the weekly bucket, which resets every Sunday.
-    tier: getTier(commitsLast7Days),
+    // The tier climbs with the week and starts over every Sunday, on the same
+    // count GitHub shows.
+    tier: getTier(commitsThisWeek),
   };
 }
 


### PR DESCRIPTION
Follow-up to #391: the big number on the pace card did not match the chart below it, nor the one GitHub shows in **Insights → Commits**.

## The mismatch

The chart has always come from `stats/commit_activity`, the exact payload GitHub draws Insights from, so the bars matched. The headline number did not: it summed a **rolling 7-day window**, while the chart counts **calendar weeks**. The two agree on a Saturday and drift apart the rest of the time — mid-week, the card could read 56 while the last bar read 34.

## What changed

- The pace card and the tier now read `commitsThisWeek`, the last bucket of the same payload. Headline number, last bar and GitHub Insights are now the same figure by construction.
- The week in progress is drawn hatched and its tooltip says `(week in progress)`, so a partial week no longer looks like a slowdown. Bar tooltips now read `Week of Aug 9, 2026: 56 commits` instead of a bare `date · number`.
- A link under the chart points to the GitHub commit-activity graph for anyone who wants to cross-check.

One consequence worth knowing: the tier now resets every Sunday and climbs through the week, instead of sliding over a rolling window. That reads more like a weekly quest, and it is the price of matching GitHub exactly.

Verified against the live API: GitHub currently reports 56 for the week of 9 August, and both locales render 56 in the pace card and in the last bar. `./build.sh` passes for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014b1351oPJkHxt3UoBLwH4f

---
_Generated by [Claude Code](https://claude.ai/code/session_014b1351oPJkHxt3UoBLwH4f)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized tooltips to the weekly commits chart.
  * Highlighted the current, in-progress week with a distinct visual style.
  * Added a link to the corresponding GitHub Insights commit activity graph.

* **Updates**
  * Development pace metrics and tier progress now reflect the current calendar week.
  * Refreshed development activity, pull request, contributor, and forum statistics.
  * Added French translations for the new weekly activity labels and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->