### PR TITLE
fix(dev): explain why GitHub refuses a call, and show the delivered feature requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,20 +65,25 @@ To refresh reliably, give the build a token and add it as a
 project (Settings > Environment variables). That raises the budget to 5000
 requests per hour. Locally, the same variable in `.env` does the same.
 
-Only public data is read, so the token needs no permission on anything — but
-it does need to be allowed to see public repositories, which is *not* what a
-fine-grained token does by default:
+Only public data is read, so the token needs no permission on anything:
 
-- **fine-grained token** (Settings > Developer settings > Personal access
-  tokens > Fine-grained tokens): under **Repository access**, pick
-  **Public Repositories (read-only)**. That option is what grants the token
-  its read access; leaving the default ("This token does not have access to
-  any repositories") makes GitHub answer `403 Forbidden — Resource not
-  accessible by personal access token` on *every* endpoint, public ones
-  included. Nothing to tick under Repository permissions or Account
-  permissions.
 - **classic token**: create it with no scope checked at all. A scopeless
-  classic token reads public data and is the simplest thing that works.
+  classic token reads public data, which is all this script does.
+- **fine-grained token**: under **Repository access**, pick **Public
+  Repositories (read-only)**; nothing to tick under Repository or Account
+  permissions. Note that an organization can refuse fine-grained tokens it has
+  not approved, and Gladys lives in one: if the build logs `403 Forbidden —
+  Resource not accessible by personal access token` while the token is set up
+  this way, that policy is the first thing to check — or switch to a classic
+  token, which is not subject to it.
+
+The build log always opens with what it got, so a deploy that refreshes nothing
+says whether the token even reached it:
+
+```
+>> GitHub calls: DEV_ACTIVITY_GITHUB_TOKEN (fine-grained token, 93 characters)
+>> GitHub calls: no token (DEV_ACTIVITY_GITHUB_TOKEN and GITHUB_TOKEN are unset): […]
+```
 
 The name is deliberately specific: `GITHUB_TOKEN` is read by a lot of tooling
 (and is the name GitHub Actions gives its own automatic token), so a variable

--- a/README.md
+++ b/README.md
@@ -60,11 +60,25 @@ logs then show `403 rate limit exceeded`). The script limits the damage by
 sending conditional requests: each answer is stored with its `ETag` and the
 `304 Not Modified` replies do not count against the limit.
 
-To refresh reliably, give the build a token: create a fine-grained personal
-access token with read-only public access (no scope needed) and add it as a
+To refresh reliably, give the build a token and add it as a
 `DEV_ACTIVITY_GITHUB_TOKEN` environment variable on the Cloudflare Pages
 project (Settings > Environment variables). That raises the budget to 5000
 requests per hour. Locally, the same variable in `.env` does the same.
+
+Only public data is read, so the token needs no permission on anything — but
+it does need to be allowed to see public repositories, which is *not* what a
+fine-grained token does by default:
+
+- **fine-grained token** (Settings > Developer settings > Personal access
+  tokens > Fine-grained tokens): under **Repository access**, pick
+  **Public Repositories (read-only)**. That option is what grants the token
+  its read access; leaving the default ("This token does not have access to
+  any repositories") makes GitHub answer `403 Forbidden — Resource not
+  accessible by personal access token` on *every* endpoint, public ones
+  included. Nothing to tick under Repository permissions or Account
+  permissions.
+- **classic token**: create it with no scope checked at all. A scopeless
+  classic token reads public data and is the simplest thing that works.
 
 The name is deliberately specific: `GITHUB_TOKEN` is read by a lot of tooling
 (and is the name GitHub Actions gives its own automatic token), so a variable

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -1857,12 +1857,16 @@
     "description": "Section title"
   },
   "devPage.requests.intro": {
-    "message": "N'importe qui peut proposer une fonctionnalité sur le forum. Une fois la demande validée, elle reçoit le tag « accepted » et rejoint la roadmap. Voici celles qui attendent d'être développées.",
+    "message": "N'importe qui peut proposer une fonctionnalité sur le forum. Une fois la demande validée, elle reçoit le tag « accepted » et rejoint la roadmap. Celles qui restent à développer viennent en premier, puis tout ce que la communauté a demandé et déjà obtenu.",
     "description": "Section intro"
   },
   "devPage.requests.accepted": {
     "message": "✓ accepté",
     "description": "Accepted tag badge"
+  },
+  "devPage.requests.delivered": {
+    "message": "🚀 livrée",
+    "description": "Badge on a request that has been shipped"
   },
   "devPage.requests.all": {
     "message": "Voir toutes les demandes acceptées sur le forum →",

--- a/scripts/load_dev_activity.js
+++ b/scripts/load_dev_activity.js
@@ -80,6 +80,31 @@ const gitHubTokenVariable = process.env.DEV_ACTIVITY_GITHUB_TOKEN
     : null;
 const gitHubToken = gitHubTokenVariable ? process.env[gitHubTokenVariable] : null;
 
+// What the build log says about the token, without ever printing it: whether
+// one was found at all, and whether it looks like a GitHub token. A deploy that
+// refreshes nothing must not leave the question "was the token even passed to
+// the build?" open, since the answer changes where to look entirely.
+function describeToken() {
+  if (!gitHubToken) {
+    return (
+      "no token (DEV_ACTIVITY_GITHUB_TOKEN and GITHUB_TOKEN are unset): GitHub " +
+      "calls go out anonymously, on 60 requests/hour shared by every build on this IP"
+    );
+  }
+  const kinds = {
+    github_pat_: "fine-grained token",
+    ghp_: "classic token",
+    ghs_: "Actions token",
+    gho_: "OAuth token",
+    ghu_: "user-to-server token",
+  };
+  const prefix = Object.keys(kinds).find((candidate) => gitHubToken.startsWith(candidate));
+  // An unrecognized shape is a finding in itself: a value truncated by a copy
+  // and paste, quoted, or holding a trailing newline never gets accepted.
+  const kind = prefix ? kinds[prefix] : "unrecognized format";
+  return `${gitHubTokenVariable} (${kind}, ${gitHubToken.length} characters)`;
+}
+
 // A token GitHub refuses (expired, revoked, missing the repository) must not
 // leave the page stale while the anonymous budget is still there: the first
 // call to be refused drops it and the following ones go out anonymously.
@@ -591,6 +616,8 @@ async function loadSection(section) {
 }
 
 async function main() {
+  console.log(`>> GitHub calls: ${describeToken()}`);
+
   const data = {};
   for (const section of SECTIONS) {
     Object.assign(data, await loadSection(section));

--- a/scripts/load_dev_activity.js
+++ b/scripts/load_dev_activity.js
@@ -67,7 +67,17 @@ const MAX_RATE_LIMIT_WAIT_MS = 30000;
 // GitHub Actions gives that name to its own automatic token), so a token meant
 // for this script alone deserves its own name. GITHUB_TOKEN is still accepted
 // as a fallback, which is what a workflow passing `secrets.GITHUB_TOKEN` uses.
-const gitHubToken = process.env.DEV_ACTIVITY_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+const gitHubTokenVariable = process.env.DEV_ACTIVITY_GITHUB_TOKEN
+  ? "DEV_ACTIVITY_GITHUB_TOKEN"
+  : process.env.GITHUB_TOKEN
+    ? "GITHUB_TOKEN"
+    : null;
+const gitHubToken = gitHubTokenVariable ? process.env[gitHubTokenVariable] : null;
+
+// A token GitHub refuses (expired, revoked, missing the repository) must not
+// leave the page stale while the anonymous budget is still there: the first
+// call to be refused drops it and the following ones go out anonymously.
+let gitHubTokenRejected = false;
 
 // Returned instead of a payload when GitHub answers 304 Not Modified.
 const NOT_MODIFIED = Symbol("not modified");
@@ -79,16 +89,50 @@ const NOT_MODIFIED = Symbol("not modified");
 const etags = new Map();
 const stagedEtags = new Map();
 
+// GitHub explains every refusal in the body ("Bad credentials", "Resource not
+// accessible by personal access token", "API rate limit exceeded for x.x.x.x"),
+// and a build log without it leaves nothing to debug with.
+async function apiMessage(response) {
+  try {
+    const body = await response.json();
+    return typeof body?.message === "string" ? body.message : "";
+  } catch (error) {
+    return "";
+  }
+}
+
+function authLabel(headers) {
+  if (!headers.Authorization) {
+    return "anonymous";
+  }
+  return `with the ${gitHubTokenVariable} token`;
+}
+
+function describeFailure(response, url, message, headers) {
+  const budget = response.headers.get("x-ratelimit-remaining");
+  const details = [message, `${authLabel(headers)}`];
+  if (budget !== null) {
+    details.push(`${budget}/${response.headers.get("x-ratelimit-limit") || "?"} requests left`);
+  }
+  return `${response.status} ${response.statusText} on ${url} — ${details.filter(Boolean).join(", ")}`;
+}
+
 class RateLimitError extends Error {
-  constructor(url, delayMs) {
+  constructor(url, delayMs, message, headers) {
     const when = Number.isFinite(delayMs)
       ? `it resets in about ${Math.max(1, Math.round(delayMs / 60000))} min`
       : "no reset date given";
     super(
-      `GitHub rate limit reached on ${url} (${when}). ` +
-        "Set DEV_ACTIVITY_GITHUB_TOKEN to lift the anonymous 60 requests/hour limit."
+      `GitHub rate limit reached on ${url} (${authLabel(headers)}, ${when})` +
+        `${message ? `: ${message}` : ""}. ` +
+        (headers.Authorization
+          ? "Wait for the reset, the token cannot lift it any further."
+          : "Set DEV_ACTIVITY_GITHUB_TOKEN to lift the anonymous 60 requests/hour limit.")
     );
     this.name = "RateLimitError";
+    // What the sections skipped afterwards report, without repeating the URL
+    // and the advice of the call that actually hit the limit.
+    this.summary = `GitHub rate limit reached (${authLabel(headers)}), ${when}`;
   }
 }
 
@@ -121,7 +165,7 @@ function rateLimitDelay(response) {
 async function getJson(url, { retryOn202 = false, conditional = false } = {}) {
   const isGitHub = url.startsWith(GITHUB_API);
   if (isGitHub && gitHubRateLimit) {
-    throw gitHubRateLimit;
+    throw new Error(`${gitHubRateLimit.summary}, skipping this call`);
   }
 
   const headers = {
@@ -133,7 +177,7 @@ async function getJson(url, { retryOn202 = false, conditional = false } = {}) {
   }
   // Optional: lifts the 60 requests/hour anonymous limit, a local run works
   // fine without one. Only ever sent to the GitHub API, never to the forum.
-  if (isGitHub && gitHubToken) {
+  if (isGitHub && gitHubToken && !gitHubTokenRejected) {
     headers.Authorization = `Bearer ${gitHubToken}`;
   }
   // A 304 answer does not count against the rate limit, which is the whole
@@ -159,16 +203,27 @@ async function getJson(url, { retryOn202 = false, conditional = false } = {}) {
     }
     const rateLimited = rateLimitDelay(response);
     if (rateLimited !== null) {
+      const message = await apiMessage(response);
       if (rateLimited <= MAX_RATE_LIMIT_WAIT_MS && attempt < MAX_ATTEMPTS - 1) {
         console.log(`   rate limited on ${url}, retrying in ${Math.round(rateLimited / 1000)}s...`);
         await sleep(rateLimited + 1000);
         continue;
       }
-      const error = new RateLimitError(url, rateLimited);
+      const error = new RateLimitError(url, rateLimited, message, headers);
       if (isGitHub) {
         gitHubRateLimit = error;
       }
       throw error;
+    }
+    // Refused for the credentials rather than for the budget: drop the token
+    // and try again anonymously, which still has its own 60 requests/hour.
+    if ((response.status === 401 || response.status === 403) && headers.Authorization) {
+      const message = await apiMessage(response);
+      console.log(`   ${describeFailure(response, url, message, headers)}`);
+      console.log(`   retrying anonymously, ${gitHubTokenVariable} is not being accepted`);
+      gitHubTokenRejected = true;
+      delete headers.Authorization;
+      continue;
     }
     // A single 502 from GitHub should not fail the daily refresh.
     if (response.status >= 500 && attempt < MAX_ATTEMPTS - 1) {
@@ -177,7 +232,7 @@ async function getJson(url, { retryOn202 = false, conditional = false } = {}) {
       continue;
     }
     if (!response.ok) {
-      throw new Error(`${response.status} ${response.statusText} on ${url}`);
+      throw new Error(describeFailure(response, url, await apiMessage(response), headers));
     }
     const etag = response.headers.get("etag");
     if (conditional && etag) {
@@ -477,6 +532,25 @@ function committedValues(section) {
   return Object.fromEntries(section.keys.map((key) => [key, committedSnapshot[key]]));
 }
 
+// A list coming back much shorter than the committed one is usually an upstream
+// change rather than real news: a forum category emptied by an archiving pass, a
+// filter that stopped matching. The fresh values are still the truth and get
+// written, but a silent collapse of a page section is worth saying out loud.
+function warnAboutShrinking(values) {
+  Object.entries(values).forEach(([key, fresh]) => {
+    const committed = committedSnapshot[key];
+    if (!Array.isArray(fresh) || !Array.isArray(committed)) {
+      return;
+    }
+    if (committed.length >= 5 && fresh.length * 2 < committed.length) {
+      console.log(
+        `   !! ${key}: ${committed.length} entries committed, ${fresh.length} downloaded, ` +
+          "check that the source still holds what this page expects"
+      );
+    }
+  });
+}
+
 async function loadSection(section) {
   console.log(`>> Downloading the ${section.name}`);
   stagedEtags.clear();
@@ -484,6 +558,7 @@ async function loadSection(section) {
     const values = await section.load();
     if (values !== NOT_MODIFIED) {
       stagedEtags.forEach((etag, url) => etags.set(url, etag));
+      warnAboutShrinking(values);
       return values;
     }
     console.log("   unchanged upstream");

--- a/scripts/load_dev_activity.js
+++ b/scripts/load_dev_activity.js
@@ -36,9 +36,15 @@ const GITHUB_REPO = "Gladys";
 const GITHUB_API = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}`;
 
 const FORUM_URL = "https://community.gladysassistant.com";
-// Feature requests (category 43) tagged "accepted" (tag 184): the roadmap the
-// community voted for and that has been greenlit.
-const FORUM_ACCEPTED_PATH = "/tags/c/feature-requests/43/accepted/184.json";
+// A feature request the community voted for gets the "accepted" tag once it is
+// greenlit, and moves to the "Demandes livrées" category once shipped. Listing
+// the tag rather than one category keeps both states: filtering on the category
+// alone made the page drop a request the day it was delivered.
+const FORUM_ACCEPTED_PATH = "/tag/accepted.json";
+// "Demande de fonctionnalités": accepted, still to be built.
+const FORUM_PENDING_CATEGORY = 43;
+// "Demandes livrées": accepted and shipped.
+const FORUM_DELIVERED_CATEGORY = 52;
 
 const OUTPUT_FILE = path.join(__dirname, "..", "src", "data", "devActivity.json");
 
@@ -423,7 +429,7 @@ async function getForumRequests() {
   const topics = [];
   const users = new Map();
 
-  // Discourse paginates tag listings; two pages cover the accepted list with
+  // Discourse paginates tag listings; two pages cover the accepted tag with
   // room to grow.
   for (let page = 0; page < 2; page += 1) {
     const url = `${FORUM_URL}${FORUM_ACCEPTED_PATH}${page > 0 ? `?page=${page}` : ""}`;
@@ -442,11 +448,26 @@ async function getForumRequests() {
   return {
     forumRequests: topics
       .filter((topic) => {
+        // The tag is what makes a topic part of the roadmap, but it can be put
+        // on anything: only the two feature request categories belong here.
+        if (
+          topic.category_id !== FORUM_PENDING_CATEGORY &&
+          topic.category_id !== FORUM_DELIVERED_CATEGORY
+        ) {
+          return false;
+        }
         if (seen.has(topic.id)) {
           return false;
         }
         seen.add(topic.id);
         return true;
+      })
+      // What is still to be built comes first: that is the part of the page
+      // that answers "what is coming next".
+      .sort((a, b) => {
+        const delivered = Number(a.category_id === FORUM_DELIVERED_CATEGORY) -
+          Number(b.category_id === FORUM_DELIVERED_CATEGORY);
+        return delivered || new Date(b.bumped_at) - new Date(a.bumped_at);
       })
       .slice(0, MAX_FORUM_REQUESTS)
       .map((topic) => {
@@ -464,6 +485,7 @@ async function getForumRequests() {
           createdAt: topic.created_at,
           bumpedAt: topic.bumped_at,
           author: author ? author.username : null,
+          delivered: topic.category_id === FORUM_DELIVERED_CATEGORY,
           // The "accepted" tag is on every topic here, so it carries no signal.
           tags: (topic.tags || [])
             .filter((tag) => tag.name !== "accepted")

--- a/src/data/devActivity.json
+++ b/src/data/devActivity.json
@@ -1,15 +1,15 @@
 {
-  "generatedAt": "2026-08-27T16:22:41.912Z",
+  "generatedAt": "2026-08-29T13:08:50.256Z",
   "repository": {
     "owner": "GladysAssistant",
     "name": "Gladys",
     "url": "https://github.com/GladysAssistant/Gladys",
-    "stars": 3154,
-    "forks": 315,
-    "openIssues": 61,
+    "stars": 3165,
+    "forks": 317,
+    "openIssues": 52,
     "watchers": 72,
     "createdAt": "2015-06-05T11:10:33Z",
-    "pushedAt": "2026-08-21T17:28:29Z"
+    "pushedAt": "2026-08-29T13:01:25Z"
   },
   "weeks": [
     {
@@ -1414,15 +1414,29 @@
   ],
   "forumRequests": [
     {
+      "id": 10521,
+      "title": "Intégration externe : Le suivi de l'énergie devrait être géré automatiquement comme pour Zigbee2mqtt",
+      "url": "https://community.gladysassistant.com/t/integration-externe-le-suivi-de-lenergie-devrait-etre-gere-automatiquement-comme-pour-zigbee2mqtt/10521",
+      "views": 37,
+      "replies": 6,
+      "likes": 1,
+      "createdAt": "2026-08-10T17:34:51.108Z",
+      "bumpedAt": "2026-08-10T20:19:59.506Z",
+      "author": "pierre-gilles",
+      "delivered": false,
+      "tags": []
+    },
+    {
       "id": 10310,
       "title": "Supprimer l'option de migration DuckDB après migration",
       "url": "https://community.gladysassistant.com/t/supprimer-loption-de-migration-duckdb-apres-migration/10310",
-      "views": 56,
+      "views": 57,
       "replies": 3,
       "likes": 6,
       "createdAt": "2026-06-29T18:32:22.549Z",
       "bumpedAt": "2026-08-18T12:16:05.743Z",
       "author": "mutmut",
+      "delivered": true,
       "tags": [
         "demande-core"
       ]
@@ -1431,84 +1445,151 @@
       "id": 9447,
       "title": "[Scène] Supprimer bloc 1 si vide",
       "url": "https://community.gladysassistant.com/t/scene-supprimer-bloc-1-si-vide/9447",
-      "views": 81,
+      "views": 82,
       "replies": 8,
       "likes": 2,
       "createdAt": "2025-03-22T08:44:29.764Z",
       "bumpedAt": "2026-08-15T15:27:24.636Z",
       "author": "mutmut",
+      "delivered": true,
       "tags": []
     },
     {
       "id": 10576,
       "title": "Intégrations - Diminuer le bandeau bleu sur mobile",
       "url": "https://community.gladysassistant.com/t/integrations-diminuer-le-bandeau-bleu-sur-mobile/10576",
-      "views": 25,
+      "views": 26,
       "replies": 0,
       "likes": 0,
       "createdAt": "2026-08-15T14:49:19.631Z",
       "bumpedAt": "2026-08-15T14:49:19.840Z",
       "author": "mutmut",
+      "delivered": true,
       "tags": []
     },
     {
       "id": 10574,
       "title": "Intégration externe - Avoir le numéro de la nouvelle version",
       "url": "https://community.gladysassistant.com/t/integration-externe-avoir-le-numero-de-la-nouvelle-version/10574",
-      "views": 24,
+      "views": 27,
       "replies": 0,
       "likes": 0,
       "createdAt": "2026-08-15T14:40:00.015Z",
       "bumpedAt": "2026-08-15T14:40:00.239Z",
       "author": "mutmut",
+      "delivered": true,
       "tags": []
+    },
+    {
+      "id": 10517,
+      "title": "IA : pouvoir demander la météo dans le chat",
+      "url": "https://community.gladysassistant.com/t/ia-pouvoir-demander-la-meteo-dans-le-chat/10517",
+      "views": 52,
+      "replies": 3,
+      "likes": 4,
+      "createdAt": "2026-08-10T12:54:21.590Z",
+      "bumpedAt": "2026-08-14T15:18:36.683Z",
+      "author": "Chris75",
+      "delivered": true,
+      "tags": []
+    },
+    {
+      "id": 9505,
+      "title": "[Scènes] Pouvoir créer une variable 'ponctuelle'",
+      "url": "https://community.gladysassistant.com/t/scenes-pouvoir-creer-une-variable-ponctuelle/9505",
+      "views": 146,
+      "replies": 7,
+      "likes": 10,
+      "createdAt": "2025-05-11T20:15:11.640Z",
+      "bumpedAt": "2026-08-14T15:12:16.289Z",
+      "author": "StephaneB",
+      "delivered": true,
+      "tags": [
+        "demande-core"
+      ]
     },
     {
       "id": 10544,
       "title": "Matter : serrures et détecteurs de fuites",
       "url": "https://community.gladysassistant.com/t/matter-serrures-et-detecteurs-de-fuites/10544",
-      "views": 29,
+      "views": 31,
       "replies": 0,
       "likes": 0,
       "createdAt": "2026-08-13T17:52:27.005Z",
       "bumpedAt": "2026-08-13T17:52:27.232Z",
       "author": "Damien",
-      "tags": []
-    },
-    {
-      "id": 10521,
-      "title": "Intégration externe : Le suivi de l'énergie devrait être géré automatiquement comme pour Zigbee2mqtt",
-      "url": "https://community.gladysassistant.com/t/integration-externe-le-suivi-de-lenergie-devrait-etre-gere-automatiquement-comme-pour-zigbee2mqtt/10521",
-      "views": 36,
-      "replies": 6,
-      "likes": 1,
-      "createdAt": "2026-08-10T17:34:51.108Z",
-      "bumpedAt": "2026-08-10T20:19:59.506Z",
-      "author": "pierre-gilles",
+      "delivered": true,
       "tags": []
     },
     {
       "id": 10514,
       "title": "Intégrations externes : pouvoir voir quelles intégrations tournent sur l'instance",
       "url": "https://community.gladysassistant.com/t/integrations-externes-pouvoir-voir-quelles-integrations-tournent-sur-linstance/10514",
-      "views": 24,
+      "views": 26,
       "replies": 0,
       "likes": 0,
       "createdAt": "2026-08-10T09:25:26.385Z",
       "bumpedAt": "2026-08-10T09:25:26.598Z",
       "author": "pierre-gilles",
+      "delivered": true,
       "tags": []
+    },
+    {
+      "id": 10461,
+      "title": "Afficher les intégrations à mettre à jour",
+      "url": "https://community.gladysassistant.com/t/afficher-les-integrations-a-mettre-a-jour/10461",
+      "views": 60,
+      "replies": 4,
+      "likes": 2,
+      "createdAt": "2026-08-05T22:26:53.473Z",
+      "bumpedAt": "2026-08-07T14:18:29.982Z",
+      "author": "prohand",
+      "delivered": true,
+      "tags": [
+        "demande-core"
+      ]
+    },
+    {
+      "id": 10477,
+      "title": "Intégrations externes : placeholders résolus par le front dans les textes du manifeste ({{gladys_host}}, {{port:xxx}})",
+      "url": "https://community.gladysassistant.com/t/integrations-externes-placeholders-resolus-par-le-front-dans-les-textes-du-manifeste-gladys-host-port-xxx/10477",
+      "views": 25,
+      "replies": 1,
+      "likes": 2,
+      "createdAt": "2026-08-07T08:10:20.236Z",
+      "bumpedAt": "2026-08-07T14:15:57.821Z",
+      "author": "pierre-gilles",
+      "delivered": true,
+      "tags": [
+        "demande-core"
+      ]
+    },
+    {
+      "id": 10476,
+      "title": "Intégrations externes : permettre de masquer le lien \"Open\" d'un port publié",
+      "url": "https://community.gladysassistant.com/t/integrations-externes-permettre-de-masquer-le-lien-open-dun-port-publie/10476",
+      "views": 26,
+      "replies": 1,
+      "likes": 2,
+      "createdAt": "2026-08-07T08:09:52.007Z",
+      "bumpedAt": "2026-08-07T14:15:27.031Z",
+      "author": "pierre-gilles",
+      "delivered": true,
+      "tags": [
+        "demande-core"
+      ]
     },
     {
       "id": 10392,
       "title": "Décaler le jour de départ du suivi de l'énergie",
       "url": "https://community.gladysassistant.com/t/decaler-le-jour-de-depart-du-suivi-de-lenergie/10392",
-      "views": 51,
+      "views": 52,
       "replies": 3,
       "likes": 2,
       "createdAt": "2026-07-29T08:21:28.972Z",
       "bumpedAt": "2026-07-30T16:32:38.020Z",
       "author": "Jluc",
+      "delivered": true,
       "tags": [
         "demande-core"
       ]
@@ -1523,6 +1604,7 @@
       "createdAt": "2026-03-05T08:32:58.541Z",
       "bumpedAt": "2026-03-05T08:32:58.676Z",
       "author": "jcmoriaud",
+      "delivered": true,
       "tags": [
         "demande-core"
       ]
@@ -1537,6 +1619,7 @@
       "createdAt": "2026-01-18T19:29:00.817Z",
       "bumpedAt": "2026-02-17T12:36:01.954Z",
       "author": "mutmut",
+      "delivered": true,
       "tags": [
         "demande-core"
       ]
@@ -1551,12 +1634,14 @@
       "createdAt": "2025-11-20T15:15:07.100Z",
       "bumpedAt": "2025-11-20T15:15:07.214Z",
       "author": "pierre-gilles",
+      "delivered": true,
       "tags": [
-        "demande-core",
-        "feature-request-ux"
+        "demande-core"
       ]
     }
   ],
   "snapshotVersion": 1,
-  "etags": {}
+  "etags": {
+    "https://api.github.com/repos/GladysAssistant/Gladys": "W/\"e195c229bda265e27784e1e1aac20060ea0a459835082fc8676f287613b8d990\""
+  }
 }

--- a/src/pages/dev.js
+++ b/src/pages/dev.js
@@ -22,8 +22,7 @@ import {
 import styles from "./dev.module.css";
 
 const GITHUB_API = "https://api.github.com/repos/GladysAssistant/Gladys";
-const FORUM_ACCEPTED_URL =
-  "https://community.gladysassistant.com/tags/c/feature-requests/43/accepted";
+const FORUM_ACCEPTED_URL = "https://community.gladysassistant.com/tag/accepted";
 const MAX_RELEASES_SHOWN = 8;
 
 const TIER_LABELS = {
@@ -1065,7 +1064,8 @@ function DevPage() {
               >
                 Anyone can suggest a feature on the forum. Once a request is
                 validated it gets the "accepted" tag and joins the roadmap.
-                These are the ones waiting to be built.
+                What is still to be built comes first, then everything the
+                community asked for and already got.
               </Translate>
             </p>
             <div className={styles.cardGrid}>
@@ -1075,13 +1075,26 @@ function DevPage() {
                   to={request.url}
                   className={styles.requestCard}
                 >
-                  <span className={styles.acceptedBadge}>
-                    <Translate
-                      id="devPage.requests.accepted"
-                      description="Accepted tag badge"
-                    >
-                      ✓ accepted
-                    </Translate>
+                  <span
+                    className={`${styles.acceptedBadge} ${
+                      request.delivered ? styles.deliveredBadge : ""
+                    }`}
+                  >
+                    {request.delivered ? (
+                      <Translate
+                        id="devPage.requests.delivered"
+                        description="Badge on a request that has been shipped"
+                      >
+                        🚀 delivered
+                      </Translate>
+                    ) : (
+                      <Translate
+                        id="devPage.requests.accepted"
+                        description="Accepted tag badge"
+                      >
+                        ✓ accepted
+                      </Translate>
+                    )}
                   </span>
                   <div className={styles.requestTitle}>{request.title}</div>
                   <div className={styles.requestMeta}>

--- a/src/pages/dev.module.css
+++ b/src/pages/dev.module.css
@@ -673,6 +673,13 @@
   background: rgba(46, 204, 113, 0.14);
 }
 
+/* Already shipped: same badge, the blue of the page rather than the green of
+   what is still on the roadmap. */
+.deliveredBadge {
+  color: #65c7f7;
+  background: rgba(101, 199, 247, 0.14);
+}
+
 .requestMeta {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Follow-up to #404, from the deploy logs of 2026-08-29.

## 1. A 403 that does not say why

```
>> Downloading the repository metadata
   403 Forbidden on https://api.github.com/repos/GladysAssistant/Gladys
   keeping the committed repository metadata
```

The fallback works, but the message settles nothing: a 403 can be the anonymous
budget, a secondary limit, a token GitHub does not accept, or a blocked IP. Only
the response body tells them apart, and it was not printed. Worth noting: on
08-27 the status was `403 rate limit exceeded`, on 08-29 it is `403 Forbidden` —
not the same refusal, and a token has been configured in between.

**Failures explain themselves.** Every refusal now carries the message GitHub
puts in the response body (`Bad credentials`, `Resource not accessible by
personal access token`, `API rate limit exceeded for x.x.x.x`), whether the call
went out anonymously or with a token — and which variable it came from — and how
much of the budget is left:

```
   GitHub rate limit reached on https://api.github.com/repos/GladysAssistant/Gladys
   (anonymous, it resets in about 48 min): API rate limit exceeded for 146.148.98.137. […]
   403 Forbidden on https://api.github.com/… — Resource not accessible by personal
   access token, with the DEV_ACTIVITY_GITHUB_TOKEN token, 0/60 requests left
```

The calls skipped after a rate limit no longer repeat the whole first error:
`GitHub rate limit reached (anonymous), it resets in about 48 min, skipping this
call`.

**Every run says which token it received.** A deploy that refreshes nothing left
one question open that changes where to look entirely — did the token even reach
the build? The run now opens with the variable it read, the kind of token it
looks like and its length, never the value:

```
>> GitHub calls: DEV_ACTIVITY_GITHUB_TOKEN (fine-grained token, 93 characters)
>> GitHub calls: no token (DEV_ACTIVITY_GITHUB_TOKEN and GITHUB_TOKEN are unset): […]
```

An unrecognized shape is a finding of its own: a value truncated by a copy and
paste, quoted, or carrying a trailing newline never gets accepted as
credentials.

**A refused token no longer blocks the refresh.** A 401, or a 403 that is not a
rate limit, on an authenticated call: the token is dropped for the rest of the
run and the call goes out anonymously, which has its own 60 requests/hour. A
token that expires or loses access must not leave the page staler than no token
at all.

**A section that collapses says so.** When a list comes back with less than half
of what is committed, the build logs a `!!` line:

```
   !! forumRequests: 11 entries committed, 1 downloaded, check that the source
   still holds what this page expects
```

The fresh values are still the truth and get written — the source has the last
word — but a page section collapsing is no longer silent.

## 2. Feature requests went from 11 to 1

Not an API problem: 15 of the topics tagged `accepted` were moved from "Demande
de fonctionnalités" (category 43) to "Demandes livrées" (category 52). The
script only read category 43, so a request left the page the day it shipped.

The snapshot now lists the `accepted` tag itself (`/tag/accepted.json`), keeps
the topics of both feature request categories and records which ones are
delivered. The page puts what is still to be built first, then the delivered
ones behind a "🚀 delivered" badge: the section shows a roadmap that completes
instead of a list that empties itself. 16 requests shown instead of one.

Pleasant side effect: one request to the forum instead of two.

## Tests

- Full `./build.sh`: OK (the only warning is the pre-existing one on
  `/fr/starter-kit/`). The EN and FR pages both render 15 "delivered" badges and
  1 "accepted".
- Refused token (403 + `Resource not accessible…`): falls back to anonymous,
  data refreshed. Malformed token: `401 Bad credentials`, then anonymous.
- Real anonymous rate limit: full message on the first call, `skipping this
  call` on the following ones, fallback on the committed snapshot, exit 0.
- 429 + `retry-after`, 304 everywhere, payload broken after a 200: unchanged.
- `!!` line verified on the real `forumRequests: 11 -> 1` case.