### PR TITLE
docs(dev): name the token lifetime the organization requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Only public data is read, so the token needs no permission on anything:
   classic token reads public data, which is all this script does.
 - **fine-grained token**: under **Repository access**, pick **Public
   Repositories (read-only)**; nothing to tick under Repository or Account
-  permissions. Note that an organization can refuse fine-grained tokens it has
-  not approved, and Gladys lives in one: if the build logs `403 Forbidden —
-  Resource not accessible by personal access token` while the token is set up
-  this way, that policy is the first thing to check — or switch to a classic
-  token, which is not subject to it.
+  permissions. Give it an **expiration date under a year**: the
+  GladysAssistant organization refuses fine-grained tokens living longer than
+  366 days, "no expiration" included, and answers `403 Forbidden` on every
+  call — the build log quotes that refusal in full. Such a token has to be
+  rotated once a year; a classic token has no such limit.
 
 The build log always opens with what it got, so a deploy that refreshes nothing
 says whether the token even reached it:


### PR DESCRIPTION
Follow-up to #407, from the deploy that ran with its diagnostics.

## What the build log said

```
>> GitHub calls: DEV_ACTIVITY_GITHUB_TOKEN (fine-grained token, 93 characters)
>> Downloading the repository metadata
   403 Forbidden on https://api.github.com/repos/GladysAssistant/Gladys — The
   'GladysAssistant' organization forbids access via a fine-grained personal
   access tokens if the token's lifetime is greater than 366 days. […],
   with the DEV_ACTIVITY_GITHUB_TOKEN token, 4882/5000 requests left
   retrying anonymously, DEV_ACTIVITY_GITHUB_TOKEN is not being accepted
```

The token was set up exactly as the README described — "Public Repositories
(read-only)", no permission ticked — but created without an expiration date,
which the organization policy refuses. Nothing about the token's own
configuration hinted at it.

So the README now names the constraint where the token gets created: give it an
expiration under a year, and expect to rotate it; a classic token is not subject
to that policy.

## Everything else in that deploy worked

The `4882/5000` in the message shows the token authenticated fine and was
refused at the authorization step, and the run carried on: the anonymous retry
went through, the repository metadata came back `304 Not Modified` from its
stored ETag, and every other section refreshed — 43 open PRs, 16 feature
requests, delivered ones included. A refused token cost the build one request
and nothing else.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSGKCYAEYMGa6fjKcZkdDh)_