### PR TITLE
docs(external-integrations): update for Gladys 4.86 and SDK 0.12.0

### DIFF
--- a/docs/dev/5_external-integrations.md
+++ b/docs/dev/5_external-integrations.md
@@ -11,14 +11,17 @@ There is **no pull request to open, no code review to wait for, and no maintaine
 
 This page is a complete, step-by-step tutorial for developers.
 
-:::tip[New in Gladys 4.85 (SDK 0.11.0)]
+:::tip[New in Gladys 4.86 (SDK 0.12.0)]
 
-- **[Weather providers](#weather-providers)**: a new `weather` integration type. Answer one handler with the pivot weather format, and your provider feeds the dashboard widget, the chat assistant and the weather-alert scene triggers — taking precedence over the built-in OpenWeather with zero configuration.
-- **[House coordinates](#house-coordinates)**: declare `location: true` and read the coordinates of the user's houses, instead of asking for a latitude and a longitude again.
-- **[Named ports and form placeholders](#guiding-the-user-sections-and-placeholders)**: `{{gladys_host}}` and `{{port:<name>}}` in your section texts, to spell out an address of the instance itself.
-- **[Non-browsable ports](#sub-containers-and-hardware)**: `browsable: false` for a port that serves no web UI.
-- **[A single HTTPS redirect URI for OAuth2](#oauth2-cloud-services)**, whether the user reaches Gladys locally or through Gladys Plus.
-- **More device categories** in the SDK constants: charging station, water heater, thermostat mode and operating state, battery storage, water valve, doorbell, air-conditioning fan speed and swing.
+- **[Store categories](#store-categories)**: a new `categories` manifest field, which puts your integration on the shelves of the redesigned catalog. Declaring it requires a `gladys_version` range starting at `4.86.0`.
+- **[PTZ cameras](#motorized-ptz-cameras)**: `move`, `preset` and absolute position features, and Gladys draws the directional pad and the preset selector on the camera widget.
+- **[Wake-on-LAN](#wake-on-lan)**: `gladys.wakeOnLan(mac)` and the `network_wake` authorization, so the core emits the magic packet from the host network.
+- **[Account linking](#account-linking-without-a-redirect)**: an `account_link` configuration field, the "Connect" button of providers that never redirect back to Gladys (a QR sign-in approved in the vendor app).
+- **[Choice lists discovered on the device](#choice-lists-discovered-on-the-device)**: the `text`/`select` feature type and its `supported_options`, for the apps of a TV, the rooms of a vacuum, or the native scenes of a device.
+- **More device categories** in the SDK constants: grid sensor, home output sensor, maintenance (consumables), and the NO₂, O₃ and SO₂ gas sensors.
+- **[Install from a locally built image](#step-4-build-and-test-locally)**: developer mode installs the output of a `docker build` directly, with no registry involved.
+
+Already published an integration? Bump `@gladysassistant/integration-sdk` to `^0.12.0` (purely additive, nothing to adapt), declare your `categories`, and move `gladys_version` to `">=4.86.0"`.
 
 :::
 
@@ -48,7 +51,7 @@ An external integration is a **Docker container** that talks to Gladys through t
 
 You do not have to implement any of this plumbing yourself: the official [JavaScript SDK](https://github.com/GladysAssistant/integration-sdk-js) handles authentication, the WebSocket connection, automatic reconnection with exponential backoff, command acknowledgments, and state resynchronization for you. You can write your integration in any language, but the SDK saves you a lot of work.
 
-On top of the basics (devices, states, configuration), the platform also supports **cameras**, **OAuth2 cloud services**, **on-demand action buttons**, **local/cloud transport badges** (with a degraded state), **mediated network discovery** (mDNS, SSDP, UDP broadcast), **sub-containers with hardware access**, **messaging channels**, **weather providers**, **the coordinates of the user's houses**, and **incoming webhooks** (through Gladys Plus). Each of these is covered in its own section below.
+On top of the basics (devices, states, configuration), the platform also supports **cameras** (including **PTZ control**), **OAuth2 cloud services**, **on-demand action buttons**, **local/cloud transport badges** (with a degraded state), **mediated network discovery** (mDNS, SSDP, UDP broadcast), **Wake-on-LAN**, **sub-containers with hardware access**, **messaging channels**, **weather providers**, **the coordinates of the user's houses**, and **incoming webhooks** (through Gladys Plus). Each of these is covered in its own section below.
 
 An integration declares one of **three types** in its manifest:
 
@@ -63,7 +66,7 @@ A few important design rules to keep in mind:
 
 ## Prerequisites
 
-- A Gladys Assistant instance running on version **4.84.0 or later** (external integrations were introduced in this version). The most recent capabilities — [weather providers](#weather-providers), [house coordinates](#house-coordinates), and the [named ports and placeholders](#guiding-the-user-sections-and-placeholders) of the configuration form — require **4.85.0 or later**, so set the `gladys_version` range of your manifest accordingly.
+- A Gladys Assistant instance running on version **4.84.0 or later** (external integrations were introduced in this version). [Weather providers](#weather-providers), [house coordinates](#house-coordinates), and the [named ports and placeholders](#guiding-the-user-sections-and-placeholders) of the configuration form require **4.85.0 or later**; the most recent capabilities — [store categories](#store-categories), [PTZ cameras](#motorized-ptz-cameras), [Wake-on-LAN](#wake-on-lan) and [account linking](#account-linking-without-a-redirect) — require **4.86.0 or later**. Set the `gladys_version` range of your manifest accordingly.
 - [Docker](https://www.docker.com/) installed on your development machine.
 - [Node.js 24 or later](https://nodejs.org/) if you use the JavaScript SDK (the SDK requires Node.js 20 or later, but 24 is recommended).
 - A public Docker registry to host your image. The simplest option is the [GitHub Container Registry](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`), which keeps your image in the same place as your code, and which the official template publishes to automatically. Docker Hub or any other public registry works too, as long as the image is anonymously pullable.
@@ -143,7 +146,7 @@ await gladys.connect();
 
 That is the entire integration. The SDK reads the credentials Gladys injects into the container as environment variables, so there is no configuration to wire up by hand. Using the exported `DEVICE_FEATURE_CATEGORIES`, `DEVICE_FEATURE_TYPES`, and `DEVICE_FEATURE_UNITS` constants (instead of raw strings) keeps your features aligned with the categories, types, and units Gladys understands.
 
-Those constants are a verbatim mirror of the ones in the Gladys core, resynchronized at every SDK release: the latest versions added **charging stations**, **water heaters**, **thermostat modes and operating states**, **battery storage**, **water valves**, **doorbells**, and the **fan speed and swing** of air conditioners. Keeping `@gladysassistant/integration-sdk` up to date is how you get them (the current version is `0.11.0`).
+Those constants are a verbatim mirror of the ones in the Gladys core, resynchronized at every SDK release: the latest versions added the **PTZ camera** features, **grid sensors** (`input-power`, `output-power`, a signed `power`, and the import/export indexes), **home output sensors** (the power an inverter or a battery delivers to the home, plus its off-grid output), the **maintenance** category (the remaining life of a consumable: vacuum brush, dust bag, mop pad…), the **NO₂, O₃ and SO₂** gas sensors, and before that charging stations, water heaters, thermostat modes and operating states, battery storage, water valves, doorbells, and the fan speed and swing of air conditioners. Keeping `@gladysassistant/integration-sdk` up to date is how you get them (the current version is `0.12.0`).
 
 ### The SDK API in a nutshell
 
@@ -200,6 +203,11 @@ await gladys.publishStates(
 - `onWeatherGet(cb)` / `onWeatherGetImage(cb)`: Gladys asks for the weather, or for a provider image (see Weather providers).
 - `onWebhook(key, cb)` / `onWebhookUpdated(cb)`: incoming webhooks (see Incoming webhooks).
 
+**Network**
+
+- `scanNetwork(type, options?)`: runs a mediated network capture declared in your manifest (see Network discovery).
+- `wakeOnLan(mac, options?)`: asks the core to send a Wake-on-LAN magic packet from the host network (see Wake-on-LAN).
+
 **Weather providers**
 
 - `requestWeatherRefresh()`: fire-and-forget nudge asking the core to re-pull your weather right now, instead of waiting for its next scheduled check (see Weather providers).
@@ -229,6 +237,78 @@ await gladys.publishCameraImage(ids.device, `image/jpg;base64,${jpeg.toString("b
 
 Images are `image/jpg;base64,...` strings and must stay under 150 KB.
 
+#### Motorized (PTZ) cameras
+
+*Requires Gladys 4.86.0 or later.*
+
+Moving a motorized camera needs no new plumbing: PTZ control is made of ordinary command features on the same device, and the movement commands arrive through `onSetValue` like any other feature. Gladys renders a directional pad and a preset selector on the live view of the camera widget, showing **only the movements you declared**.
+
+```js
+const ids = gladys.externalIds("camera", "front-door");
+
+await gladys.publishDiscoveredDevices([
+  {
+    name: "Front door",
+    external_id: ids.device,
+    features: [
+      { name: "Image", external_id: ids.feature("image"), category: DEVICE_FEATURE_CATEGORIES.CAMERA,
+        type: DEVICE_FEATURE_TYPES.CAMERA.IMAGE, min: 0, max: 1, read_only: true, has_feedback: false, keep_history: false },
+      {
+        name: "Move",
+        external_id: ids.feature("move"),
+        category: DEVICE_FEATURE_CATEGORIES.CAMERA,
+        type: DEVICE_FEATURE_TYPES.CAMERA.MOVE,
+        min: 0,
+        max: 6,
+        read_only: false,
+        has_feedback: false,
+        keep_history: false,
+        // The movements this camera actually supports (0, stop, is always supported
+        // and never listed):
+        supported_options: [
+          { value: 1, label: { en: "Left", fr: "Gauche" }, sort_order: 1 },
+          { value: 2, label: { en: "Right", fr: "Droite" }, sort_order: 2 },
+        ],
+      },
+    ],
+  },
+]);
+```
+
+- **`CAMERA.MOVE`** is a single feature for every movement: the value names the movement (`0` stop — always supported, never listed as an option —, `1` pan left, `2` pan right, `3` tilt up, `4` tilt down, `5` zoom in, `6` zoom out), and `supported_options` (`[{ value, label, sort_order }]`) declares the subset this camera supports.
+- **`CAMERA.PRESET`** recalls a saved position. The labeled list of presets lives in `supported_options`, and the value sent back to you is the option's integer, which you map to your protocol's own token.
+- **`CAMERA.PAN_POSITION`, `CAMERA.TILT_POSITION`, `CAMERA.ZOOM_POSITION`** are optional numeric read/write features for cameras that report an absolute position, with their bounds declared through `min`/`max` (the unit is yours: normalized ONVIF space, degrees…).
+
+**Safety rule**: always bound a continuous movement with a watchdog (about 5 seconds) so a lost stop command can never leave the camera turning against its mechanical stop, and prefer a relative step when your camera supports one.
+
+Re-publishing an already-created device silently upserts the `supported_options` of its features, exactly like its `params` — a preset renamed on the camera shows up without the user having to do anything.
+
+### Choice lists discovered on the device
+
+*Requires Gladys 4.86.0 or later.*
+
+Some capabilities are a list of choices that only the appliance itself knows: the apps installed on a TV, its HDMI sources, the rooms of a robot vacuum, the scenes stored in a device. The `text`/`select` feature type covers exactly that — a choice among values your integration discovers, declared per device through `supported_options`:
+
+```js
+{
+  name: "Application",
+  external_id: ids.feature("app"),
+  category: DEVICE_FEATURE_CATEGORIES.TEXT,
+  type: DEVICE_FEATURE_TYPES.TEXT.SELECT,
+  min: 0,
+  max: 0,
+  read_only: false,
+  has_feedback: true,
+  keep_history: false,
+  supported_options: [
+    { value: "netflix", label: { en: "Netflix" }, sort_order: 1 },
+    { value: "youtube", label: { en: "YouTube" }, sort_order: 2 },
+  ],
+}
+```
+
+The state is the selected option's value, stored as a string and kept without history. Keep this type for lists no generic value set can describe: the enum-like capabilities standards already cover (air-conditioning modes, fan speeds, thermostat modes…) keep their own category and type, with integer values.
+
 ### OAuth2 cloud services
 
 For cloud providers that use OAuth2, declare a config field of type `oauth2` in your manifest, then build the authorization URL and handle the callback:
@@ -252,6 +332,28 @@ gladys.onOAuthCallback(async (key, { code, state: returnedState, redirectUri }) 
 Refreshing the token is your integration's responsibility. When it expires, report it with `setConnectionStatus(false, { en: "Token expired, please reconnect.", fr: "Token expire, reconnectez-vous." })`.
 
 **Never hardcode the redirect URI**: use the `redirectUri` Gladys hands you, and give it back byte for byte in the token exchange. Providers now require an HTTPS callback (Spotify has enforced it since 2025), which a Gladys reached at `http://192.168.1.50:1443` can never satisfy, so the flow goes through a fixed HTTPS page hosted by Gladys, which bounces the browser back to the instance. The practical consequence for you and your users: **a single redirect URI has to be declared at the provider**, whether Gladys is reached locally or through Gladys Plus. The Configuration screen shows the exact URL to copy into the provider's developer application.
+
+#### Account linking without a redirect
+
+*Requires Gladys 4.86.0 or later.*
+
+Some providers link an account **without ever redirecting back** to Gladys: a QR sign-in approved in the vendor's own app (Xiaomi Home style), a pairing confirmed on the device itself. Declare the field as `account_link` instead of `oauth2`:
+
+```json
+{ "key": "account", "type": "account_link", "label": { "en": "Link my account", "fr": "Lier mon compte" } }
+```
+
+The Configuration screen renders the same "Connect" button, and `onOAuthAuthorizeUrl` is called the same way — but `redirectUri` is `undefined` (there is none), no anti-CSRF `state` is needed (there is no round trip to protect), and `onOAuthCallback` is never called. Return the provider's sign-in URL, watch for the approval yourself (typically by long-polling the provider), then report it through `setConnectionStatus(true)`: that is what drives the connection badge shown to the user.
+
+```js
+gladys.onOAuthAuthorizeUrl(async () => {
+  const { loginUrl, ticket } = await startQrLogin();
+  waitForApproval(ticket).then(() => gladys.setConnectionStatus(true));
+  return loginUrl;
+});
+```
+
+An `account_link` field is forbidden in a `contact_schema`: linking a provider account is scoped to the integration, never to a single user.
 
 ### Action buttons
 
@@ -325,6 +427,21 @@ const replies = await gladys.scanNetwork("udp-active-broadcast", {
   timeoutSeconds: 10,
 });
 ```
+
+### Wake-on-LAN
+
+*Requires Gladys 4.86.0 or later.*
+
+Same network position problem, on the emission side: a magic packet is a UDP broadcast, which never crosses the bridge to the LAN. Declare `"network_wake": true` in your manifest (shown on the install screen, like the other authorization contracts — an undeclared access gets a `403`) and ask the core to emit it:
+
+```js
+await gladys.wakeOnLan("64:e4:d5:b4:12:66"); // ":", "-" and bare formats are accepted
+
+// The device ignores the limited broadcast? Target the subnet broadcast, or tune the port:
+await gladys.wakeOnLan("64:e4:d5:b4:12:66", { address: "192.168.1.255", port: 9 });
+```
+
+The core always builds the standard 102-byte magic packet itself (6 × `0xFF` followed by the MAC repeated 16 times), so you never provide the payload and the endpoint is not a general UDP proxy. It is rate-limited to **one wake every 2 seconds** per integration (`429` beyond), which is enough for the usual "retry until the device answers" loop. A resolved call means the packet was **emitted**, not that the device woke up: poll the device to confirm.
 
 ### Sub-containers and hardware
 
@@ -557,8 +674,9 @@ Every external integration is described by a single file named `gladys-assistant
   },
   "version": "1.0.0",
   "docker_image": "ghcr.io/yourname/my-integration:1.0.0",
-  "gladys_version": ">=4.84.0",
+  "gladys_version": ">=4.86.0",
   "cover_image": "https://raw.githubusercontent.com/yourname/my-integration/main/cover.jpg",
+  "categories": ["lighting", "energy"],
   "transports": ["local", "cloud"],
   "config_schema": [
     {
@@ -584,19 +702,41 @@ Every external integration is described by a single file named `gladys-assistant
 | `docker_image` | Yes | A well-formed image reference with an explicit tag or digest. It must exist and be anonymously pullable. |
 | `gladys_version` | Yes | A semver range (npm syntax) used to filter compatible instances. |
 | `cover_image` | No | Direct HTTPS URL to a cover image (see rules below). |
+| `categories` | No | 1 to 3 browse categories of the catalog (see below). Requires a `gladys_version` range starting at `4.86.0`. |
 | `config_schema` | No | The list of configuration fields shown to the user. |
 | `transports` | No | Non-empty subset of `local` and `cloud`, if your integration is dual-channel. |
 | `actions` | No | 1 to 10 action buttons, each with a `key`, a multi-language `label`, a `timeout_seconds` (5 to 120), and optional `fields`. |
 | `network_discovery` | No | 1 to 5 mediated capture methods (`udp-broadcast`, `udp-active-broadcast`, `mdns`, `ssdp`). |
 | `containers` | No | Up to 5 companion containers, each with `name`, `docker_image`, `start` (`auto` or `manual`), and optional `env`, `volumes`, `ports` (up to 3, each with `container_port`, `protocol`, a multi-language `label`, an optional `name` and `browsable`), `devices` (`coral-usb`, `coral-pcie`, `gpu`, `video`), `read_only`, `command`, `memory_mb` (32 to 4096), `cpu` (0.1 to 2), `shm_mb` (64 to 512). |
 | `location` | No | `true` requests access to the coordinates of the user's houses (`GET /house`). Shown on the install screen, enforced server-side. |
+| `network_wake` | No | `true` requests permission to send Wake-on-LAN magic packets through the core. Shown on the install screen, enforced server-side. |
 | `messaging` | Mandatory for `communication` | `{ "receive": true }` for a bidirectional chat channel, `{ "receive": false }` for a send-only notification channel. Forbidden for the other types. |
 | `contact_schema` | Mandatory when `messaging.receive` is `false` | The per-user credentials of a send-only channel, same field format as `config_schema` (minus `oauth2` fields). Forbidden otherwise. |
 | `webhooks` | No | Up to 3 incoming webhooks (Gladys Plus), each with a `key`, a multi-language `label`, and a `mode` (`fire_and_forget` or `sync`). |
 
+### Store categories
+
+*Requires Gladys 4.86.0 or later.*
+
+Since Gladys 4.86, the catalog is browsable: a category sidebar, facet filters (native, community, local, cloud, Gladys Plus) and a "Newest first" sort. The `categories` field is what puts your integration on the right shelf — a domain of use, decoupled from the technical `type` of the manifest:
+
+```json
+"categories": ["lighting", "energy"],
+"gladys_version": ">=4.86.0"
+```
+
+The rules:
+
+- **1 to 3 categories**, from the controlled vocabulary: `climate`, `lighting`, `energy`, `security`, `multimedia`, `appliances`, `environment`, `protocols`, `network`, `notifications`, `assistants`, `services`.
+- **`gladys_version` must start at `4.86.0`** as soon as you declare the field. Older cores reject any unknown manifest field, so the store validator refuses a manifest that declares `categories` with a lower minimum — the two go together.
+- An unknown key is **dropped with a warning** rather than rejecting the manifest, so an integration published against a newer vocabulary than the running Gladys still installs.
+- Without the field, your integration stays visible under "All" and in search, but it sits on no shelf.
+
+Integrations published before 4.86 were categorized once through a fallback mapping file kept in the [store repository](https://github.com/GladysAssistant/integration-store), but **your manifest always wins** as soon as it declares the field: it is the occasion to check that the categories you were given actually fit, and to adjust them if not.
+
 ### The config schema
 
-`config_schema` is a flat list of fields. Each field has a `key` (lowercase, matching `[a-z0-9_]`), a `type`, and a multi-language `label` (with `en` mandatory). Supported types are `string`, `number`, `boolean`, `select`, `multi_select`, `secret`, `oauth2`, and `section`. Depending on the type, a field can also declare `placeholder` (for `string`/`number`/`secret`), `required`, `default`, `min`/`max` (for numbers), and `options` (for `select`/`multi_select`).
+`config_schema` is a flat list of fields. Each field has a `key` (lowercase, matching `[a-z0-9_]`), a `type`, and a multi-language `label` (with `en` mandatory). Supported types are `string`, `number`, `boolean`, `select`, `multi_select`, `secret`, `oauth2`, `account_link`, and `section`. Depending on the type, a field can also declare `placeholder` (for `string`/`number`/`secret`), `required`, `default`, `min`/`max` (for numbers), and `options` (for `select`/`multi_select`).
 
 A `select` or `multi_select` can either list static `options` or pull its choices dynamically from the user's devices with `source: "devices"`, and render as a `dropdown` or `radio` (`display`). A `section` field is presentational only: it shows a `description` and up to five documentation `links`, and stores no value.
 
@@ -703,6 +843,8 @@ npm start
 docker build -t ghcr.io/yourname/my-integration:1.0.0 .
 ```
 
+Since Gladys 4.86, developer mode installs that image **straight from your local Docker daemon**, with an optional manifest and without pushing anything to a registry: build on the machine that runs Gladys, then install the tag from the "Developer mode: install from a Docker image" link of the catalog. It is the fastest way to test a real container.
+
 **Or build it on GitHub in one click.** If you would rather not build locally (or you do not have a multi-architecture builder set up), the template also ships a **Build** workflow you can run by hand: go to the **Actions** tab, select **Build**, click **Run workflow**, and optionally set an image tag (it defaults to your branch name). GitHub builds the multi-architecture image (`linux/amd64` and `linux/arm64`) and pushes it to `ghcr.io` under that tag, without ever touching `:latest`. You can then install that exact tag in your Gladys instance to test a real build, with no local Docker required. This is a test build, not a release: use [Step 5](#step-5-publish-your-integration) when you are ready to publish for everyone.
 
 **Validate your manifest offline** with the exact checks the store indexer runs, before waiting for the hourly cycle:
@@ -764,9 +906,9 @@ The maintainer approves nothing and is never a bottleneck.
 
 ## Step 6: Users install in one click
 
-From the Gladys catalog, external integrations appear alongside the built-in ones, with a **community badge**, the local/cloud badges derived from your `transports`, and a live status indicator. A user clicks **Install**, and Gladys pulls your image, starts the container, and shows the generated interface. Users can also install directly from a GitHub repository URL, without waiting for the next index cycle.
+From the Gladys catalog, external integrations appear alongside the built-in ones, with a **community badge**, the local/cloud badges derived from your `transports`, and a live status indicator. Users browse the catalog by category (yours comes from the `categories` field of your manifest), filter it, and sort it by newest first. A user clicks **Install**, and Gladys pulls your image, starts the container, and shows the generated interface. Users can also install directly from a GitHub repository URL, without waiting for the next index cycle.
 
-Before installing, the screen shows everything your manifest declared: your documentation, the sub-containers that will run and the ports they will publish, the hardware you request, the network captures, the webhooks, and the access to the house coordinates. Declare only what you actually use — each line is a question the user has to answer before trusting your integration.
+Before installing, the screen shows everything your manifest declared: your documentation, the sub-containers that will run and the ports they will publish, the hardware you request, the network captures, the Wake-on-LAN permission, the webhooks, and the access to the house coordinates. Declare only what you actually use — each line is a question the user has to answer before trusting your integration.
 
 ## Updating your integration
 
@@ -774,11 +916,13 @@ Shipping a new version is one click: run the **Release** workflow again and pick
 
 If you publish manually, do the same two things by hand: build and push a new image tag (for example `ghcr.io/yourname/my-integration:1.1.0`), then bump `version` and `docker_image` in the manifest and push.
 
+Following a new Gladys version is the same, short exercise: bump `@gladysassistant/integration-sdk` (SDK releases are additive, so existing code keeps working), declare the manifest fields the new capabilities need, raise the `gladys_version` range accordingly, run `npx github:GladysAssistant/integration-store .` to validate, and release. For 4.86, that means `^0.12.0`, a `categories` field, and `">=4.86.0"`.
+
 ## Troubleshooting
 
 Installing your integration from its repository URL (or in developer mode) shows the **detailed validation errors** of your manifest, field by field, so you can fix them without waiting for the next index cycle.
 
-The indexer is fully transparent. If your integration does not appear in the catalog, check the published `rejected.json` file: it lists every repository that failed validation, along with the reason and a severity level (invalid manifest, malformed or unpullable image reference, incompatible `gladys_version` range, oversized or wrongly-sized cover, missing `docs/en.md` or `docs/fr.md`, and so on). You can catch most of these before publishing by running `npx github:GladysAssistant/integration-store .` locally. Fix the issue, release again, and wait for the next cycle.
+The indexer is fully transparent. If your integration does not appear in the catalog, check the published `rejected.json` file: it lists every repository that failed validation, along with the reason and a severity level (invalid manifest, malformed or unpullable image reference, incompatible `gladys_version` range, `categories` declared with a `gladys_version` minimum below 4.86.0, oversized or wrongly-sized cover, missing `docs/en.md` or `docs/fr.md`, and so on). Warnings are worth reading too: an unknown category key is dropped, and an integration that declares none is indexed uncategorized. You can catch most of these before publishing by running `npx github:GladysAssistant/integration-store .` locally. Fix the issue, release again, and wait for the next cycle.
 
 ## Security model
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/dev/5_external-integrations.md
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/dev/5_external-integrations.md
@@ -11,14 +11,17 @@ Il n'y a **aucune pull request à ouvrir, aucune review de code à attendre, et 
 
 Cette page est un tutoriel complet, étape par étape, à destination des développeurs.
 
-:::tip[Nouveautés de Gladys 4.85 (SDK 0.11.0)]
+:::tip[Nouveautés de Gladys 4.86 (SDK 0.12.0)]
 
-- **[Fournisseurs météo](#fournisseurs-météo)** : un nouveau type d'intégration `weather`. Répondez à un seul gestionnaire avec le format pivot météo, et votre fournisseur alimente le widget du tableau de bord, l'assistant conversationnel et les déclencheurs de scène sur alerte météo — en prenant le pas sur le service OpenWeather intégré, sans aucune configuration.
-- **[Coordonnées des maisons](#coordonnées-des-maisons)** : déclarez `location: true` et lisez les coordonnées des maisons de l'utilisateur, au lieu de redemander une latitude et une longitude.
-- **[Ports nommés et placeholders de formulaire](#guider-vos-utilisateurs-dans-le-formulaire)** : `{{gladys_host}}` et `{{port:<name>}}` dans vos textes de section, pour écrire une adresse de l'instance elle-même.
-- **[Ports non navigables](#sous-conteneurs-et-matériel)** : `browsable: false` pour un port qui n'expose aucune interface web.
-- **[Une seule URL de redirection HTTPS pour OAuth2](#services-cloud-oauth2)**, que l'utilisateur atteigne Gladys en local ou via Gladys Plus.
-- **De nouvelles catégories d'appareils** dans les constantes du SDK : borne de recharge, chauffe-eau, mode et état de fonctionnement de thermostat, batterie de stockage, vanne d'eau, sonnette, vitesse de ventilation et oscillation de climatisation.
+- **[Catégories du store](#catégories-du-store)** : un nouveau champ `categories` dans le manifeste, qui range votre intégration dans les rayons du catalogue redessiné. Le déclarer impose une plage `gladys_version` qui démarre à `4.86.0`.
+- **[Caméras PTZ](#caméras-motorisées-ptz)** : les fonctionnalités `move`, `preset` et les positions absolues, et Gladys affiche la croix directionnelle et le sélecteur de préréglages sur le widget caméra.
+- **[Wake-on-LAN](#wake-on-lan)** : `gladys.wakeOnLan(mac)` et l'autorisation `network_wake`, pour que le cœur émette le magic packet depuis le réseau de l'hôte.
+- **[Liaison de compte](#lier-un-compte-sans-redirection)** : un champ de configuration `account_link`, le bouton « Connecter » des fournisseurs qui ne redirigent jamais vers Gladys (une connexion par QR code validée dans l'application du fabricant).
+- **[Listes de choix découvertes sur les appareils](#listes-de-choix-découvertes-sur-les-appareils)** : le type de fonctionnalité `text`/`select` et ses `supported_options`, pour les applications d'une TV, les pièces d'un aspirateur ou les scènes natives d'un appareil.
+- **De nouvelles catégories d'appareils** dans les constantes du SDK : capteur de réseau électrique, capteur de sortie maison, maintenance (consommables), et les capteurs de gaz NO₂, O₃ et SO₂.
+- **[Installation depuis une image construite en local](#étape-4--construire-et-tester-en-local)** : le mode développeur installe directement le résultat d'un `docker build`, sans passer par un registre.
+
+Vous avez déjà publié une intégration ? Passez `@gladysassistant/integration-sdk` en `^0.12.0` (changements purement additifs, rien à adapter), déclarez vos `categories`, et passez `gladys_version` à `">=4.86.0"`.
 
 :::
 
@@ -48,7 +51,7 @@ Une intégration externe est un **conteneur Docker** qui dialogue avec Gladys vi
 
 Vous n'avez à implémenter aucune de cette plomberie vous-même : le [SDK JavaScript officiel](https://github.com/GladysAssistant/integration-sdk-js) gère pour vous l'authentification, la connexion WebSocket, la reconnexion automatique avec backoff exponentiel, les accusés de réception des commandes, et la resynchronisation de l'état. Vous pouvez écrire votre intégration dans n'importe quel langage, mais le SDK vous fait gagner beaucoup de temps.
 
-Au-delà des bases (appareils, états, configuration), la plateforme prend aussi en charge les **caméras**, les **services cloud OAuth2**, les **boutons d'action à la demande**, les **badges de transport local/cloud** (avec un état dégradé), la **découverte réseau médiée** (mDNS, SSDP, broadcast UDP), les **sous-conteneurs avec accès au matériel**, les **canaux de messagerie**, les **fournisseurs météo**, les **coordonnées des maisons de l'utilisateur**, et les **webhooks entrants** (via Gladys Plus). Chacun de ces points est couvert dans sa propre section ci-dessous.
+Au-delà des bases (appareils, états, configuration), la plateforme prend aussi en charge les **caméras** (y compris le **contrôle PTZ**), les **services cloud OAuth2**, les **boutons d'action à la demande**, les **badges de transport local/cloud** (avec un état dégradé), la **découverte réseau médiée** (mDNS, SSDP, broadcast UDP), le **Wake-on-LAN**, les **sous-conteneurs avec accès au matériel**, les **canaux de messagerie**, les **fournisseurs météo**, les **coordonnées des maisons de l'utilisateur**, et les **webhooks entrants** (via Gladys Plus). Chacun de ces points est couvert dans sa propre section ci-dessous.
 
 Une intégration déclare dans son manifeste l'un des **trois types** suivants :
 
@@ -63,7 +66,7 @@ Quelques règles de conception importantes à garder en tête :
 
 ## Prérequis
 
-- Une instance Gladys Assistant en version **4.84.0 ou ultérieure** (les intégrations externes ont été introduites dans cette version). Les capacités les plus récentes — les [fournisseurs météo](#fournisseurs-météo), les [coordonnées des maisons](#coordonnées-des-maisons), et les [ports nommés et placeholders](#guider-vos-utilisateurs-dans-le-formulaire) du formulaire de configuration — nécessitent la version **4.85.0 ou ultérieure** : ajustez l'intervalle `gladys_version` de votre manifeste en conséquence.
+- Une instance Gladys Assistant en version **4.84.0 ou ultérieure** (les intégrations externes ont été introduites dans cette version). Les [fournisseurs météo](#fournisseurs-météo), les [coordonnées des maisons](#coordonnées-des-maisons) et les [ports nommés et placeholders](#guider-vos-utilisateurs-dans-le-formulaire) du formulaire de configuration nécessitent la version **4.85.0 ou ultérieure** ; les capacités les plus récentes — les [catégories du store](#catégories-du-store), les [caméras PTZ](#caméras-motorisées-ptz), le [Wake-on-LAN](#wake-on-lan) et la [liaison de compte](#lier-un-compte-sans-redirection) — nécessitent la version **4.86.0 ou ultérieure**. Ajustez l'intervalle `gladys_version` de votre manifeste en conséquence.
 - [Docker](https://www.docker.com/) installé sur votre machine de développement.
 - [Node.js 24 ou ultérieur](https://nodejs.org/) si vous utilisez le SDK JavaScript (le SDK requiert Node.js 20 ou ultérieur, mais la version 24 est recommandée).
 - Un registre Docker public pour héberger votre image. L'option la plus simple est le [GitHub Container Registry](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`ghcr.io`), qui garde votre image au même endroit que votre code, et sur lequel le template officiel publie automatiquement. Docker Hub ou n'importe quel autre registre public fonctionne aussi, tant que l'image est téléchargeable de façon anonyme.
@@ -143,7 +146,7 @@ await gladys.connect();
 
 Voilà toute l'intégration. Le SDK lit les identifiants que Gladys injecte dans le conteneur sous forme de variables d'environnement, il n'y a donc aucune configuration à câbler à la main. Utiliser les constantes exportées `DEVICE_FEATURE_CATEGORIES`, `DEVICE_FEATURE_TYPES` et `DEVICE_FEATURE_UNITS` (plutôt que des chaînes brutes) garde vos fonctionnalités alignées avec les catégories, types et unités que Gladys comprend.
 
-Ces constantes sont une copie conforme de celles du cœur de Gladys, resynchronisées à chaque version du SDK : les dernières ont ajouté les **bornes de recharge**, les **chauffe-eau**, les **modes et états de fonctionnement de thermostat**, les **batteries de stockage**, les **vannes d'eau**, les **sonnettes**, ainsi que la **vitesse de ventilation et l'oscillation** des climatisations. C'est en gardant `@gladysassistant/integration-sdk` à jour que vous en profitez (la version actuelle est la `0.11.0`).
+Ces constantes sont une copie conforme de celles du cœur de Gladys, resynchronisées à chaque version du SDK : les dernières ont ajouté les fonctionnalités **PTZ des caméras**, les **capteurs de réseau électrique** (`input-power`, `output-power`, un `power` signé, et les index d'import/export), les **capteurs de sortie maison** (la puissance qu'un onduleur ou une batterie délivre à la maison, plus sa sortie secourue), la catégorie **maintenance** (la durée de vie restante d'un consommable : brosse d'aspirateur, sac, serpillière…), les capteurs de gaz **NO₂, O₃ et SO₂**, et avant cela les bornes de recharge, les chauffe-eau, les modes et états de fonctionnement de thermostat, les batteries de stockage, les vannes d'eau, les sonnettes, ainsi que la vitesse de ventilation et l'oscillation des climatisations. C'est en gardant `@gladysassistant/integration-sdk` à jour que vous en profitez (la version actuelle est la `0.12.0`).
 
 ### L'API du SDK en un coup d'œil
 
@@ -200,6 +203,11 @@ await gladys.publishStates(
 - `onWeatherGet(cb)` / `onWeatherGetImage(cb)` : Gladys demande la météo, ou une image du fournisseur (voir Fournisseurs météo).
 - `onWebhook(key, cb)` / `onWebhookUpdated(cb)` : webhooks entrants (voir Webhooks entrants).
 
+**Réseau**
+
+- `scanNetwork(type, options?)` : lance une capture réseau médiée déclarée dans votre manifeste (voir Découverte réseau).
+- `wakeOnLan(mac, options?)` : demande au cœur d'émettre un magic packet Wake-on-LAN depuis le réseau de l'hôte (voir Wake-on-LAN).
+
 **Fournisseurs météo**
 
 - `requestWeatherRefresh()` : un signal sans réponse attendue qui demande au cœur de re-solliciter votre météo immédiatement, au lieu d'attendre sa prochaine vérification planifiée (voir Fournisseurs météo).
@@ -229,6 +237,78 @@ await gladys.publishCameraImage(ids.device, `image/jpg;base64,${jpeg.toString("b
 
 Les images sont des chaînes `image/jpg;base64,...` et doivent rester sous 150 Ko.
 
+#### Caméras motorisées (PTZ)
+
+*Nécessite Gladys 4.86.0 ou ultérieur.*
+
+Piloter une caméra motorisée ne demande aucune nouvelle plomberie : le contrôle PTZ est fait de fonctionnalités de commande ordinaires sur le même appareil, et les commandes de mouvement arrivent par `onSetValue` comme n'importe quelle fonctionnalité. Gladys affiche une croix directionnelle et un sélecteur de préréglages sur la vue en direct du widget caméra, en ne montrant **que les mouvements que vous avez déclarés**.
+
+```js
+const ids = gladys.externalIds("camera", "front-door");
+
+await gladys.publishDiscoveredDevices([
+  {
+    name: "Porte d'entrée",
+    external_id: ids.device,
+    features: [
+      { name: "Image", external_id: ids.feature("image"), category: DEVICE_FEATURE_CATEGORIES.CAMERA,
+        type: DEVICE_FEATURE_TYPES.CAMERA.IMAGE, min: 0, max: 1, read_only: true, has_feedback: false, keep_history: false },
+      {
+        name: "Déplacement",
+        external_id: ids.feature("move"),
+        category: DEVICE_FEATURE_CATEGORIES.CAMERA,
+        type: DEVICE_FEATURE_TYPES.CAMERA.MOVE,
+        min: 0,
+        max: 6,
+        read_only: false,
+        has_feedback: false,
+        keep_history: false,
+        // Les mouvements que cette caméra sait réellement faire (0, l'arrêt, est
+        // toujours pris en charge et n'est jamais listé) :
+        supported_options: [
+          { value: 1, label: { en: "Left", fr: "Gauche" }, sort_order: 1 },
+          { value: 2, label: { en: "Right", fr: "Droite" }, sort_order: 2 },
+        ],
+      },
+    ],
+  },
+]);
+```
+
+- **`CAMERA.MOVE`** est une fonctionnalité unique pour tous les mouvements : la valeur désigne le mouvement (`0` arrêt — toujours pris en charge, jamais listé comme option —, `1` panoramique gauche, `2` panoramique droite, `3` inclinaison haut, `4` inclinaison bas, `5` zoom avant, `6` zoom arrière), et `supported_options` (`[{ value, label, sort_order }]`) déclare le sous-ensemble que cette caméra prend en charge.
+- **`CAMERA.PRESET`** rappelle une position enregistrée. La liste des préréglages et leurs libellés vivent dans `supported_options`, et la valeur qui vous est envoyée est l'entier de l'option, que vous faites correspondre au jeton de votre protocole.
+- **`CAMERA.PAN_POSITION`, `CAMERA.TILT_POSITION`, `CAMERA.ZOOM_POSITION`** sont des fonctionnalités numériques optionnelles en lecture/écriture, pour les caméras qui rapportent une position absolue, avec des bornes déclarées via `min`/`max` (l'unité est la vôtre : espace ONVIF normalisé, degrés…).
+
+**Règle de sécurité** : bornez toujours un mouvement continu par un chien de garde (environ 5 secondes), pour qu'une commande d'arrêt perdue ne puisse jamais laisser la caméra tourner contre sa butée mécanique, et préférez un pas relatif quand votre caméra en propose un.
+
+Republier un appareil déjà créé met silencieusement à jour les `supported_options` de ses fonctionnalités, exactement comme ses `params` : un préréglage renommé sur la caméra apparaît sans aucune action de l'utilisateur.
+
+### Listes de choix découvertes sur les appareils
+
+*Nécessite Gladys 4.86.0 ou ultérieur.*
+
+Certaines capacités sont une liste de choix que seul l'appareil connaît : les applications installées sur une TV, ses entrées HDMI, les pièces d'un aspirateur robot, les scènes enregistrées dans un appareil. Le type de fonctionnalité `text`/`select` couvre exactement ce cas — un choix parmi des valeurs que votre intégration découvre, déclarées par appareil via `supported_options` :
+
+```js
+{
+  name: "Application",
+  external_id: ids.feature("app"),
+  category: DEVICE_FEATURE_CATEGORIES.TEXT,
+  type: DEVICE_FEATURE_TYPES.TEXT.SELECT,
+  min: 0,
+  max: 0,
+  read_only: false,
+  has_feedback: true,
+  keep_history: false,
+  supported_options: [
+    { value: "netflix", label: { en: "Netflix", fr: "Netflix" }, sort_order: 1 },
+    { value: "youtube", label: { en: "YouTube", fr: "YouTube" }, sort_order: 2 },
+  ],
+}
+```
+
+L'état est la valeur de l'option sélectionnée, stockée sous forme de chaîne et conservée sans historique. Gardez ce type pour les listes qu'aucun jeu de valeurs générique ne peut décrire : les capacités de type énumération que les standards couvrent déjà (modes de climatisation, vitesses de ventilation, modes de thermostat…) conservent leur propre catégorie et leur propre type, avec des valeurs entières.
+
 ### Services cloud OAuth2
 
 Pour les fournisseurs cloud qui utilisent OAuth2, déclarez un champ de configuration de type `oauth2` dans votre manifeste, puis construisez l'URL d'autorisation et gérez le callback :
@@ -252,6 +332,28 @@ gladys.onOAuthCallback(async (key, { code, state: returnedState, redirectUri }) 
 Le rafraîchissement du token est de la responsabilité de votre intégration. Quand il expire, signalez-le avec `setConnectionStatus(false, { en: "Token expired, please reconnect.", fr: "Token expiré, reconnectez-vous." })`.
 
 **Ne codez jamais l'URL de redirection en dur** : utilisez le `redirectUri` que Gladys vous transmet, et renvoyez-le à l'octet près lors de l'échange des tokens. Les fournisseurs exigent désormais une URL de callback en HTTPS (Spotify l'impose depuis 2025), ce qu'un Gladys joignable sur `http://192.168.1.50:1443` ne pourra jamais satisfaire : le flux passe donc par une page HTTPS fixe hébergée par Gladys, qui renvoie le navigateur vers l'instance. La conséquence pratique pour vous et vos utilisateurs : **une seule URL de redirection est à déclarer chez le fournisseur**, que Gladys soit atteint en local ou via Gladys Plus. L'écran de configuration affiche l'URL exacte à copier dans l'application développeur du fournisseur.
+
+#### Lier un compte sans redirection
+
+*Nécessite Gladys 4.86.0 ou ultérieur.*
+
+Certains fournisseurs relient un compte **sans jamais rediriger** vers Gladys : une connexion par QR code validée dans l'application du fabricant (style Xiaomi Home), un appairage confirmé sur l'appareil lui-même. Déclarez alors le champ en `account_link` plutôt qu'en `oauth2` :
+
+```json
+{ "key": "account", "type": "account_link", "label": { "en": "Link my account", "fr": "Lier mon compte" } }
+```
+
+L'écran de configuration affiche le même bouton « Connecter », et `onOAuthAuthorizeUrl` est appelé de la même façon — mais `redirectUri` vaut `undefined` (il n'y en a pas), aucun `state` anti-CSRF n'est nécessaire (il n'y a pas d'aller-retour à protéger), et `onOAuthCallback` n'est jamais appelé. Retournez l'URL de connexion du fournisseur, surveillez vous-même la validation (typiquement en interrogeant le fournisseur en long-polling), puis signalez-la via `setConnectionStatus(true)` : c'est ce qui pilote le badge de connexion affiché à l'utilisateur.
+
+```js
+gladys.onOAuthAuthorizeUrl(async () => {
+  const { loginUrl, ticket } = await startQrLogin();
+  waitForApproval(ticket).then(() => gladys.setConnectionStatus(true));
+  return loginUrl;
+});
+```
+
+Un champ `account_link` est interdit dans un `contact_schema` : lier un compte chez un fournisseur concerne l'intégration entière, jamais un utilisateur en particulier.
 
 ### Boutons d'action
 
@@ -325,6 +427,21 @@ const replies = await gladys.scanNetwork("udp-active-broadcast", {
   timeoutSeconds: 10,
 });
 ```
+
+### Wake-on-LAN
+
+*Nécessite Gladys 4.86.0 ou ultérieur.*
+
+Même problème de position réseau, côté émission : un magic packet est un broadcast UDP, qui ne franchit jamais le bridge vers le réseau local. Déclarez `"network_wake": true` dans votre manifeste (affiché sur l'écran d'installation, comme les autres contrats d'autorisation — un accès non déclaré reçoit un `403`) et demandez au cœur de l'émettre :
+
+```js
+await gladys.wakeOnLan("64:e4:d5:b4:12:66"); // les formats « : », « - » et sans séparateur sont acceptés
+
+// L'appareil ignore le broadcast limité ? Visez le broadcast du sous-réseau, ou changez le port :
+await gladys.wakeOnLan("64:e4:d5:b4:12:66", { address: "192.168.1.255", port: 9 });
+```
+
+Le cœur construit toujours lui-même le magic packet standard de 102 octets (6 × `0xFF` suivis de la MAC répétée 16 fois) : vous ne fournissez jamais la charge utile, et le point d'entrée n'est donc pas un proxy UDP générique. Il est limité à **un réveil toutes les 2 secondes** par intégration (`429` au-delà), ce qui suffit à la boucle habituelle « on réessaie jusqu'à ce que l'appareil réponde ». Un appel résolu signifie que le paquet a été **émis**, pas que l'appareil s'est réveillé : interrogez l'appareil pour le confirmer.
 
 ### Sous-conteneurs et matériel
 
@@ -557,8 +674,9 @@ Chaque intégration externe est décrite par un unique fichier nommé `gladys-as
   },
   "version": "1.0.0",
   "docker_image": "ghcr.io/yourname/my-integration:1.0.0",
-  "gladys_version": ">=4.84.0",
+  "gladys_version": ">=4.86.0",
   "cover_image": "https://raw.githubusercontent.com/yourname/my-integration/main/cover.jpg",
+  "categories": ["lighting", "energy"],
   "transports": ["local", "cloud"],
   "config_schema": [
     {
@@ -584,19 +702,41 @@ Chaque intégration externe est décrite par un unique fichier nommé `gladys-as
 | `docker_image` | Oui | Une référence d'image bien formée avec un tag ou un digest explicite. Elle doit exister et être téléchargeable de façon anonyme. |
 | `gladys_version` | Oui | Une plage semver (syntaxe npm) utilisée pour filtrer les instances compatibles. |
 | `cover_image` | Non | URL HTTPS directe vers une image de couverture (voir les règles ci-dessous). |
+| `categories` | Non | De 1 à 3 catégories de navigation du catalogue (voir ci-dessous). Nécessite une plage `gladys_version` qui démarre à `4.86.0`. |
 | `config_schema` | Non | La liste des champs de configuration affichés à l'utilisateur. |
 | `transports` | Non | Sous-ensemble non vide de `local` et `cloud`, si votre intégration est à double canal. |
 | `actions` | Non | De 1 à 10 boutons d'action, chacun avec une `key`, un `label` multilingue, un `timeout_seconds` (de 5 à 120) et des `fields` optionnels. |
 | `network_discovery` | Non | De 1 à 5 méthodes de capture médiée (`udp-broadcast`, `udp-active-broadcast`, `mdns`, `ssdp`). |
 | `containers` | Non | Jusqu'à 5 conteneurs compagnons, chacun avec `name`, `docker_image`, `start` (`auto` ou `manual`), et optionnellement `env`, `volumes`, `ports` (jusqu'à 3, chacun avec `container_port`, `protocol`, un `label` multilingue, un `name` optionnel et `browsable`), `devices` (`coral-usb`, `coral-pcie`, `gpu`, `video`), `read_only`, `command`, `memory_mb` (de 32 à 4096), `cpu` (de 0,1 à 2), `shm_mb` (de 64 à 512). |
 | `location` | Non | `true` demande l'accès aux coordonnées des maisons de l'utilisateur (`GET /house`). Affiché sur l'écran d'installation, appliqué côté serveur. |
+| `network_wake` | Non | `true` demande l'autorisation d'émettre des magic packets Wake-on-LAN via le cœur. Affiché sur l'écran d'installation, appliqué côté serveur. |
 | `messaging` | Obligatoire pour `communication` | `{ "receive": true }` pour un canal de chat bidirectionnel, `{ "receive": false }` pour un canal de notification en envoi seul. Interdit pour les autres types. |
 | `contact_schema` | Obligatoire quand `messaging.receive` vaut `false` | Les identifiants propres à chaque utilisateur d'un canal en envoi seul, même format de champs que `config_schema` (hors champs `oauth2`). Interdit sinon. |
 | `webhooks` | Non | Jusqu'à 3 webhooks entrants (Gladys Plus), chacun avec une `key`, un `label` multilingue, et un `mode` (`fire_and_forget` ou `sync`). |
 
+### Catégories du store
+
+*Nécessite Gladys 4.86.0 ou ultérieur.*
+
+Depuis Gladys 4.86, le catalogue se parcourt : une barre latérale de catégories, des filtres à facettes (native, communautaire, local, cloud, Gladys Plus) et un tri « Plus récentes ». Le champ `categories` est ce qui range votre intégration dans le bon rayon — un domaine d'usage, découplé du `type` technique du manifeste :
+
+```json
+"categories": ["lighting", "energy"],
+"gladys_version": ">=4.86.0"
+```
+
+Les règles :
+
+- **1 à 3 catégories**, parmi le vocabulaire officiel : `climate`, `lighting`, `energy`, `security`, `multimedia`, `appliances`, `environment`, `protocols`, `network`, `notifications`, `assistants`, `services`.
+- **`gladys_version` doit démarrer à `4.86.0`** dès que vous déclarez le champ. Les versions plus anciennes du cœur rejettent tout champ inconnu du manifeste, donc le validateur du store refuse un manifeste qui déclare `categories` avec un minimum plus bas — les deux vont ensemble.
+- Une clé inconnue est **ignorée avec un avertissement** plutôt que de rejeter le manifeste : une intégration publiée avec un vocabulaire plus récent que le Gladys qui tourne s'installe quand même.
+- Sans ce champ, votre intégration reste visible sous « Toutes » et dans la recherche, mais elle n'apparaît sur aucun rayon.
+
+Les intégrations publiées avant la 4.86 ont été catégorisées une première fois via un fichier de correspondance conservé dans le [dépôt du store](https://github.com/GladysAssistant/integration-store), mais **c'est votre manifeste qui fait foi** dès qu'il déclare le champ : c'est l'occasion de vérifier que les catégories attribuées vous conviennent, et de les ajuster si non.
+
 ### Le schéma de configuration
 
-`config_schema` est une liste plate de champs. Chaque champ a une `key` (en minuscules, correspondant à `[a-z0-9_]`), un `type`, et un `label` multilingue (avec `en` obligatoire). Les types pris en charge sont `string`, `number`, `boolean`, `select`, `multi_select`, `secret`, `oauth2` et `section`. Selon le type, un champ peut aussi déclarer `placeholder` (pour `string`/`number`/`secret`), `required`, `default`, `min`/`max` (pour les nombres) et `options` (pour `select`/`multi_select`).
+`config_schema` est une liste plate de champs. Chaque champ a une `key` (en minuscules, correspondant à `[a-z0-9_]`), un `type`, et un `label` multilingue (avec `en` obligatoire). Les types pris en charge sont `string`, `number`, `boolean`, `select`, `multi_select`, `secret`, `oauth2`, `account_link` et `section`. Selon le type, un champ peut aussi déclarer `placeholder` (pour `string`/`number`/`secret`), `required`, `default`, `min`/`max` (pour les nombres) et `options` (pour `select`/`multi_select`).
 
 Un `select` ou un `multi_select` peut soit lister des `options` statiques, soit tirer ses choix dynamiquement des appareils de l'utilisateur avec `source: "devices"`, et s'afficher en `dropdown` ou en `radio` (`display`). Un champ `section` est purement présentationnel : il affiche une `description` et jusqu'à cinq liens de documentation (`links`), et ne stocke aucune valeur.
 
@@ -703,6 +843,8 @@ npm start
 docker build -t ghcr.io/yourname/my-integration:1.0.0 .
 ```
 
+Depuis Gladys 4.86, le mode développeur installe cette image **directement depuis votre démon Docker local**, avec un manifeste optionnel et sans rien pousser sur un registre : construisez-la sur la machine qui fait tourner Gladys, puis installez le tag depuis le lien « Mode développeur : installer depuis une image Docker » du catalogue. C'est la façon la plus rapide de tester un vrai conteneur.
+
 **Ou construisez-la sur GitHub en un clic.** Si vous préférez ne pas construire en local (ou si vous n'avez pas de builder multi-architectures configuré), le template fournit aussi un workflow **Build** que vous pouvez lancer à la main : allez dans l'onglet **Actions**, sélectionnez **Build**, cliquez sur **Run workflow**, et définissez éventuellement un tag d'image (il prend par défaut le nom de votre branche). GitHub construit l'image multi-architectures (`linux/amd64` et `linux/arm64`) et la pousse sur `ghcr.io` sous ce tag, sans jamais toucher `:latest`. Vous pouvez ensuite installer ce tag précis dans votre instance Gladys pour tester une vraie image, sans Docker en local. C'est une image de test, pas une release : utilisez l'[Étape 5](#étape-5--publier-votre-intégration) quand vous êtes prêt à publier pour tout le monde.
 
 **Valider votre manifeste hors ligne** avec exactement les vérifications que fait l'indexeur du store, avant d'attendre le cycle horaire :
@@ -764,9 +906,9 @@ Le mainteneur ne valide rien et n'est jamais un goulot d'étranglement.
 
 ## Étape 6 : Les utilisateurs installent en un clic
 
-Depuis le catalogue de Gladys, les intégrations externes apparaissent aux côtés des intégrations intégrées, avec un **badge communautaire**, les badges local/cloud déduits de vos `transports`, et un indicateur de statut en direct. Un utilisateur clique sur **Installer**, et Gladys télécharge votre image, démarre le conteneur, et affiche l'interface générée. Les utilisateurs peuvent aussi installer directement depuis une URL de dépôt GitHub, sans attendre le prochain cycle d'indexation.
+Depuis le catalogue de Gladys, les intégrations externes apparaissent aux côtés des intégrations intégrées, avec un **badge communautaire**, les badges local/cloud déduits de vos `transports`, et un indicateur de statut en direct. Les utilisateurs parcourent le catalogue par catégorie (la vôtre vient du champ `categories` de votre manifeste), le filtrent, et le trient par nouveauté. Un utilisateur clique sur **Installer**, et Gladys télécharge votre image, démarre le conteneur, et affiche l'interface générée. Les utilisateurs peuvent aussi installer directement depuis une URL de dépôt GitHub, sans attendre le prochain cycle d'indexation.
 
-Avant l'installation, l'écran montre tout ce que votre manifeste a déclaré : votre documentation, les sous-conteneurs qui vont tourner et les ports qu'ils vont exposer, le matériel que vous demandez, les captures réseau, les webhooks, et l'accès aux coordonnées des maisons. Ne déclarez que ce dont vous vous servez réellement : chaque ligne est une question à laquelle l'utilisateur doit répondre avant de vous faire confiance.
+Avant l'installation, l'écran montre tout ce que votre manifeste a déclaré : votre documentation, les sous-conteneurs qui vont tourner et les ports qu'ils vont exposer, le matériel que vous demandez, les captures réseau, l'autorisation Wake-on-LAN, les webhooks, et l'accès aux coordonnées des maisons. Ne déclarez que ce dont vous vous servez réellement : chaque ligne est une question à laquelle l'utilisateur doit répondre avant de vous faire confiance.
 
 ## Mettre à jour votre intégration
 
@@ -774,11 +916,13 @@ Livrer une nouvelle version tient en un clic : relancez le workflow **Release** 
 
 Si vous publiez manuellement, faites les deux mêmes choses à la main : construisez et poussez un nouveau tag d'image (par exemple `ghcr.io/yourname/my-integration:1.1.0`), puis incrémentez `version` et `docker_image` dans le manifeste et poussez.
 
+Suivre une nouvelle version de Gladys est un exercice tout aussi court : passez `@gladysassistant/integration-sdk` à la version suivante (les versions du SDK sont additives, le code existant continue de fonctionner), déclarez les champs de manifeste dont les nouvelles capacités ont besoin, relevez la plage `gladys_version` en conséquence, validez avec `npx github:GladysAssistant/integration-store .`, et publiez. Pour la 4.86, cela veut dire `^0.12.0`, un champ `categories`, et `">=4.86.0"`.
+
 ## Dépannage
 
 Installer votre intégration depuis l'URL de son dépôt (ou en mode développeur) affiche les **erreurs de validation détaillées** de votre manifeste, champ par champ, pour les corriger sans attendre le prochain cycle d'indexation.
 
-L'indexeur est totalement transparent. Si votre intégration n'apparaît pas dans le catalogue, consultez le fichier `rejected.json` publié : il liste chaque dépôt qui a échoué à la validation, avec la raison et un niveau de sévérité (manifeste invalide, référence d'image mal formée ou non téléchargeable, plage `gladys_version` incompatible, couverture trop lourde ou aux mauvaises dimensions, `docs/en.md` ou `docs/fr.md` manquant, etc.). Vous pouvez détecter la plupart de ces problèmes avant de publier en lançant `npx github:GladysAssistant/integration-store .` en local. Corrigez le problème, republiez, et attendez le prochain cycle.
+L'indexeur est totalement transparent. Si votre intégration n'apparaît pas dans le catalogue, consultez le fichier `rejected.json` publié : il liste chaque dépôt qui a échoué à la validation, avec la raison et un niveau de sévérité (manifeste invalide, référence d'image mal formée ou non téléchargeable, plage `gladys_version` incompatible, `categories` déclaré avec un minimum `gladys_version` inférieur à 4.86.0, couverture trop lourde ou aux mauvaises dimensions, `docs/en.md` ou `docs/fr.md` manquant, etc.). Les avertissements méritent aussi une lecture : une clé de catégorie inconnue est ignorée, et une intégration qui n'en déclare aucune est indexée sans catégorie. Vous pouvez détecter la plupart de ces problèmes avant de publier en lançant `npx github:GladysAssistant/integration-store .` en local. Corrigez le problème, republiez, et attendez le prochain cycle.
 
 ## Modèle de sécurité
 


### PR DESCRIPTION
The external integrations tutorial still described Gladys 4.85 and SDK 0.11.0. This updates both the English and the French page for 4.86 / SDK 0.12.0, following the [forum announcement](``https://community.gladysassistant.com/t/developpeurs-dintegrations-mettez-a-jour-pour-gladys-4-86-sdk-0-12-0-categories-du-store/10556).``

## What changed

- **"New in Gladys 4.86 (SDK 0.12.0)" tip block** replaces the 4.85 one, with a short migration reminder (bump to `^0.12.0`, declare `categories`, move `gladys_version` to `">=4.86.0"`).
- **New section "Store categories"**: the `categories` manifest field, the controlled vocabulary (`climate`, `lighting`, `energy`, `security`, `multimedia`, `appliances`, `environment`, `protocols`, `network`, `notifications`, `assistants`, `services`), the 1-to-3 rule, the `gladys_version >= 4.86.0` requirement, the drop-with-a-warning behavior for unknown keys, and the fallback mapping the manifest overrides.
- **New subsection "Motorized (PTZ) cameras"**: `CAMERA.MOVE` with its `supported_options`, `CAMERA.PRESET`, the optional absolute position features, and the watchdog rule for continuous movements.
- **New section "Wake-on-LAN"**: `gladys.wakeOnLan(mac, options?)`, the `network_wake` authorization contract, the fixed magic packet built by the core, and the 1-per-2-seconds rate limit.
- **New subsection "Account linking without a redirect"**: the `account_link` config field for providers that never redirect back (QR sign-in approved in the vendor app), and how `onOAuthAuthorizeUrl` behaves there.
- **New section "Choice lists discovered on the device"**: the `text`/`select` feature type with per-device `supported_options`.
- **Manifest reference**: `categories` and `network_wake` rows added, `account_link` added to the config schema types, the example manifest now declares `categories` and `">=4.86.0"`.
- **SDK constants paragraph** updated (grid sensor, home output sensor, maintenance, NO₂/O₃/SO₂, PTZ) and the current SDK version moved to `0.12.0`; `scanNetwork` and `wakeOnLan` listed in the API summary.
- **Step 4** mentions installing a locally built Docker image through developer mode; **Step 6**, the prerequisites, the troubleshooting section and the "Updating your integration" section were adjusted accordingly.

## Test plan

- `yarn install --frozen-lockfile` then `npx docusaurus build`: builds both locales successfully, no broken link or anchor warning (the only warning is a pre-existing HTML-minifier diagnostic on `/fr/starter-kit/`).
- All the new anchors verified in the generated HTML for both locales (`store-categories`, `motorized-ptz-cameras`, `wake-on-lan`, `account-linking-without-a-redirect`, `choice-lists-discovered-on-the-device` and their French counterparts).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTX1rBZdvee7yER1XxjnFB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the external integrations guide for Gladys 4.86 and SDK 0.12.0.
  * Documented store categories, PTZ cameras, Wake-on-LAN, account linking, dynamic choice lists, and new device feature categories.
  * Added guidance for installing integrations from local Docker images.
  * Updated manifest requirements, permissions, configuration schemas, catalog behavior, and upgrade instructions in English and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->