### PR TITLE
feat(contact): away banner, Turnstile widget and error handling for the new contact API

### DIFF
--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -478,6 +478,26 @@
     "message": "Ecrivez ici votre message!",
     "description": "Contact page message placeholder"
   },
+  "contactPage.name": {
+    "message": "Nom (optionnel)",
+    "description": "Gladys contact name"
+  },
+  "contact.namePlaceholder": {
+    "message": "Votre nom",
+    "description": "Contact page name placeholder"
+  },
+  "contactPage.rateLimited": {
+    "message": "Vous avez envoyé trop de messages en peu de temps. Merci de patienter une heure avant de réessayer, ou écrivez-nous sur le forum.",
+    "description": "Gladys contact page rate limited error"
+  },
+  "contactPage.captchaFailed": {
+    "message": "Nous n'avons pas pu vérifier que vous êtes humain. Merci de compléter la vérification ci-dessous et de réessayer.",
+    "description": "Gladys contact page captcha error"
+  },
+  "contactPage.sendError": {
+    "message": "Votre message n'a pas pu être envoyé. Merci de réessayer dans quelques minutes. Si le problème persiste, contactez-nous sur le forum.",
+    "description": "Gladys contact page send error"
+  },
   "gladysPlusPage.submit": {
     "message": "M'inscrire",
     "description": "Gladys Plus submit"

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,15 +1,22 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import HorizonPage from "../components/horizon/HorizonPage";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import styles from "./styles.module.css";
 import Translate from "@docusaurus/Translate";
 import { translate } from "@docusaurus/Translate";
 
+const CONTACT_API = "https://contact-page.gladysassistant.workers.dev";
+const TURNSTILE_SCRIPT =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
 const STATUS = {
   INITIAL: "INITIAL",
   SENDING: "SENDING",
   NETWORK_ERROR: "NETWORK_ERROR",
   VALIDATION_ERROR: "VALIDATION_ERROR",
+  RATE_LIMITED: "RATE_LIMITED",
+  CAPTCHA_FAILED: "CAPTCHA_FAILED",
+  SEND_ERROR: "SEND_ERROR",
   SUCCESS: "SUCCESS",
 };
 
@@ -19,52 +26,147 @@ function validateEmail(email) {
   return re.test(String(email).toLowerCase());
 }
 
+function loadTurnstileScript() {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("no window"));
+  }
+  if (window.turnstile) {
+    return Promise.resolve(window.turnstile);
+  }
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[src="${TURNSTILE_SCRIPT}"]`);
+    const script = existing || document.createElement("script");
+    script.addEventListener("load", () => resolve(window.turnstile));
+    script.addEventListener("error", reject);
+    if (!existing) {
+      script.src = TURNSTILE_SCRIPT;
+      script.async = true;
+      document.head.appendChild(script);
+    }
+  });
+}
+
+/** Renders the Turnstile widget and reports the token to the parent. */
+function Turnstile({ siteKey, language, onToken }) {
+  const container = useRef(null);
+  const widgetId = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadTurnstileScript()
+      .then((turnstile) => {
+        if (cancelled || !container.current) {
+          return;
+        }
+        widgetId.current = turnstile.render(container.current, {
+          sitekey: siteKey,
+          language,
+          callback: (token) => onToken(token),
+          "expired-callback": () => onToken(""),
+          "error-callback": () => onToken(""),
+        });
+      })
+      .catch((e) => console.error("Turnstile failed to load", e));
+    return () => {
+      cancelled = true;
+      if (widgetId.current && window.turnstile) {
+        window.turnstile.remove(widgetId.current);
+      }
+    };
+  }, [siteKey, language]);
+
+  return <div ref={container} className="margin-top--sm" />;
+}
+
 function Home() {
   const context = useDocusaurusContext();
+  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [message, setMessage] = useState("");
+  const [website, setWebsite] = useState(""); // honeypot, must stay empty
   const [status, setStatus] = useState(STATUS.INITIAL);
+  const [availability, setAvailability] = useState(null);
+  const [turnstile, setTurnstile] = useState({ required: false, siteKey: null });
+  const [turnstileToken, setTurnstileToken] = useState("");
+  const [turnstileKey, setTurnstileKey] = useState(0);
   const { i18n } = context;
   const language = i18n.currentLocale;
 
-  const updateEmail = (e) => {
-    setEmail(e.target.value);
-  };
+  // Away banner + Turnstile configuration, from the API.
+  useEffect(() => {
+    fetch(`${CONTACT_API}/status`)
+      .then((res) => res.json())
+      .then((data) => {
+        setAvailability(data);
+        if (data.turnstile) {
+          setTurnstile(data.turnstile);
+        }
+      })
+      .catch(() => {});
+  }, []);
 
-  const updateMessage = (e) => {
-    setMessage(e.target.value);
+  const awayMessage =
+    availability && availability.available === false && availability.message
+      ? availability.message[language] || availability.message.en
+      : null;
+
+  const resetTurnstile = () => {
+    setTurnstileToken("");
+    setTurnstileKey((k) => k + 1); // remounts the widget: a token is single use
   };
 
   const sendMessage = async (e) => {
     e.preventDefault();
 
-    if (!validateEmail(email)) {
+    if (!validateEmail(email) || message.trim().length === 0) {
       setStatus(STATUS.VALIDATION_ERROR);
       return;
     }
-
-    if (message.length === 0) {
-      setStatus(STATUS.VALIDATION_ERROR);
+    if (turnstile.required && turnstile.siteKey && !turnstileToken) {
+      setStatus(STATUS.CAPTCHA_FAILED);
       return;
     }
 
     try {
       setStatus(STATUS.SENDING);
-      await fetch("https://contact-page.gladysassistant.workers.dev/", {
+      const res = await fetch(`${CONTACT_API}/`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email,
           message,
+          name,
+          language,
+          page: window.location.href,
+          website,
+          turnstileToken,
         }),
       });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        resetTurnstile();
+        if (data.error === "validation_error") {
+          setStatus(STATUS.VALIDATION_ERROR);
+        } else if (data.error === "rate_limited") {
+          setStatus(STATUS.RATE_LIMITED);
+        } else if (data.error === "captcha_failed") {
+          setStatus(STATUS.CAPTCHA_FAILED);
+        } else {
+          setStatus(STATUS.SEND_ERROR);
+        }
+        return;
+      }
+      if (data.available === false) {
+        setAvailability(data);
+      }
+      setName("");
       setEmail("");
       setMessage("");
+      resetTurnstile();
       setStatus(STATUS.SUCCESS);
     } catch (e) {
       console.error(e);
+      resetTurnstile();
       setStatus(STATUS.NETWORK_ERROR);
     }
   };
@@ -124,7 +226,15 @@ function Home() {
                 logiciel de maison connectée open-source.{" "}
                 <a href="/fr/">Pour en savoir plus</a>.<br />
                 <br />
-                Nous n'avons <b>aucun lien</b> avec wedoogift !
+                Nous n'avons <b>aucun lien</b> avec Glady / Wedoogift !
+              </div>
+            )}
+            {awayMessage && (
+              <div
+                className="alert alert--info margin-bottom--md"
+                role="status"
+              >
+                {awayMessage}
               </div>
             )}
             {status === STATUS.SUCCESS && (
@@ -155,6 +265,49 @@ function Home() {
                 </Translate>
               </div>
             )}
+            {status === STATUS.RATE_LIMITED && (
+              <div
+                className="alert alert--warning margin-bottom--md"
+                role="alert"
+              >
+                <Translate
+                  id="contactPage.rateLimited"
+                  description="Gladys contact page rate limited error"
+                >
+                  You have sent too many messages in a short time. Please wait
+                  an hour before trying again, or write to us on the forum.
+                </Translate>
+              </div>
+            )}
+            {status === STATUS.CAPTCHA_FAILED && (
+              <div
+                className="alert alert--warning margin-bottom--md"
+                role="alert"
+              >
+                <Translate
+                  id="contactPage.captchaFailed"
+                  description="Gladys contact page captcha error"
+                >
+                  We could not verify that you are a human. Please complete the
+                  verification below and try again.
+                </Translate>
+              </div>
+            )}
+            {status === STATUS.SEND_ERROR && (
+              <div
+                className="alert alert--danger margin-bottom--md"
+                role="alert"
+              >
+                <Translate
+                  id="contactPage.sendError"
+                  description="Gladys contact page send error"
+                >
+                  Your message could not be delivered. Please retry in a few
+                  minutes. If the problem persists, you can contact us on the
+                  forum.
+                </Translate>
+              </div>
+            )}
             {status === STATUS.NETWORK_ERROR && (
               <div
                 className="alert alert--danger margin-bottom--md"
@@ -172,6 +325,28 @@ function Home() {
             )}
             <form onSubmit={sendMessage}>
               <label>
+                <Translate id="contactPage.name" description="Gladys contact name">
+                  Name (optional)
+                </Translate>
+              </label>
+              <input
+                type="text"
+                name="name"
+                autoComplete="name"
+                maxLength={100}
+                className={
+                  styles.inputField + " margin-top--sm margin-bottom--sm"
+                }
+                onChange={(e) => setName(e.target.value)}
+                value={name}
+                placeholder={translate({
+                  id: "contact.namePlaceholder",
+                  description: "Contact page name placeholder",
+                  message: "Your name",
+                })}
+              />
+
+              <label>
                 <Translate
                   id="contactPage.email"
                   description="Gladys contact email"
@@ -180,11 +355,14 @@ function Home() {
                 </Translate>
               </label>
               <input
-                type="text"
+                type="email"
+                name="email"
+                autoComplete="email"
+                required
                 className={
                   styles.inputField + " margin-top--sm margin-bottom--sm"
                 }
-                onChange={updateEmail}
+                onChange={(e) => setEmail(e.target.value)}
                 value={email}
                 placeholder={translate({
                   id: "contact.emailPlaceholder",
@@ -202,6 +380,9 @@ function Home() {
                 </Translate>
               </label>
               <textarea
+                name="message"
+                required
+                maxLength={10000}
                 placeholder={translate({
                   id: "contact.messagePlaceholder",
                   description: "Contact page message placeholder",
@@ -211,9 +392,36 @@ function Home() {
                   styles.contactTextAreaField +
                   " margin-top--sm margin-bottom--sm"
                 }
-                onChange={updateMessage}
+                onChange={(e) => setMessage(e.target.value)}
                 value={message}
               ></textarea>
+
+              {/* Honeypot: invisible for humans, bots fill it. Never rendered by
+                  screen readers or the tab order. */}
+              <div
+                aria-hidden="true"
+                style={{ position: "absolute", left: "-9999px", top: "-9999px" }}
+              >
+                <label htmlFor="contact-website">Website</label>
+                <input
+                  id="contact-website"
+                  type="text"
+                  name="website"
+                  tabIndex={-1}
+                  autoComplete="off"
+                  onChange={(e) => setWebsite(e.target.value)}
+                  value={website}
+                />
+              </div>
+
+              {turnstile.required && turnstile.siteKey && (
+                <Turnstile
+                  key={turnstileKey}
+                  siteKey={turnstile.siteKey}
+                  language={language}
+                  onToken={setTurnstileToken}
+                />
+              )}
 
               <input
                 type="submit"

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -137,7 +137,7 @@ function Home() {
           message,
           name,
           language,
-          page: window.location.href,
+          page: window.location.origin + window.location.pathname,
           website,
           turnstileToken,
         }),


### PR DESCRIPTION
## Summary

Adapts `src/pages/contact.js` to the new version of the `contact-page` Cloudflare Worker (Pierre-Gilles/cloudflare-worker-gladys#1, https://github.com/Pierre-Gilles/cloudflare-worker-gladys/pull/1). The base URL is unchanged (`https://contact-page.gladysassistant.workers.dev`).

