### PR TITLE
fix(dev): survive the GitHub API rate limit when building the dev activity snapshot

### DIFF
--- a/.github/workflows/refresh-external-integrations.yml
+++ b/.github/workflows/refresh-external-integrations.yml
@@ -26,6 +26,8 @@ jobs:
       # A pull request opened with GITHUB_TOKEN does not trigger the CI
       # workflow, so the build runs here instead.
       - run: ./build.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: peter-evans/create-pull-request@v7
         with:
           branch: chore/refresh-external-integrations

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,9 @@ jobs:
         with:
           node-version: "22"
       - run: yarn install --frozen-lockfile
+      # The /dev/ page snapshot is refreshed by build.sh: the automatic token
+      # gives it 5000 requests/hour instead of the 60 shared by every anonymous
+      # build running on this runner.
       - run: ./build.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -62,9 +62,15 @@ sending conditional requests: each answer is stored with its `ETag` and the
 
 To refresh reliably, give the build a token: create a fine-grained personal
 access token with read-only public access (no scope needed) and add it as a
-`GITHUB_TOKEN` environment variable on the Cloudflare Pages project
-(Settings > Environment variables). That raises the budget to 5000 requests
-per hour. Locally, a `GITHUB_TOKEN` in `.env` does the same.
+`DEV_ACTIVITY_GITHUB_TOKEN` environment variable on the Cloudflare Pages
+project (Settings > Environment variables). That raises the budget to 5000
+requests per hour. Locally, the same variable in `.env` does the same.
+
+The name is deliberately specific: `GITHUB_TOKEN` is read by a lot of tooling
+(and is the name GitHub Actions gives its own automatic token), so a variable
+set for this script alone should not be handed to everything else running in
+the build. `GITHUB_TOKEN` is still accepted as a fallback, which is what the
+workflows use when they pass `secrets.GITHUB_TOKEN`.
 
 ## How to add new integrations ?
 

--- a/README.md
+++ b/README.md
@@ -40,15 +40,31 @@ requests on the forum.
 
 Nothing to do by hand: `build.sh` regenerates it on every deploy, and the
 `refresh-dev-activity` workflow asks Cloudflare Pages for a daily rebuild so
-the page keeps moving even on quiet days. If GitHub or the forum is
-unreachable during a build, the version committed in the repository is used
-instead.
+the page keeps moving even on quiet days. Whatever cannot be downloaded during
+a build (GitHub unreachable, rate limit reached, forum down) simply keeps the
+values committed in the repository, section by section, so a refresh never
+fails the deploy.
 
 To regenerate it locally:
 
 ```bash
 yarn load-dev-activity
 ```
+
+### About the GitHub rate limit
+
+Without a token, GitHub allows 60 requests per hour and *per IP*. Cloudflare
+Pages builds run on shared IPs, so that budget is often already spent by
+someone else and the GitHub half of the snapshot stops refreshing (the build
+logs then show `403 rate limit exceeded`). The script limits the damage by
+sending conditional requests: each answer is stored with its `ETag` and the
+`304 Not Modified` replies do not count against the limit.
+
+To refresh reliably, give the build a token: create a fine-grained personal
+access token with read-only public access (no scope needed) and add it as a
+`GITHUB_TOKEN` environment variable on the Cloudflare Pages project
+(Settings > Environment variables). That raises the budget to 5000 requests
+per hour. Locally, a `GITHUB_TOKEN` in `.env` does the same.
 
 ## How to add new integrations ?
 

--- a/build.sh
+++ b/build.sh
@@ -4,8 +4,9 @@ set -e
 # Cleaning build folder
 rm -rf build
 
-# Refreshing the /dev/ page data. Never fails the build: if GitHub or the forum
-# is unreachable, the snapshot committed in src/data/devActivity.json is used.
+# Refreshing the /dev/ page data. The script already falls back on the snapshot
+# committed in src/data/devActivity.json, section by section, when GitHub or the
+# forum cannot be reached; this only guards against it failing outright.
 npm run load-dev-activity || echo ">> Keeping the committed dev activity snapshot"
 
 # Building website

--- a/scripts/load_dev_activity.js
+++ b/scripts/load_dev_activity.js
@@ -7,9 +7,10 @@
  * limit) and it is the only source for the forum feature requests, which
  * Discourse does not serve cross-origin.
  *
- * The deploy build runs without a GITHUB_TOKEN, on a shared Cloudflare Pages
- * IP, so the anonymous 60 requests/hour budget is often already spent by
- * someone else. Two things keep that from wiping the page data:
+ * The deploy build runs without a token (see DEV_ACTIVITY_GITHUB_TOKEN below),
+ * on a shared Cloudflare Pages IP, so the anonymous 60 requests/hour budget is
+ * often already spent by someone else. Two things keep that from wiping the
+ * page data:
  *
  *   - conditional requests: each answer is stored with its ETag and re-sent as
  *     `If-None-Match`, and GitHub does not count the 304 answers against the
@@ -20,8 +21,8 @@
  * Run with `yarn load-dev-activity`. Refreshed daily by the
  * `refresh-dev-activity` workflow.
  */
-// Only useful to read a local GITHUB_TOKEN from .env, and this script runs
-// during the deploy build, where a missing dev dependency must not break it.
+// Only useful to read a local token from .env, and this script runs during the
+// deploy build, where a missing dev dependency must not break it.
 try {
   require("dotenv").config();
 } catch (error) {
@@ -61,6 +62,13 @@ const REQUEST_TIMEOUT_MS = 20000;
 // than parking the deploy build.
 const MAX_RATE_LIMIT_WAIT_MS = 30000;
 
+// DEV_ACTIVITY_GITHUB_TOKEN is the name to set on the deploy environment:
+// GITHUB_TOKEN is generic enough that half the tooling of a build reads it (and
+// GitHub Actions gives that name to its own automatic token), so a token meant
+// for this script alone deserves its own name. GITHUB_TOKEN is still accepted
+// as a fallback, which is what a workflow passing `secrets.GITHUB_TOKEN` uses.
+const gitHubToken = process.env.DEV_ACTIVITY_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+
 // Returned instead of a payload when GitHub answers 304 Not Modified.
 const NOT_MODIFIED = Symbol("not modified");
 
@@ -78,7 +86,7 @@ class RateLimitError extends Error {
       : "no reset date given";
     super(
       `GitHub rate limit reached on ${url} (${when}). ` +
-        "Set a GITHUB_TOKEN to lift the anonymous 60 requests/hour limit."
+        "Set DEV_ACTIVITY_GITHUB_TOKEN to lift the anonymous 60 requests/hour limit."
     );
     this.name = "RateLimitError";
   }
@@ -123,11 +131,10 @@ async function getJson(url, { retryOn202 = false, conditional = false } = {}) {
   if (isGitHub) {
     headers["X-GitHub-Api-Version"] = "2022-11-28";
   }
-  // Optional: lifts the 60 requests/hour anonymous limit. The workflow passes
-  // the automatic GITHUB_TOKEN, a local run works fine without one. Only ever
-  // sent to the GitHub API, never to the forum.
-  if (isGitHub && process.env.GITHUB_TOKEN) {
-    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  // Optional: lifts the 60 requests/hour anonymous limit, a local run works
+  // fine without one. Only ever sent to the GitHub API, never to the forum.
+  if (isGitHub && gitHubToken) {
+    headers.Authorization = `Bearer ${gitHubToken}`;
   }
   // A 304 answer does not count against the rate limit, which is the whole
   // point: an unchanged repository makes the refresh free.

--- a/scripts/load_dev_activity.js
+++ b/scripts/load_dev_activity.js
@@ -7,6 +7,16 @@
  * limit) and it is the only source for the forum feature requests, which
  * Discourse does not serve cross-origin.
  *
+ * The deploy build runs without a GITHUB_TOKEN, on a shared Cloudflare Pages
+ * IP, so the anonymous 60 requests/hour budget is often already spent by
+ * someone else. Two things keep that from wiping the page data:
+ *
+ *   - conditional requests: each answer is stored with its ETag and re-sent as
+ *     `If-None-Match`, and GitHub does not count the 304 answers against the
+ *     rate limit, so an unchanged repository costs nothing;
+ *   - per section fallback: whatever cannot be downloaded keeps the values
+ *     committed in the snapshot instead of failing the whole refresh.
+ *
  * Run with `yarn load-dev-activity`. Refreshed daily by the
  * `refresh-dev-activity` workflow.
  */
@@ -31,6 +41,11 @@ const FORUM_ACCEPTED_PATH = "/tags/c/feature-requests/43/accepted/184.json";
 
 const OUTPUT_FILE = path.join(__dirname, "..", "src", "data", "devActivity.json");
 
+// Bump this whenever the shape of the snapshot or the way a payload is parsed
+// below changes: it throws away the stored ETags, which would otherwise keep
+// serving data built by the previous version of this script.
+const SNAPSHOT_VERSION = 1;
+
 const MAX_RELEASES = 12;
 const MAX_OPEN_PULL_REQUESTS = 15;
 const MAX_MERGED_PULL_REQUESTS = 12;
@@ -41,18 +56,84 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const MAX_ATTEMPTS = 6;
 const REQUEST_TIMEOUT_MS = 20000;
+// A rate limit resets on the hour, so waiting it out is only worth it when it
+// is seconds away. Anything longer falls back on the committed snapshot rather
+// than parking the deploy build.
+const MAX_RATE_LIMIT_WAIT_MS = 30000;
 
-async function getJson(url, { retryOn202 = false } = {}) {
+// Returned instead of a payload when GitHub answers 304 Not Modified.
+const NOT_MODIFIED = Symbol("not modified");
+
+// ETag per URL, read from the committed snapshot and written back to it. An
+// entry means "the values committed for this URL are what it last answered",
+// so it is only kept once the section it belongs to parsed fine: `stagedEtags`
+// holds the ETags of the section being loaded until then.
+const etags = new Map();
+const stagedEtags = new Map();
+
+class RateLimitError extends Error {
+  constructor(url, delayMs) {
+    const when = Number.isFinite(delayMs)
+      ? `it resets in about ${Math.max(1, Math.round(delayMs / 60000))} min`
+      : "no reset date given";
+    super(
+      `GitHub rate limit reached on ${url} (${when}). ` +
+        "Set a GITHUB_TOKEN to lift the anonymous 60 requests/hour limit."
+    );
+    this.name = "RateLimitError";
+  }
+}
+
+// Once the budget is spent every other GitHub call would fail the same way, so
+// the first one to hit it makes the rest give up immediately.
+let gitHubRateLimit = null;
+
+// Returns how long to wait when a response was refused for rate limiting, or
+// null when it was refused for another reason. GitHub answers 403 or 429 with
+// `retry-after` on the secondary limit, and with `x-ratelimit-remaining: 0`
+// plus a `x-ratelimit-reset` timestamp on the primary one.
+function rateLimitDelay(response) {
+  if (response.status !== 403 && response.status !== 429) {
+    return null;
+  }
+  const retryAfter = Number(response.headers.get("retry-after"));
+  if (Number.isFinite(retryAfter) && retryAfter > 0) {
+    return retryAfter * 1000;
+  }
+  if (response.headers.get("x-ratelimit-remaining") !== "0") {
+    return null;
+  }
+  const reset = Number(response.headers.get("x-ratelimit-reset"));
+  if (!Number.isFinite(reset) || reset <= 0) {
+    return Infinity;
+  }
+  return Math.max(0, reset * 1000 - Date.now());
+}
+
+async function getJson(url, { retryOn202 = false, conditional = false } = {}) {
   const isGitHub = url.startsWith(GITHUB_API);
+  if (isGitHub && gitHubRateLimit) {
+    throw gitHubRateLimit;
+  }
+
   const headers = {
     Accept: isGitHub ? "application/vnd.github+json" : "application/json",
     "User-Agent": "gladysassistant-website",
   };
+  if (isGitHub) {
+    headers["X-GitHub-Api-Version"] = "2022-11-28";
+  }
   // Optional: lifts the 60 requests/hour anonymous limit. The workflow passes
   // the automatic GITHUB_TOKEN, a local run works fine without one. Only ever
   // sent to the GitHub API, never to the forum.
   if (isGitHub && process.env.GITHUB_TOKEN) {
     headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  // A 304 answer does not count against the rate limit, which is the whole
+  // point: an unchanged repository makes the refresh free.
+  const knownEtag = conditional ? etags.get(url) : undefined;
+  if (knownEtag) {
+    headers["If-None-Match"] = knownEtag;
   }
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
@@ -60,11 +141,27 @@ async function getJson(url, { retryOn202 = false } = {}) {
       headers,
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
+    if (response.status === 304) {
+      return NOT_MODIFIED;
+    }
     // The statistics endpoints answer 202 while GitHub computes the cache.
     if (response.status === 202 && retryOn202) {
       console.log(`   202 from ${url}, waiting for GitHub to compute it...`);
       await sleep(3000);
       continue;
+    }
+    const rateLimited = rateLimitDelay(response);
+    if (rateLimited !== null) {
+      if (rateLimited <= MAX_RATE_LIMIT_WAIT_MS && attempt < MAX_ATTEMPTS - 1) {
+        console.log(`   rate limited on ${url}, retrying in ${Math.round(rateLimited / 1000)}s...`);
+        await sleep(rateLimited + 1000);
+        continue;
+      }
+      const error = new RateLimitError(url, rateLimited);
+      if (isGitHub) {
+        gitHubRateLimit = error;
+      }
+      throw error;
     }
     // A single 502 from GitHub should not fail the daily refresh.
     if (response.status >= 500 && attempt < MAX_ATTEMPTS - 1) {
@@ -74,6 +171,10 @@ async function getJson(url, { retryOn202 = false } = {}) {
     }
     if (!response.ok) {
       throw new Error(`${response.status} ${response.statusText} on ${url}`);
+    }
+    const etag = response.headers.get("etag");
+    if (conditional && etag) {
+      stagedEtags.set(url, etag);
     }
     return response.json();
   }
@@ -119,23 +220,33 @@ function parseReleaseBody(body) {
 }
 
 async function getRepository() {
-  console.log(">> Downloading repository metadata");
-  const repository = await getJson(GITHUB_API);
+  const repository = await getJson(GITHUB_API, { conditional: true });
+  if (repository === NOT_MODIFIED) {
+    return NOT_MODIFIED;
+  }
   return {
-    stars: repository.stargazers_count,
-    forks: repository.forks_count,
-    openIssues: repository.open_issues_count,
-    watchers: repository.subscribers_count,
-    createdAt: repository.created_at,
-    pushedAt: repository.pushed_at,
+    repository: {
+      owner: GITHUB_OWNER,
+      name: GITHUB_REPO,
+      url: `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`,
+      stars: repository.stargazers_count,
+      forks: repository.forks_count,
+      openIssues: repository.open_issues_count,
+      watchers: repository.subscribers_count,
+      createdAt: repository.created_at,
+      pushedAt: repository.pushed_at,
+    },
   };
 }
 
 async function getWeeks() {
-  console.log(">> Downloading the last 52 weeks of commit activity");
   const weeks = await getJson(`${GITHUB_API}/stats/commit_activity`, {
     retryOn202: true,
+    conditional: true,
   });
+  if (weeks === NOT_MODIFIED) {
+    return NOT_MODIFIED;
+  }
   // GitHub answers 202 with an empty body while it builds the statistics
   // cache; fail with something readable rather than a map() stack trace.
   if (!Array.isArray(weeks)) {
@@ -143,32 +254,40 @@ async function getWeeks() {
   }
   // Compact keys: this file lands in git, and 52 weeks of verbose objects make
   // for a needlessly noisy diff.
-  return weeks.map((week) => ({
-    w: week.week,
-    t: week.total,
-    d: week.days,
-  }));
+  return {
+    weeks: weeks.map((week) => ({
+      w: week.week,
+      t: week.total,
+      d: week.days,
+    })),
+  };
 }
 
 async function getReleases() {
-  console.log(">> Downloading releases");
-  const releases = await getJson(`${GITHUB_API}/releases?per_page=30`);
-  return releases
-    .filter((release) => !release.draft)
-    .slice(0, MAX_RELEASES)
-    .map((release) => {
-      const { changes, authors, highlights } = parseReleaseBody(release.body);
-      return {
-        tag: release.tag_name,
-        name: release.name || release.tag_name,
-        url: release.html_url,
-        publishedAt: release.published_at,
-        prerelease: release.prerelease,
-        changes,
-        authors,
-        highlights,
-      };
-    });
+  const releases = await getJson(`${GITHUB_API}/releases?per_page=30`, {
+    conditional: true,
+  });
+  if (releases === NOT_MODIFIED) {
+    return NOT_MODIFIED;
+  }
+  return {
+    releases: releases
+      .filter((release) => !release.draft)
+      .slice(0, MAX_RELEASES)
+      .map((release) => {
+        const { changes, authors, highlights } = parseReleaseBody(release.body);
+        return {
+          tag: release.tag_name,
+          name: release.name || release.tag_name,
+          url: release.html_url,
+          publishedAt: release.published_at,
+          prerelease: release.prerelease,
+          changes,
+          authors,
+          highlights,
+        };
+      }),
+  };
 }
 
 function mapPullRequest(pullRequest) {
@@ -186,10 +305,13 @@ function mapPullRequest(pullRequest) {
 }
 
 async function getOpenPullRequests() {
-  console.log(">> Downloading open pull requests");
   const pullRequests = await getJson(
-    `${GITHUB_API}/pulls?state=open&per_page=100&sort=updated&direction=desc`
+    `${GITHUB_API}/pulls?state=open&per_page=100&sort=updated&direction=desc`,
+    { conditional: true }
   );
+  if (pullRequests === NOT_MODIFIED) {
+    return NOT_MODIFIED;
+  }
   const openPullRequests = pullRequests
     .filter((pullRequest) => !pullRequest.draft)
     .map(mapPullRequest);
@@ -201,20 +323,29 @@ async function getOpenPullRequests() {
 }
 
 async function getMergedPullRequests() {
-  console.log(">> Downloading recently merged pull requests");
   const pullRequests = await getJson(
-    `${GITHUB_API}/pulls?state=closed&per_page=100&sort=updated&direction=desc`
+    `${GITHUB_API}/pulls?state=closed&per_page=100&sort=updated&direction=desc`,
+    { conditional: true }
   );
-  return pullRequests
-    .filter((pullRequest) => pullRequest.merged_at)
-    .map(mapPullRequest)
-    .sort((a, b) => new Date(b.mergedAt) - new Date(a.mergedAt))
-    .slice(0, MAX_MERGED_PULL_REQUESTS);
+  if (pullRequests === NOT_MODIFIED) {
+    return NOT_MODIFIED;
+  }
+  return {
+    mergedPullRequests: pullRequests
+      .filter((pullRequest) => pullRequest.merged_at)
+      .map(mapPullRequest)
+      .sort((a, b) => new Date(b.mergedAt) - new Date(a.mergedAt))
+      .slice(0, MAX_MERGED_PULL_REQUESTS),
+  };
 }
 
 async function getContributors() {
-  console.log(">> Downloading contributors");
-  const contributors = await getJson(`${GITHUB_API}/contributors?per_page=100`);
+  const contributors = await getJson(`${GITHUB_API}/contributors?per_page=100`, {
+    conditional: true,
+  });
+  if (contributors === NOT_MODIFIED) {
+    return NOT_MODIFIED;
+  }
   return {
     contributorsCount: contributors.length,
     contributors: contributors.slice(0, MAX_CONTRIBUTORS).map((contributor) => ({
@@ -227,7 +358,6 @@ async function getContributors() {
 }
 
 async function getForumRequests() {
-  console.log(">> Downloading accepted feature requests from the forum");
   const topics = [];
   const users = new Map();
 
@@ -235,6 +365,8 @@ async function getForumRequests() {
   // room to grow.
   for (let page = 0; page < 2; page += 1) {
     const url = `${FORUM_URL}${FORUM_ACCEPTED_PATH}${page > 0 ? `?page=${page}` : ""}`;
+    // No conditional request here: a section made of several calls could not
+    // rebuild itself from a mix of 304 and 200 answers.
     const data = await getJson(url);
     (data.users || []).forEach((user) => users.set(user.id, user));
     const pageTopics = data.topic_list?.topics || [];
@@ -245,80 +377,150 @@ async function getForumRequests() {
   }
 
   const seen = new Set();
-  return topics
-    .filter((topic) => {
-      if (seen.has(topic.id)) {
-        return false;
-      }
-      seen.add(topic.id);
-      return true;
-    })
-    .slice(0, MAX_FORUM_REQUESTS)
-    .map((topic) => {
-      const posterId = topic.posters?.[0]?.user_id;
-      const author = posterId != null ? users.get(posterId) : null;
-      return {
-        id: topic.id,
-        // Not fancy_title: Discourse HTML-encodes it ("l&rsquo;énergie") and
-        // React would render the entity as-is.
-        title: topic.title,
-        url: `${FORUM_URL}/t/${topic.slug}/${topic.id}`,
-        views: topic.views,
-        replies: topic.posts_count > 0 ? topic.posts_count - 1 : 0,
-        likes: topic.like_count,
-        createdAt: topic.created_at,
-        bumpedAt: topic.bumped_at,
-        author: author ? author.username : null,
-        // The "accepted" tag is on every topic here, so it carries no signal.
-        tags: (topic.tags || [])
-          .filter((tag) => tag.name !== "accepted")
-          .map((tag) => tag.name),
-      };
-    });
+  return {
+    forumRequests: topics
+      .filter((topic) => {
+        if (seen.has(topic.id)) {
+          return false;
+        }
+        seen.add(topic.id);
+        return true;
+      })
+      .slice(0, MAX_FORUM_REQUESTS)
+      .map((topic) => {
+        const posterId = topic.posters?.[0]?.user_id;
+        const author = posterId != null ? users.get(posterId) : null;
+        return {
+          id: topic.id,
+          // Not fancy_title: Discourse HTML-encodes it ("l&rsquo;énergie") and
+          // React would render the entity as-is.
+          title: topic.title,
+          url: `${FORUM_URL}/t/${topic.slug}/${topic.id}`,
+          views: topic.views,
+          replies: topic.posts_count > 0 ? topic.posts_count - 1 : 0,
+          likes: topic.like_count,
+          createdAt: topic.created_at,
+          bumpedAt: topic.bumped_at,
+          author: author ? author.username : null,
+          // The "accepted" tag is on every topic here, so it carries no signal.
+          tags: (topic.tags || [])
+            .filter((tag) => tag.name !== "accepted")
+            .map((tag) => tag.name),
+        };
+      }),
+  };
+}
+
+// Each section is one part of the snapshot: the keys it owns in the output
+// file, and the loader downloading them. A section either refreshes entirely
+// or keeps the values already committed.
+const GITHUB_SECTIONS = [
+  { name: "repository metadata", keys: ["repository"], load: getRepository },
+  { name: "commit activity", keys: ["weeks"], load: getWeeks },
+  { name: "releases", keys: ["releases"], load: getReleases },
+  {
+    name: "open pull requests",
+    keys: ["openPullRequestsCount", "openPullRequests"],
+    load: getOpenPullRequests,
+  },
+  { name: "merged pull requests", keys: ["mergedPullRequests"], load: getMergedPullRequests },
+  { name: "contributors", keys: ["contributorsCount", "contributors"], load: getContributors },
+];
+
+const FORUM_SECTION = {
+  name: "accepted feature requests",
+  keys: ["forumRequests"],
+  load: getForumRequests,
+};
+
+// The GitHub sections come first and are loaded one after the other: they share
+// one rate limit budget, and the first call to exhaust it saves the following
+// ones the round trip.
+const SECTIONS = [...GITHUB_SECTIONS, FORUM_SECTION];
+
+// Every key of the snapshot holding data, in the order the sections build them.
+const DATA_KEYS = SECTIONS.flatMap((section) => section.keys);
+
+function readCommittedSnapshot() {
+  try {
+    const snapshot = JSON.parse(fs.readFileSync(OUTPUT_FILE, "utf8"));
+    // Written by an older version of this script: the values are still usable
+    // as a fallback, but its ETags would freeze the data in the old shape.
+    if (snapshot.snapshotVersion === SNAPSHOT_VERSION) {
+      Object.entries(snapshot.etags || {}).forEach(([url, etag]) => etags.set(url, etag));
+    }
+    return snapshot;
+  } catch (error) {
+    console.log(`>> No usable snapshot committed yet (${error.message})`);
+    return {};
+  }
+}
+
+const committedSnapshot = readCommittedSnapshot();
+
+function committedValues(section) {
+  const missing = section.keys.filter((key) => committedSnapshot[key] === undefined);
+  if (missing.length > 0) {
+    throw new Error(
+      `Nothing to fall back on for the ${section.name}: ${missing.join(", ")} ` +
+        "missing from the committed snapshot"
+    );
+  }
+  console.log(`   keeping the committed ${section.name}`);
+  return Object.fromEntries(section.keys.map((key) => [key, committedSnapshot[key]]));
+}
+
+async function loadSection(section) {
+  console.log(`>> Downloading the ${section.name}`);
+  stagedEtags.clear();
+  try {
+    const values = await section.load();
+    if (values !== NOT_MODIFIED) {
+      stagedEtags.forEach((etag, url) => etags.set(url, etag));
+      return values;
+    }
+    console.log("   unchanged upstream");
+  } catch (error) {
+    console.log(`   ${error.message}`);
+  }
+  return committedValues(section);
 }
 
 async function main() {
-  const [
-    repository,
-    weeks,
-    releases,
-    { openPullRequestsCount, openPullRequests },
-    mergedPullRequests,
-    { contributorsCount, contributors },
-    forumRequests,
-  ] = await Promise.all([
-    getRepository(),
-    getWeeks(),
-    getReleases(),
-    getOpenPullRequests(),
-    getMergedPullRequests(),
-    getContributors(),
-    getForumRequests(),
-  ]);
+  const data = {};
+  for (const section of SECTIONS) {
+    Object.assign(data, await loadSection(section));
+  }
+
+  // The /dev/ page shows this as "last updated", so it has to date the data
+  // rather than the build: a refresh where everything was kept from the
+  // committed snapshot did not make the numbers any fresher.
+  const dataChanged = DATA_KEYS.some(
+    (key) => JSON.stringify(data[key]) !== JSON.stringify(committedSnapshot[key])
+  );
+  const generatedAt =
+    dataChanged || !committedSnapshot.generatedAt
+      ? new Date().toISOString()
+      : committedSnapshot.generatedAt;
+  if (!dataChanged) {
+    console.log(">> Nothing changed since the committed snapshot");
+  }
 
   const snapshot = {
-    generatedAt: new Date().toISOString(),
-    repository: {
-      owner: GITHUB_OWNER,
-      name: GITHUB_REPO,
-      url: `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`,
-      ...repository,
-    },
-    weeks,
-    releases,
-    openPullRequestsCount,
-    openPullRequests,
-    mergedPullRequests,
-    contributorsCount,
-    contributors,
-    forumRequests,
+    generatedAt,
+    ...data,
+    snapshotVersion: SNAPSHOT_VERSION,
+    // Sorted so the file stays diff-friendly.
+    etags: Object.fromEntries([...etags.entries()].sort(([a], [b]) => a.localeCompare(b))),
   };
 
   fs.writeFileSync(OUTPUT_FILE, `${JSON.stringify(snapshot, null, 2)}\n`);
   console.log(
-    `>> Wrote ${path.relative(process.cwd(), OUTPUT_FILE)}: ${weeks.length} weeks, ` +
-      `${releases.length} releases, ${openPullRequests.length}/${openPullRequestsCount} open PRs, ` +
-      `${mergedPullRequests.length} merged PRs, ${forumRequests.length} feature requests`
+    `>> Wrote ${path.relative(process.cwd(), OUTPUT_FILE)}: ${snapshot.weeks.length} weeks, ` +
+      `${snapshot.releases.length} releases, ` +
+      `${snapshot.openPullRequests.length}/${snapshot.openPullRequestsCount} open PRs, ` +
+      `${snapshot.mergedPullRequests.length} merged PRs, ` +
+      `${snapshot.forumRequests.length} feature requests`
   );
 }
 

--- a/src/data/devActivity.json
+++ b/src/data/devActivity.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-24T04:36:47.835Z",
+  "generatedAt": "2026-08-27T16:22:41.912Z",
   "repository": {
     "owner": "GladysAssistant",
     "name": "Gladys",
@@ -1431,7 +1431,7 @@
       "id": 9447,
       "title": "[Scène] Supprimer bloc 1 si vide",
       "url": "https://community.gladysassistant.com/t/scene-supprimer-bloc-1-si-vide/9447",
-      "views": 80,
+      "views": 81,
       "replies": 8,
       "likes": 2,
       "createdAt": "2025-03-22T08:44:29.764Z",
@@ -1479,7 +1479,7 @@
       "id": 10521,
       "title": "Intégration externe : Le suivi de l'énergie devrait être géré automatiquement comme pour Zigbee2mqtt",
       "url": "https://community.gladysassistant.com/t/integration-externe-le-suivi-de-lenergie-devrait-etre-gere-automatiquement-comme-pour-zigbee2mqtt/10521",
-      "views": 35,
+      "views": 36,
       "replies": 6,
       "likes": 1,
       "createdAt": "2026-08-10T17:34:51.108Z",
@@ -1517,7 +1517,7 @@
       "id": 10095,
       "title": "Gestion du capteur de fuite d’eau Ikea dans l’intégration Matter",
       "url": "https://community.gladysassistant.com/t/gestion-du-capteur-de-fuite-d-eau-ikea-dans-l-integration-matter/10095",
-      "views": 35,
+      "views": 36,
       "replies": 0,
       "likes": 0,
       "createdAt": "2026-03-05T08:32:58.541Z",
@@ -1531,7 +1531,7 @@
       "id": 9925,
       "title": "Amélioration de déclencheur : changement d'état d'appareil avec ... TOUT ou RIEN",
       "url": "https://community.gladysassistant.com/t/amelioration-de-declencheur-changement-detat-dappareil-avec-tout-ou-rien/9925",
-      "views": 73,
+      "views": 74,
       "replies": 2,
       "likes": 0,
       "createdAt": "2026-01-18T19:29:00.817Z",
@@ -1556,5 +1556,7 @@
         "feature-request-ux"
       ]
     }
-  ]
+  ],
+  "snapshotVersion": 1,
+  "etags": {}
 }


### PR DESCRIPTION
## Le problème

Dans les logs de build Cloudflare :

```
>> Downloading accepted feature requests from the forum
Error: 403 rate limit exceeded on https://api.github.com/repos/GladysAssistant/Gladys/contributors?per_page=100
    at getJson (/opt/buildhome/repo/scripts/load_dev_activity.js:76:13)
>> Keeping the committed dev activity snapshot
```

Les builds Cloudflare Pages tournent sans token et sur des IP partagées : le
budget anonyme de 60 requêtes/heure est donc souvent déjà consommé par
quelqu'un d'autre quand le déploiement démarre. Comme les 7 appels étaient
lancés dans un seul `Promise.all`, le premier 403 faisait échouer tout le
rafraîchissement — y compris la partie forum, qui n'a pourtant aucune limite.
La page `/dev/` restait alors figée sur le snapshot commité.

## Ce que fait cette PR

**Rafraîchissement section par section.** Le snapshot est désormais construit
par sections (métadonnées du dépôt, activité de commits, releases, PR
ouvertes, PR mergées, contributeurs, demandes de fonctionnalités du forum).
Chacune se rafraîchit indépendamment et, si son téléchargement échoue (rate
limit, 401, réseau, payload inattendu), conserve les valeurs commitées au lieu
de faire échouer le run. Un rate limit GitHub ne bloque donc plus la mise à
jour du forum.

**Requêtes conditionnelles (ETag).** Chaque réponse GitHub est stockée avec son
`ETag`, renvoyé en `If-None-Match` au build suivant. Les réponses `304` ne sont
pas décomptées du rate limit : un dépôt inchangé ne coûte donc rien. Un ETag
n'est retenu qu'une fois sa section correctement parsée, pour qu'il ne puisse
jamais prendre de l'avance sur les données commitées (`snapshotVersion` permet
d'invalider le cache si le format change).

**Gestion explicite du rate limit.** Les deux limites sont reconnues (primaire
via `x-ratelimit-remaining`/`x-ratelimit-reset`, secondaire via `retry-after`) :
attente si le reset est à moins de 30 s, abandon rapide et message clair sinon,
au lieu de retenter à l'aveugle. Une fois le budget épuisé, les appels GitHub
suivants abandonnent immédiatement au lieu de refaire l'aller-retour.

**`generatedAt` date les données, pas le build.** La page affiche cette date en
« dernière mise à jour » : elle ne bouge plus quand rien n'a réellement été
rafraîchi.

**Token lu depuis `DEV_ACTIVITY_GITHUB_TOKEN`.** `GITHUB_TOKEN` est un nom
générique, lu par beaucoup d'outils dans un build et déjà utilisé par GitHub
Actions pour son token automatique : le définir sur le projet Cloudflare
donnerait le token à tout ce qui tourne dans le build, et n'importe quelle
autre source le définissant se retrouverait silencieusement dans l'en-tête
`Authorization` de ce script. `GITHUB_TOKEN` reste accepté en repli, ce qui
permet aux workflows de passer `secrets.GITHUB_TOKEN` — ce qu'ils font
maintenant, pour que les builds sur Actions aient 5000 requêtes/heure au lieu
des 60 partagées par tous les builds anonymes du runner.

## Configuration recommandée (à faire côté Cloudflare)

Le correctif rend le build robuste, mais tant qu'il n'y a pas de token la
partie GitHub du snapshot peut rester figée quand l'IP partagée est saturée.
Pour un rafraîchissement fiable : créer un fine-grained PAT en lecture seule
sur les dépôts publics et l'ajouter en variable d'environnement
`DEV_ACTIVITY_GITHUB_TOKEN` sur le projet Cloudflare Pages (Settings >
Environment variables) → 5000 requêtes/heure. C'est documenté dans le README.

## Tests

- `./build.sh` complet : OK (le seul warning est celui, préexistant, sur
  `/fr/starter-kit/`).
- Script exécuté sans token dans un environnement lui-même rate limité : sortie
  0, chaque section GitHub retombe sur les valeurs commitées, le forum se
  rafraîchit normalement.
- Chemins vérifiés avec un `fetch` bouchonné : 200 partout (ETags stockés), 304
  partout (données conservées, 6 requêtes conditionnelles), 429 + `retry-after`
  (attente puis succès), 403 rate limit à 30 min (repli immédiat, 5 appels
  GitHub économisés), payload cassé après un 200 (repli sans empoisonner le
  cache d'ETag), et absence de snapshot exploitable (échec explicite).
- Précédence des variables vérifiée : `DEV_ACTIVITY_GITHUB_TOKEN` l'emporte sur
  `GITHUB_TOKEN`, et le token n'est jamais envoyé au forum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development activity updates continue when GitHub, rate-limit, or forum requests fail.
  * Unchanged or unavailable sections retain committed values.
  * Rate limits are detected and briefly retried.

* **Performance**
  * Conditional requests reduce unnecessary data retrieval.

* **Documentation**
  * Added guidance for configuring `DEV_ACTIVITY_GITHUB_TOKEN`, authentication, rate limits, and fallback behavior.

* **Data Updates**
  * Refreshed the activity snapshot and updated forum request counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->