**This PR is compatible with the API currently deployed** and can be merged before or after the worker PR: the worker still accepts the old `{ email, message }` payload, and the new fields (`name`, `language`, `page`, `website`, `turnstileToken`) are simply ignored by the old worker. Conversely, if the worker PR lands first, the current site keeps working.

## What changes on the page

- **"Away" banner via `GET /status`.** On load, the page fetches `/status`. When `available === false`, it shows `message[locale]` (falling back to `message.en`) in an info alert above the form, e.g. "Pierre-Gilles est actuellement indisponible jusqu'au …". A successful `POST /` that reports `available: false` updates the banner too. If the status call fails, the page silently behaves as today.
- **Name field (optional).** New `name` input, sent along with `language` (current Docusaurus locale) and `page` (site origin and path of the current page, without query string or fragment).
- **Honeypot.** A `website` field is rendered off-screen with `aria-hidden` and `tabIndex={-1}`, so humans never see or focus it, and is sent to the worker. Bots that fill it get rejected server-side.
- **Cloudflare Turnstile, only when the API asks for it.** When `/status` returns `turnstile.required === true` with a `siteKey`, the page lazily loads the Turnstile script (explicit render mode) and mounts the widget above the submit button, in the current locale. The token is sent as `turnstileToken`, and the widget is remounted after each submit since a token is single-use. As long as the Turnstile secret is not set on the worker, `required` is `false` and **nothing changes visually**: no script is loaded, no widget is shown.
- **Error messages per error code.** The response is now read and mapped to dedicated alerts:
  - `validation_error` (400) → existing "form not valid" message
  - `rate_limited` (429) → new "too many messages, wait an hour or use the forum" message
  - `captcha_failed` (403) → new "we could not verify you are a human" message (also shown client-side if Turnstile is required and no token is available yet)
  - `email_not_sent` (502), `invalid_json` (400) and any other non-OK response → new generic "could not be delivered, retry later" message
  - network failure → existing "network error" message
- Small form hygiene: `type="email"`, `required`, `autoComplete`, `maxLength` on the inputs, `message.trim()` in the client-side validation.

## Translations

French strings added to `i18n/fr/code.json` next to the other `contactPage.*` / `contact.*` keys: `contactPage.name`, `contact.namePlaceholder`, `contactPage.rateLimited`, `contactPage.captchaFailed`, `contactPage.sendError`. English is the default locale, so the English texts live in the JSX. No other translation file for `fr` exists in the repo.

## Verification

- `yarn install --frozen-lockfile` then `yarn build`: full build succeeds for both `en` and `fr`. `yarn.lock` is untouched.
- The built `build/contact/index.html` and `build/fr/contact/index.html` contain the new field and its translated label/placeholder.
- The only build warning (`/fr/starter-kit/` HTML minifier diagnostic) is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3ry4z9jwRtJuNMcHHhGkk